### PR TITLE
feat: provide `upgrade-node-manager` command

### DIFF
--- a/resources/ansible/upgrade_node_manager.yml
+++ b/resources/ansible/upgrade_node_manager.yml
@@ -1,0 +1,20 @@
+---
+- name: upgrade safenode-manager to a new version
+  hosts: all
+  become: False
+  max_fail_percentage: 10
+  ignore_unreachable: yes
+  vars:
+    node_manager_archive_filename: safenode-manager-{{ version }}-x86_64-unknown-linux-musl.tar.gz
+    node_manager_archive_url: https://sn-node-manager.s3.eu-west-2.amazonaws.com/{{ node_manager_archive_filename }}
+  tasks:
+    - name: download the node manager binary
+      ansible.builtin.get_url:
+        url: "{{ node_manager_archive_url }}"
+        dest: /tmp/{{ node_manager_archive_filename }}
+    - name: extract the node manager binary to /usr/local/bin
+      become: True
+      ansible.builtin.unarchive:
+        src: "/tmp/{{ node_manager_archive_filename }}"
+        dest: "/usr/local/bin"
+        remote_src: True

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -766,6 +766,43 @@ impl TestnetDeploy {
         Ok(())
     }
 
+    pub async fn upgrade_node_manager(&self, name: &str, version: Version) -> Result<()> {
+        let environments = self.terraform_runner.workspace_list()?;
+        if !environments.contains(&name.to_string()) {
+            return Err(Error::EnvironmentDoesNotExist(name.to_string()));
+        }
+
+        // The ansible runner will have its working directory set to this location. We need the
+        // same here to test the inventory paths, which are relative to the `ansible` directory.
+        let ansible_dir_path = self.working_directory_path.join("ansible");
+        std::env::set_current_dir(ansible_dir_path.clone())?;
+
+        let genesis_inventory_path = PathBuf::from("inventory")
+            .join(format!(".{}_genesis_inventory_digital_ocean.yml", name));
+        let remaining_nodes_inventory_path =
+            PathBuf::from("inventory").join(format!(".{}_node_inventory_digital_ocean.yml", name));
+        if !genesis_inventory_path.exists() || !remaining_nodes_inventory_path.exists() {
+            return Err(Error::EnvironmentDoesNotExist(name.to_string()));
+        }
+
+        let mut extra_vars = ExtraVarsDocBuilder::default();
+        extra_vars.add_variable("version", &version.to_string());
+        self.ansible_runner.run_playbook(
+            PathBuf::from("upgrade_node_manager.yml"),
+            genesis_inventory_path,
+            self.cloud_provider.get_ssh_user(),
+            Some(extra_vars.build()),
+        )?;
+        self.ansible_runner.run_playbook(
+            PathBuf::from("upgrade_node_manager.yml"),
+            remaining_nodes_inventory_path,
+            self.cloud_provider.get_ssh_user(),
+            Some(extra_vars.build()),
+        )?;
+
+        Ok(())
+    }
+
     pub async fn clean(&self, name: &str) -> Result<()> {
         do_clean(
             name,

--- a/src/main.rs
+++ b/src/main.rs
@@ -254,6 +254,27 @@ enum Commands {
         /// There should be no 'v' prefix.
         safenode_version: Option<String>,
     },
+    /// Upgrade the safenode-manager binaries to a particular version.
+    ///
+    /// Simple mechanism that simply copies over the existing binary.
+    #[clap(name = "upgrade-node-manager")]
+    UpgradeNodeManager {
+        /// The name of the environment
+        #[arg(short = 'n', long)]
+        name: String,
+        #[arg(long)]
+        /// The cloud provider of the environment.
+        ///
+        /// Valid values are "aws" or "digital-ocean".
+        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
+        provider: CloudProvider,
+        /// Supply a version for the binary to be upgraded to.
+        ///
+        /// There should be no 'v' prefix.
+        /// The name of the environment
+        #[arg(short = 'v', long)]
+        version: String,
+    },
     /// Clean a deployed testnet environment.
     #[clap(name = "upload-test-data")]
     UploadTestData {
@@ -733,6 +754,21 @@ async fn main() -> Result<()> {
                     provider,
                     safenode_version,
                 })
+                .await?;
+            Ok(())
+        }
+        Commands::UpgradeNodeManager {
+            name,
+            provider,
+            version,
+        } => {
+            println!("Upgrading the node manager binaries...");
+            let testnet_deploy = TestnetDeployBuilder::default()
+                .ansible_verbose_mode(false)
+                .provider(provider.clone())
+                .build()?;
+            testnet_deploy
+                .upgrade_node_manager(&name, version.parse()?)
                 .await?;
             Ok(())
         }


### PR DESCRIPTION
Simple mechanism for upgrading the node manager binaries. It connects to each machine and downloads the given version of the binary, then overwrites the existing copy. This should be all we need for now.