### PR TITLE
fix: empty json document for no vars

### DIFF
--- a/src/ansible.rs
+++ b/src/ansible.rs
@@ -434,6 +434,10 @@ impl ExtraVarsDocBuilder {
     }
 
     pub fn build(&self) -> String {
+        if self.variables.is_empty() && self.list_variables.is_empty() {
+            return "{}".to_string();
+        }
+
         let mut doc = String::new();
         doc.push_str("{ ");
 


### PR DESCRIPTION
When no variables are specified, just return an empty document. Not doing so caused an error on the `unwrap` call shortly after.