### PR TITLE
chore: remaining node failure will not end deploy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,6 +944,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "colored"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2724,6 +2734,7 @@ dependencies = [
  "chrono",
  "clap",
  "color-eyre",
+ "colored",
  "dirs-next",
  "dotenv",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ aws-sdk-s3 = "0.29.0"
 chrono = "0.4.31"
 clap = { version = "4.2.1", features = ["derive"] }
 color-eyre = "0.6.2"
+colored = "2.0.4"
 dirs-next = "2.0.0"
 dotenv = "0.15.0"
 env_logger = "0.10.0"

--- a/resources/ansible/roles/node/tasks/main.yml
+++ b/resources/ansible/roles/node/tasks/main.yml
@@ -48,6 +48,7 @@
   vars:
     command_args:
       - "{{ node_manager_archive_dest_path }}/safenode-manager"
+      - -v
       - add
       - --first
       - --port={{ genesis_port }}
@@ -79,6 +80,7 @@
   vars:
     command_args:
       - "{{ node_manager_archive_dest_path }}/safenode-manager"
+      - -v
       - add
       - "--count={{ nodes_to_add }}"
       - "--peer={{ genesis_multiaddr }}"
@@ -87,4 +89,4 @@
 
 - name: start the node services
   become: True
-  command: safenode-manager start
+  command: safenode-manager -v start

--- a/src/ansible.rs
+++ b/src/ansible.rs
@@ -48,6 +48,7 @@ pub struct AnsibleRunner {
     pub working_directory_path: PathBuf,
     pub ssh_sk_path: PathBuf,
     pub vault_password_file_path: PathBuf,
+    pub verbose_mode: bool,
 }
 
 // The following three structs are utilities that are used to parse the output of the
@@ -71,12 +72,14 @@ impl AnsibleRunner {
         provider: CloudProvider,
         ssh_sk_path: PathBuf,
         vault_password_file_path: PathBuf,
+        verbose_mode: bool,
     ) -> AnsibleRunner {
         AnsibleRunner {
             provider,
             working_directory_path,
             ssh_sk_path,
             vault_password_file_path,
+            verbose_mode,
         }
     }
 
@@ -159,7 +162,6 @@ impl AnsibleRunner {
         // error variant, which is very cumbersome. These paths are extremely unlikely to have any
         // unicode characters in them.
         let mut args = vec![
-            "-v".to_string(),
             "--inventory".to_string(),
             inventory_path.to_string_lossy().to_string(),
             "--private-key".to_string(),
@@ -172,6 +174,9 @@ impl AnsibleRunner {
         if let Some(extra_vars) = extra_vars_document {
             args.push("--extra-vars".to_string());
             args.push(extra_vars);
+        }
+        if self.verbose_mode {
+            args.push("-v".to_string());
         }
         args.push(playbook_path.to_string_lossy().to_string());
         run_external_command(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,11 +169,13 @@ impl DeploymentInventory {
         }
         println!("SSH user: {}", self.ssh_user);
         let testnet_dir = get_data_directory()?;
-        println!("Sample Peers (Entire list can be found inside {testnet_dir:?})",);
+        println!("Sample Peers",);
         println!("============");
         for peer in self.peers.iter().take(10) {
             println!("{peer}");
         }
+        println!("The entire peer list can be found at {testnet_dir:?}",);
+
         println!("\nGenesis multiaddr: {}", self.genesis_multiaddr);
         println!("Faucet address: {}", self.faucet_address);
         println!("Check the faucet:");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,6 +194,7 @@ impl DeploymentInventory {
 
 #[derive(Default)]
 pub struct TestnetDeployBuilder {
+    ansible_verbose_mode: bool,
     provider: Option<CloudProvider>,
     state_bucket_name: Option<String>,
     terraform_binary_path: Option<PathBuf>,
@@ -205,6 +206,11 @@ pub struct TestnetDeployBuilder {
 impl TestnetDeployBuilder {
     pub fn new() -> Self {
         Default::default()
+    }
+
+    pub fn ansible_verbose_mode(&mut self, ansible_verbose_mode: bool) -> &mut Self {
+        self.ansible_verbose_mode = ansible_verbose_mode;
+        self
     }
 
     pub fn provider(&mut self, provider: CloudProvider) -> &mut Self {
@@ -298,6 +304,7 @@ impl TestnetDeployBuilder {
             provider.clone(),
             ssh_secret_key_path.clone(),
             vault_password_path,
+            self.ansible_verbose_mode,
         );
         let rpc_client = RpcClient::new(
             PathBuf::from("/usr/local/bin/safenode_rpc_client"),

--- a/src/logstash.rs
+++ b/src/logstash.rs
@@ -135,6 +135,7 @@ impl LogstashDeployBuilder {
             provider.clone(),
             ssh_secret_key_path.clone(),
             vault_password_path,
+            false,
         );
 
         let logstash = LogstashDeploy::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,8 @@ enum Commands {
         /// Useful for testing experimental versions of the node manager.
         #[arg(long)]
         node_manager_url: Option<String>,
+        /// Set to run Ansible with more verbose output.
+        ansible_verbose: Option<bool>,
     },
     Inventory {
         /// The name of the environment
@@ -310,6 +312,7 @@ async fn main() -> Result<()> {
             safe_version,
             safenode_version,
             node_manager_url,
+            ansible_verbose,
         }) => {
             let sn_codebase_type = get_sn_codebase_type(
                 branch,
@@ -320,6 +323,7 @@ async fn main() -> Result<()> {
             )?;
 
             let testnet_deploy = TestnetDeployBuilder::default()
+                .ansible_verbose_mode(ansible_verbose.unwrap_or(false))
                 .provider(provider.clone())
                 .build()?;
 


### PR DESCRIPTION
- 401beb6 **chore: require arg for verbose ansible output**

  I find the verbose output in Ansible to be a bit excessive for most situations, though it can
  definitely be useful for debugging. This small change uses a flag to tell it to be more verbose.

- 88277a9 **chore: use minimal verbosity on node manager**

  These node manager commands can produce lots of output, which makes it difficult to read if the run
  fails. Using one `-v` makes the manager output in a more minimal style, making the failures easier
  to read.

- 12f1c8e **chore: remaining node failure will not end deploy**

  Most of the time, the errors we are seeing on the provision of the remaining nodes is because one or
  two nodes, out of something like forty, will randomly fail to start. Previously this was causing the
  whole deploy to fail because Ansible returned a failure. We now handle this error and use it to
  print a warning at the end of the run. The deployment should still be usable if a small number of
  nodes fail to start.