### PR TITLE
feat: report error message as part of Error::ListS3ObjectsError

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -45,8 +45,8 @@ pub enum Error {
     InquireError(#[from] inquire::InquireError),
     #[error(transparent)]
     Io(#[from] std::io::Error),
-    #[error("Failed to list objects in S3 bucket with '{0}' prefix")]
-    ListS3ObjectsError(String),
+    #[error("Failed to list objects in S3 bucket with prefix '{prefix}': {error}")]
+    ListS3ObjectsError { prefix: String, error: String },
     #[error("Logs for a '{0}' testnet already exist")]
     LogsForPreviousTestnetExist(String),
     #[error("Logs have not been retrieved for the '{0}' environment.")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,27 +246,25 @@ async fn main() -> Result<()> {
             let testnet_deploy = TestnetDeployBuilder::default()
                 .provider(provider.clone())
                 .build()?;
-            let result = testnet_deploy.init(&name).await;
-            match result {
+
+            match testnet_deploy.init(&name).await {
                 Ok(_) => {}
-                Err(e) => match e {
-                    Error::LogsForPreviousTestnetExist(_) => {
-                        return Err(eyre!(e)
-                            .wrap_err(format!(
-                                "Logs already exist for a previous testnet with the \
+                Err(e @ Error::LogsForPreviousTestnetExist(_)) => {
+                    return Err(eyre!(e)
+                        .wrap_err(format!(
+                            "Logs already exist for a previous testnet with the \
                                     name '{name}'"
-                            ))
-                            .suggestion(
-                                "If you wish to keep them, retrieve the logs with the 'logs get' \
+                        ))
+                        .suggestion(
+                            "If you wish to keep them, retrieve the logs with the 'logs get' \
                                 command, then remove them with 'logs rm'. If you don't need them, \
                                 simply run 'logs rm'. Then you can proceed with deploying your \
                                 new testnet.",
-                            ));
-                    }
-                    _ => {
-                        return Err(eyre!(e));
-                    }
-                },
+                        ));
+                }
+                Err(e) => {
+                    return Err(eyre!(e));
+                }
             }
 
             let logstash_deploy = LogstashDeployBuilder::default()


### PR DESCRIPTION
Example error output with this change:
```
$ cargo run -- deploy --name beta

Error: 
   0: Failed to list objects in S3 bucket with prefix 'testnet-logs/beta/': The AWS Access Key Id you provided does not exist in our records.
```