### PR TITLE
chore: upgrade build and node images

### DIFF
--- a/resources/packer/build.pkr.hcl
+++ b/resources/packer/build.pkr.hcl
@@ -17,7 +17,7 @@ variable "user_home" {
 
 variable "droplet_image" {
   type = string
-  default = "ubuntu-22-10-x64"
+  default = "ubuntu-22-04-x64"
   description = ""
 }
 

--- a/resources/terraform/testnet/digital-ocean/variables.tf
+++ b/resources/terraform/testnet/digital-ocean/variables.tf
@@ -24,13 +24,14 @@ variable "build_machine_size" {
   default = "s-8vcpu-16gb"
 }
 
-# This corresponds to the 'safe_network-build-1692211486' image/snapshot.
+# This corresponds to the 'safe_network-build-1698957366' image/snapshot.
 variable "build_droplet_image_id" {
-  default = "138592390"
+  default = "143568442"
 }
 
+# This corresponds to the 'safe_network-node-1698958142' image/snapshot.
 variable "node_droplet_image_id" {
-  default = "140310435"
+  default = "143568506"
 }
 
 variable "region" {


### PR DESCRIPTION
A new image was generated for the build machine with the newest version of Rust on it. The Rust installation is not applied during the provisioning process. It's installed along with some other prerequisites in an attempt to save time in the deploy process.

The version of Ubuntu that the build machine was using is actually no longer available, so I changed it to a slightly earlier version. I tried a later one, but Ansible wouldn't install on it.

The node image was also regenerated here because I thought it also had a Rust installation on it, but it actually doesn't. It doesn't really do any harm to just generate a new version anyway.