### PR TITLE
feat: provide `--safenode-manager-version` arg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3686,6 +3686,9 @@ name = "semver"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
@@ -3917,6 +3920,7 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest",
+ "semver",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,6 +1021,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "castaway"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1020,6 +1052,10 @@ name = "cc"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0ba8f7aaa012f30d5b2861462f6708eccd49c3c39863fe083a308035f63d723"
+dependencies = [
+ "jobserver",
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -1039,6 +1075,16 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-targets 0.52.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -1151,6 +1197,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "core-foundation"
@@ -2204,6 +2256,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "inquire"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2306,6 +2367,15 @@ name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "jobserver"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -2893,10 +2963,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -3778,6 +3871,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
+name = "sn-releases"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6a96b5beffe1eb01d46e3270c0b25723ed556cc96d75301c31aacc492057a64"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "flate2",
+ "lazy_static",
+ "regex",
+ "reqwest",
+ "semver",
+ "serde_json",
+ "tar",
+ "thiserror",
+ "tokio",
+ "zip",
+]
+
+[[package]]
 name = "sn-testnet-deploy"
 version = "0.1.0"
 dependencies = [
@@ -3807,6 +3920,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "sn-releases",
  "sn_service_management",
  "tar",
  "tempfile",
@@ -4996,4 +5110,53 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.52",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "aes",
+ "byteorder",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "hmac",
+ "pbkdf2",
+ "sha1",
+ "time",
+ "zstd",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.10+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ sha2 = "0.10.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sn_service_management = "0.1.1"
+sn-releases = "0.2.0"
 thiserror = "1.0.23"
 tar = "0.4"
 tempfile = "3.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ rayon = "1.8.0"
 regex = "1.9.5"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 sha2 = "0.10.7"
+semver = { version = "1.0.20", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sn_service_management = "0.1.1"

--- a/src/ansible.rs
+++ b/src/ansible.rs
@@ -328,7 +328,7 @@ impl ExtraVarsDocBuilder {
             }
             SnCodebaseType::Versioned { faucet_version, .. } => self
                 .variables
-                .push(("version".to_string(), faucet_version.clone())),
+                .push(("version".to_string(), faucet_version.to_string())),
         }
     }
 
@@ -374,12 +374,21 @@ impl ExtraVarsDocBuilder {
                 safenode_version, ..
             } => self
                 .variables
