### PR TITLE
feat: deploy using version numbers for binaries

### DIFF
--- a/resources/ansible/build.yml
+++ b/resources/ansible/build.yml
@@ -10,10 +10,11 @@
       }
     - {
         role: build_safe_network_binary,
-        bin_name: "safe"
+        bin_name: "safe",
+        when: custom_bin == "true"
       }
     - {
         role: build_safe_network_binary,
         bin_name: "safenode",
-        when: custom_safenode == "true"
+        when: custom_bin == "true"
       }

--- a/src/error.rs
+++ b/src/error.rs
@@ -59,6 +59,8 @@ pub enum Error {
     RegexError(#[from] regex::Error),
     #[error("Safe client command failed: {0}")]
     SafeCmdError(String),
+    #[error("Failed to download the safe or safenode binary")]
+    SafeBinaryDownloadError,
     #[error("Error in byte stream when attempting to retrieve S3 object")]
     S3ByteStreamError,
     #[error(transparent)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,17 +51,15 @@ enum Commands {
         /// safenode binary. A safenode binary will be built from this repository.
         ///
         /// This argument must be used in conjunction with the --repo-owner argument.
+        ///
+        /// The --branch and --repo-owner arguments are mutually exclusive with the --safe-version
+        /// and --safenode-version arguments. You can only supply version numbers or a custom
+        /// branch, not both.
         #[arg(long)]
         branch: Option<String>,
         /// The name of the Logstash stack to forward logs to.
         #[clap(long, default_value = "main")]
         logstash_stack_name: String,
-        /// Optionally supply the owner or organisation of the Github repository to be used for the
-        /// safenode binary. A safenode binary will be built from this repository.
-        ///
-        /// This argument must be used in conjunction with the --branch argument.
-        #[arg(long)]
-        repo_owner: Option<String>,
         /// The name of the environment
         #[arg(short = 'n', long)]
         name: String,
@@ -73,6 +71,36 @@ enum Commands {
         /// Valid values are "aws" or "digital-ocean".
         #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
         provider: CloudProvider,
+        /// Optionally supply the owner or organisation of the Github repository to be used for the
+        /// safenode binary. A safenode binary will be built from this repository.
+        ///
+        /// This argument must be used in conjunction with the --branch argument.
+        ///
+        /// The --branch and --repo-owner arguments are mutually exclusive with the --safe-version
+        /// and --safenode-version arguments. You can only supply version numbers or a custom
+        /// branch, not both.
+        #[arg(long)]
+        repo_owner: Option<String>,
+        /// Optionally supply a version number to be used for the safe binary. There should be no
+        /// 'v' prefix.
+        ///
+        /// This argument must be used in conjunction with the --safenode-version argument.
+        ///
+        /// The --safe-version and --safenode-version arguments are mutually exclusive with the
+        /// --branch and --repo-owner arguments. You can only supply version numbers or a custom
+        /// branch, not both.
+        #[arg(long)]
+        safe_version: Option<String>,
+        #[arg(long)]
+        /// Optionally supply a version number to be used for the safenode binary. There should be
+        /// no 'v' prefix.
+        ///
+        /// This argument must be used in conjunction with the --safe-version argument.
+        ///
+        /// The --safe-version and --safenode-version arguments are mutually exclusive with the
+        /// --branch and --repo-owner arguments. You can only supply version numbers or a custom
+        /// branch, not both.
+        safenode_version: Option<String>,
         /// The number of node VMs to create.
         ///
         /// Each VM will run many safenode processes.
@@ -115,6 +143,32 @@ enum Commands {
         /// machine. This information gets used for Slack notifications.
         #[arg(long)]
         node_count: Option<u16>,
+        /// Optionally supply a version number to be used for the safe binary. There should be no
+        /// 'v' prefix.
+        ///
+        /// You can supply this value to inventory when you are running the process on a different
+        /// machine from where the testnet was deployed.
+        ///
+        /// This argument must be used in conjunction with the --safenode-version argument.
+        ///
+        /// The --safe-version and --safenode-version arguments are mutually exclusive with the
+        /// --branch and --repo-owner arguments. You can only supply version numbers or a custom
+        /// branch, not both.
+        #[arg(long)]
+        safe_version: Option<String>,
+        #[arg(long)]
+        /// Optionally supply a version number to be used for the safenode binary. There should be
+        /// no 'v' prefix.
+        ///
+        /// You can supply this value to inventory when you are running the process on a different
+        /// machine from where the testnet was deployed.
+        ///
+        /// This argument must be used in conjunction with the --safe-version argument.
+        ///
+        /// The --safe-version and --safenode-version arguments are mutually exclusive with the
+        /// --branch and --repo-owner arguments. You can only supply version numbers or a custom
+        /// branch, not both.
+        safenode_version: Option<String>,
     },
     #[clap(name = "logs", subcommand)]
     Logs(LogCommands),
@@ -232,16 +286,16 @@ async fn main() -> Result<()> {
             node_count,
             provider,
             repo_owner,
+            safe_version,
+            safenode_version,
             vm_count,
         }) => {
-            if (repo_owner.is_some() && branch.is_none())
-                || (branch.is_some() && repo_owner.is_none())
-            {
-                return Err(eyre!(
-                    "Both the repository owner and branch name must be supplied if either are used"
-                ));
-            }
-            let custom_branch_details = repo_owner.map(|repo_owner| (repo_owner, branch.unwrap()));
+            let (custom_branch_details, custom_version_details) = validate_branch_and_version_args(
+                branch,
+                repo_owner,
+                safenode_version,
+                safe_version,
+            )?;
 
             let testnet_deploy = TestnetDeployBuilder::default()
                 .provider(provider.clone())
@@ -282,6 +336,7 @@ async fn main() -> Result<()> {
                     vm_count,
                     node_count,
                     custom_branch_details,
+                    custom_version_details,
                 )
                 .await?;
             Ok(())
@@ -292,19 +347,25 @@ async fn main() -> Result<()> {
             branch,
             repo_owner,
             node_count,
+            safe_version,
+            safenode_version,
         }) => {
-            if (repo_owner.is_some() && branch.is_none())
-                || (branch.is_some() && repo_owner.is_none())
-            {
-                return Err(eyre!(
-                    "Both the repository owner and branch name must be supplied if either are used"
-                ));
-            }
+            let (custom_branch_details, custom_version_details) = validate_branch_and_version_args(
+                branch,
+                repo_owner,
+                safenode_version,
+                safe_version,
+            )?;
 
-            let custom_branch_details = repo_owner.map(|repo_owner| (repo_owner, branch.unwrap()));
             let testnet_deploy = TestnetDeployBuilder::default().provider(provider).build()?;
             testnet_deploy
-                .list_inventory(&name, false, custom_branch_details, node_count)
+                .list_inventory(
+                    &name,
+                    false,
+                    custom_branch_details,
+                    custom_version_details,
+                    node_count,
+                )
                 .await?;
             Ok(())
         }
@@ -398,9 +459,15 @@ async fn main() -> Result<()> {
             let i = rng.gen_range(0..inventory.peers.len());
             let random_peer = &inventory.peers[i];
 
+            let safe_version = inventory.version_info.as_ref().map(|x| x.1.clone());
             let test_data_client = TestDataClientBuilder::default().build()?;
             let uploaded_files = test_data_client
-                .upload_test_data(&name, random_peer, inventory.branch_info.clone())
+                .upload_test_data(
+                    &name,
+                    random_peer,
+                    inventory.branch_info.clone(),
+                    safe_version,
+                )
                 .await?;
 
             println!("Uploaded files:");
@@ -414,4 +481,49 @@ async fn main() -> Result<()> {
         }
         None => Ok(()),
     }
+}
+
+/// Clippy complains the return type here is too complicated.
+///
+/// It is convoluted, but it's just a way to share the validation of the same arguments between two
+/// commands. In my opinion, it does not merit introducing some kind of type to wrap the data.
+#[allow(clippy::type_complexity)]
+fn validate_branch_and_version_args(
+    branch: Option<String>,
+    repo_owner: Option<String>,
+    safe_version: Option<String>,
+    safenode_version: Option<String>,
+) -> Result<(Option<(String, String)>, Option<(String, String)>)> {
+    if (repo_owner.is_some() && branch.is_none()) || (branch.is_some() && repo_owner.is_none()) {
+        return Err(eyre!(
+            "Both the repository owner and branch name must be supplied if either are used"
+        ));
+    }
+    if (safe_version.is_some() && safenode_version.is_none())
+        || (safenode_version.is_some() && safe_version.is_none())
+    {
+        return Err(eyre!(
+            "Both the safe and safenode versions must be supplied if either are used"
+        ));
+    }
+
+    if branch.is_some()
+        && repo_owner.is_some()
+        && safe_version.is_some()
+        && safenode_version.is_some()
+    {
+        return Err(eyre!(
+            "Custom version numbers and custom branches cannot be supplied at the same time"
+        )
+        .suggestion(
+            "Please choose whether you want to use specific versions or a custom \
+                    branch, then run again.",
+        ));
+    }
+
+    let custom_branch_details = repo_owner.map(|repo_owner| (repo_owner, branch.unwrap()));
+    let custom_version_details =
+        safe_version.map(|safe_version| (safe_version, safenode_version.unwrap()));
+
+    Ok((custom_branch_details, custom_version_details))
 }

--- a/src/tests/build_safe_network_binaries.rs
+++ b/src/tests/build_safe_network_binaries.rs
@@ -14,7 +14,7 @@ use mockall::predicate::*;
 use std::path::PathBuf;
 
 #[tokio::test]
-async fn should_run_ansible_to_build_safe_related_binaries() -> Result<()> {
+async fn should_run_ansible_to_only_build_the_faucet() -> Result<()> {
     let (tmp_dir, working_dir) = setup_working_directory()?;
     let s3_repository = setup_deploy_s3_repository("beta", &working_dir)?;
     let mut ansible_runner = MockAnsibleRunnerInterface::new();
@@ -33,7 +33,7 @@ async fn should_run_ansible_to_build_safe_related_binaries() -> Result<()> {
             eq(PathBuf::from("inventory").join(".beta_build_inventory_digital_ocean.yml")),
             eq("root".to_string()),
             eq(Some(
-                "{ \"custom_safenode\": \"false\", \"testnet_name\": \"beta\" }".to_string(),
+                "{ \"custom_bin\": \"false\", \"testnet_name\": \"beta\" }".to_string(),
             )),
         )
         .returning(|_, _, _, _| Ok(()));
@@ -82,7 +82,7 @@ async fn should_run_ansible_to_build_binaries_with_custom_branch() -> Result<()>
             eq(PathBuf::from("inventory").join(".beta_build_inventory_digital_ocean.yml")),
             eq("root".to_string()),
             eq(Some(
-                "{ \"custom_safenode\": \"true\", \"branch\": \"custom_branch\", \"org\": \"maidsafe\", \"testnet_name\": \"beta\" }".to_string(),
+                "{ \"custom_bin\": \"true\", \"branch\": \"custom_branch\", \"org\": \"maidsafe\", \"testnet_name\": \"beta\" }".to_string(),
             )),
         )
         .returning(|_, _, _, _| Ok(()));

--- a/src/tests/provision_remaining_nodes.rs
+++ b/src/tests/provision_remaining_nodes.rs
@@ -16,6 +16,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 
 const CUSTOM_BIN_URL: &str = "https://sn-node.s3.eu-west-2.amazonaws.com/maidsafe/custom_branch/safenode-beta-x86_64-unknown-linux-musl.tar.gz";
+const VERSIONED_BIN_URL: &str = "https://github.com/maidsafe/safe_network/releases/download/sn_node-v0.90.35/safenode-0.90.35-x86_64-unknown-linux-musl.tar.gz";
 
 #[tokio::test]
 async fn should_run_ansible_against_the_remaining_nodes() -> Result<()> {
@@ -58,6 +59,7 @@ async fn should_run_ansible_against_the_remaining_nodes() -> Result<()> {
             "/ip4/10.0.0.10/tcp/12000/p2p/12D3KooWLvmkUDQRthtZv9CrzozRLk9ZVEHXgmx6UxVMiho5aded"
                 .to_string(),
             30,
+            None,
             None,
         )
         .await?;
@@ -110,6 +112,59 @@ async fn should_run_ansible_against_the_remaining_nodes_with_a_custom_binary() -
                 .to_string(),
             30,
             Some(("maidsafe".to_string(), "custom_branch".to_string())),
+            None,
+        )
+        .await?;
+
+    drop(tmp_dir);
+    Ok(())
+}
+
+#[tokio::test]
+async fn should_run_ansible_against_the_remaining_nodes_with_a_versioned_binary() -> Result<()> {
+    let extra_vars_doc = r#"{ "provider": "digital-ocean", "testnet_name": "beta", "genesis_multiaddr": "/ip4/10.0.0.10/tcp/12000/p2p/12D3KooWLvmkUDQRthtZv9CrzozRLk9ZVEHXgmx6UxVMiho5aded", "node_instance_count": "30", "node_archive_url": "VERSIONED_BIN_URL", "logstash_stack_name": "main", "logstash_hosts": ["10.0.0.1:5044", "10.0.0.2:5044"] }"#;
+    let (tmp_dir, working_dir) = setup_working_directory()?;
+    let s3_repository = setup_deploy_s3_repository("beta", &working_dir)?;
+    let mut ansible_runner = MockAnsibleRunnerInterface::new();
+    ansible_runner
+        .expect_run_playbook()
+        .times(1)
+        .with(
+            eq(PathBuf::from("nodes.yml")),
+            eq(PathBuf::from("inventory").join(".beta_node_inventory_digital_ocean.yml")),
+            eq("root".to_string()),
+            eq(Some(
+                extra_vars_doc.replace("VERSIONED_BIN_URL", VERSIONED_BIN_URL),
+            )),
+        )
+        .returning(|_, _, _, _| Ok(()));
+
+    let testnet = TestnetDeploy::new(
+        Box::new(setup_default_terraform_runner("beta")),
+        Box::new(ansible_runner),
+        Box::new(MockRpcClientInterface::new()),
+        Box::new(MockSshClientInterface::new()),
+        working_dir.to_path_buf(),
+        CloudProvider::DigitalOcean,
+        Box::new(s3_repository),
+    );
+
+    testnet.init("beta").await?;
+    testnet
+        .provision_remaining_nodes(
+            "beta",
+            (
+                "main",
+                &[
+                    SocketAddr::new(IpAddr::V4("10.0.0.1".parse()?), LOGSTASH_PORT),
+                    SocketAddr::new(IpAddr::V4("10.0.0.2".parse()?), LOGSTASH_PORT),
+                ],
+            ),
+            "/ip4/10.0.0.10/tcp/12000/p2p/12D3KooWLvmkUDQRthtZv9CrzozRLk9ZVEHXgmx6UxVMiho5aded"
+                .to_string(),
+            30,
+            None,
+            Some("0.90.35".to_string()),
         )
         .await?;
 


### PR DESCRIPTION
Optionally supply version numbers, which will deploy the binaries built during the release process. We still need to build the faucet binary because that's not a released artifact at the moment.

When the version number arguments are used, we skip building the `safenode` and `safe` binaries, which does shave a decent amount of time off the overall process.

The other significant difference is that we pull the version binaries from the Github release rather than S3, so we had to introduce another mechanism for downloading those. At the moment the release process does not include uploading the versioned binaries to S3. Only the 'latest' version goes up there.