### PR TITLE
chore: remove additional prerequisite roles

### DIFF
--- a/resources/ansible/faucet.yml
+++ b/resources/ansible/faucet.yml
@@ -3,8 +3,6 @@
   hosts: all
   become: False
   roles:
-    - role: prerequisites
-      become: True
     - {
         role: format_disk,
         become: True,

--- a/resources/ansible/logstash.yml
+++ b/resources/ansible/logstash.yml
@@ -44,6 +44,5 @@
   hosts: all
   become: True
   roles:
-    - prerequisites
     - logstash
     - log_forwarding

--- a/resources/ansible/safenode_rpc_client.yml
+++ b/resources/ansible/safenode_rpc_client.yml
@@ -3,8 +3,6 @@
   hosts: all
   become: False
   roles:
-    - role: prerequisites
-      become: True
     - {
         role: format_disk,
         become: True,


### PR DESCRIPTION
These should also have been removed because they are also no longer required.