-                .push(("version".to_string(), safenode_version.clone())),
+                .push(("version".to_string(), safenode_version.to_string())),
         }
     }
 
     pub fn add_node_manager_url(&mut self, deployment_name: &str, codebase_type: &SnCodebaseType) {
         match codebase_type {
+            SnCodebaseType::Main { .. } => {
+                self.variables.push((
+                    "node_manager_archive_url".to_string(),
+                    format!(
+                        "{}/safenode-manager-latest-x86_64-unknown-linux-musl.tar.gz",
+                        NODE_MANAGER_S3_BUCKET_URL
+                    ),
+                ));
+            }
             SnCodebaseType::Branch {
                 repo_owner, branch, ..
             } => {
@@ -387,18 +396,21 @@ impl ExtraVarsDocBuilder {
                     "node_manager_archive_url",
                     &format!(
                         "{}/{}/{}/safenode-manager-{}-x86_64-unknown-linux-musl.tar.gz",
-                        NODE_S3_BUCKET_URL, repo_owner, branch, deployment_name
+                        NODE_MANAGER_S3_BUCKET_URL, repo_owner, branch, deployment_name
                     ),
                     branch,
                     repo_owner,
                 );
             }
-            _ => {
+            SnCodebaseType::Versioned {
+                safenode_manager_version,
+                ..
+            } => {
                 self.variables.push((
                     "node_manager_archive_url".to_string(),
                     format!(
-                        "{}/safenode-manager-latest-x86_64-unknown-linux-musl.tar.gz",
-                        NODE_MANAGER_S3_BUCKET_URL
+                        "{}/safenode-manager-{}-x86_64-unknown-linux-musl.tar.gz",
+                        NODE_MANAGER_S3_BUCKET_URL, safenode_manager_version
                     ),
                 ));
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use log::{debug, trace};
 use rand::Rng;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use semver::Version;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{
@@ -66,10 +67,10 @@ pub enum SnCodebaseType {
     },
     /// The specific versions of `safe` and `safenode` are fetched from `maidsafe/safe_network/releases`
     Versioned {
-        safe_version: String,
-        safenode_version: String,
-        faucet_version: String,
-        // todo: make `rpc, node manager` versions optional?
+        faucet_version: Version,
+        safe_version: Version,
+        safenode_version: Version,
+        safenode_manager_version: Version,
     },
 }
 
@@ -158,15 +159,17 @@ impl DeploymentInventory {
                 println!("Branch name: {}", branch);
             }
             SnCodebaseType::Versioned {
+                faucet_version,
                 safe_version,
                 safenode_version,
-                faucet_version,
+                safenode_manager_version,
             } => {
                 println!("Version Details");
                 println!("===============");
-                println!("safenode version: {}", safenode_version);
-                println!("safe version: {}", safe_version);
                 println!("faucet version: {}", faucet_version);
+                println!("safe version: {}", safe_version);
+                println!("safenode version: {}", safenode_version);
+                println!("safenode-manager version: {}", safenode_manager_version);
             }
         }
 
@@ -958,14 +961,19 @@ pub async fn notify_slack(inventory: DeploymentInventory) -> Result<()> {
             message.push_str(&format!("Branch: {}\n", branch));
         }
         SnCodebaseType::Versioned {
+            faucet_version,
             safe_version,
             safenode_version,
-            faucet_version,
+            safenode_manager_version,
         } => {
             message.push_str("*Version Details*\n");
-            message.push_str(&format!("safenode version: {}\n", safenode_version));
-            message.push_str(&format!("safe version: {}\n", safe_version));
             message.push_str(&format!("faucet version: {}\n", faucet_version));
+            message.push_str(&format!("safe version: {}\n", safe_version));
+            message.push_str(&format!("safenode version: {}\n", safenode_version));
+            message.push_str(&format!(
+                "safenode-manager version: {}\n",
+                safenode_manager_version
+            ));
         }
     }
 

--- a/src/manage_test_data.rs
+++ b/src/manage_test_data.rs
@@ -104,7 +104,7 @@ impl TestDataClient {
             crate::SnCodebaseType::Versioned { safe_version, .. } => {
                 Self::download_and_extract_safe_client_from_url(
                     &self.safe_binary_repository,
-                    safe_version,
+                    &safe_version.to_string(),
                     &self.working_directory_path,
                 )
                 .await?;
@@ -209,7 +209,7 @@ impl TestDataClient {
             SnCodebaseType::Versioned { safe_version, .. } => {
                 Self::download_and_extract_safe_client_from_url(
                     &self.safe_binary_repository,
-                    safe_version,
+                    &safe_version.to_string(),
                     &self.working_directory_path,
                 )
                 .await?;


### PR DESCRIPTION
- 513773c **chore: alphabetically arrange cmds and args**

  In my opinion, when you have so many commands and arguments, the best way to keep them tidy is to
  arrange them alphabetically. The `clap` crate that provides the CLI will indicate which of the
  arguments are mandatory, and if the user needs more information on the mandatory arguments, they can
  consult the list alphabetically.

  Also just tidied the documentation on some of the arguments.

- d68cb8e **chore: use version/branch arguments differently**

  To make things easier to manage, I've changed argument usage with respect to versioning and building
  binaries: you either use versions or you build all the binaries.

  In the case of building the binaries, things are as they were before: you need to supply the branch
  and repo owner at the same time.

  With respect to versioning, each of the version arguments are optional, but if any get used,
  versions will be used for all binaries. For the versions not supplied, the latest version will be
  obtained using the releases repository.

- 04e5e6f **feat: provide `--safenode-manager-version` arg**

  Allows a specific version of the node manager to be deployed, which is useful for testing the
  upgrade process.

  I also changed the `Versioned` variant of the `SnCodeBaseType` enum to use `semver::Version` rather
  than strings, because I accidentally specified a version number in the wrong format, and didn't know
  about it until Ansible tried to provision the node manager. Using the `Version` type forces the
  argument to be validated at an early stage.