### PR TITLE
chore: add debugging output

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The tool makes use of Terraform to create either droplets on Digital Ocean or EC
 
 We make use of Ansible for provisioning the VMs. Since Ansible is a Python application, it is advisable to install it in a virtualenv. If this sounds unfamiliar, I would recommend asking ChatGPT something along the lines of, "How can I install Ansible in a virtualenv created and managed by virtualenvwrapper?" The virtualenv must be activated any time you use the tool.
 
+August 2023 update: please pin to Ansible version 8.2.0, using `pip install ansible==8.2.0`. There is an issue with the newer version not correctly reading the Digital Ocean environment variables for the dynamic inventory.
+
 After you've installed these tools, run our `setup` command:
 ```
 cargo run -- setup

--- a/src/ansible.rs
+++ b/src/ansible.rs
@@ -6,6 +6,7 @@
 use crate::error::{Error, Result};
 use crate::CloudProvider;
 use crate::{is_binary_on_path, run_external_command};
+use log::debug;
 #[cfg(test)]
 use mockall::automock;
 use serde::Deserialize;
@@ -111,6 +112,8 @@ impl AnsibleRunnerInterface for AnsibleRunner {
             true,
         )?;
 
+        debug!("Inventory list output:");
+        debug!("{output:#?}");
         let mut output_string = output
             .into_iter()
             .skip_while(|line| !line.starts_with('{'))

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,7 +27,7 @@ pub enum Error {
     DeleteS3ObjectError(String, String),
     #[error("The '{0}' environment does not exist")]
     EnvironmentDoesNotExist(String),
-    #[error("Command executed with {0} failed. See output for details.")]
+    #[error("Command that executed with {0} failed. See output for details.")]
     ExternalCommandRunFailed(String),
     #[error("To provision the remaining nodes the multiaddr of the genesis node must be supplied")]
     GenesisMultiAddrNotSupplied,

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,6 +184,7 @@ async fn main() -> Result<()> {
         Some(Commands::Logs(log_cmd)) => match log_cmd {
             LogCommands::Copy { name, provider } => {
                 let testnet_deploy = TestnetDeployBuilder::default().provider(provider).build()?;
+                testnet_deploy.init(&name).await?;
                 testnet_deploy.copy_logs(&name).await?;
                 Ok(())
             }


### PR DESCRIPTION
The tool would not run correctly in a GHA workflow, which needed some extra debugging information and changes:

* Call `terraform init` on the `clean` command. In a GHA workflow you can't assume that Terraform has already been initialised. This would also facilitate a clean from your dev machine rather than using the GHA workflow, if you done that.
* Only attempt to remove inventory files if they exist. They don't exist in the GHA destroy workflow.
* Run the `init` command when using `logs copy`. This may be necessary if you've launched your testnet using the GHA workflow but you want to obtain the logs on your dev machine. In this case, the inventory needs to be created.