### PR TITLE
chore: adapt to new safenode-rpc-client and use royalties beneficiary PK instead of SK

### DIFF
--- a/resources/ansible/roles/safenode_rpc_client/templates/safenode_rpc_client.service.j2
+++ b/resources/ansible/roles/safenode_rpc_client/templates/safenode_rpc_client.service.j2
@@ -4,7 +4,7 @@ Description=Safe node RPC client Service
 [Service]
 ExecStart={{ safenode_rpc_client_archive_dest_path }}/safenode_rpc_client \
   {{ node_rpc_ip }}:{{ node_rpc_port }} \
-  transfers 5f15ae2ea589007e1474e049bbc32904d583265f12ce1f8153f955076a9af49b \
+  transfers 8c54a5e8b3be5315516fc70c70cc532a16c932bc78780b396eed544feedb6f862ea749a894ccf4e1ff9c0b9ebe23412a \
   {{ royalties_cash_notes_dir_path }} \
   --peer {{ genesis_multiaddr }}
 StandardOutput=journal


### PR DESCRIPTION
Depends on https://github.com/maidsafe/safe_network/pull/1045