### PR TITLE
Inventory Enhancements and Reorganisation

### DIFF
--- a/resources/ansible/roles/build_safe_network_binary/tasks/main.yml
+++ b/resources/ansible/roles/build_safe_network_binary/tasks/main.yml
@@ -13,7 +13,7 @@
 - name: "build {{ bin_name }} binary"
   ansible.builtin.shell: |
     source $HOME/.cargo/env
-    {% if protocol_version != "" %}
+    {% if protocol_version is defined and protocol_version != "" %}
     export NETWORK_VERSION_MODE={{ protocol_version }}
     {% endif %}
 

--- a/src/ansible.rs
+++ b/src/ansible.rs
@@ -363,8 +363,8 @@ impl ExtraVarsDocBuilder {
         self
     }
 
-    pub fn add_build_variables(&mut self, deployment_name: &str, codebase_type: &BinaryOption) {
-        match codebase_type {
+    pub fn add_build_variables(&mut self, deployment_name: &str, binary_option: &BinaryOption) {
+        match binary_option {
             BinaryOption::BuildFromSource {
                 repo_owner,
                 branch,
@@ -391,9 +391,9 @@ impl ExtraVarsDocBuilder {
     pub fn add_rpc_client_url_or_version(
         &mut self,
         deployment_name: &str,
-        codebase_type: &BinaryOption,
+        binary_option: &BinaryOption,
     ) {
-        match codebase_type {
+        match binary_option {
             BinaryOption::BuildFromSource {
                 repo_owner, branch, ..
             } => {
@@ -422,9 +422,9 @@ impl ExtraVarsDocBuilder {
     pub fn add_faucet_url_or_version(
         &mut self,
         deployment_name: &str,
-        codebase_type: &BinaryOption,
+        binary_option: &BinaryOption,
     ) {
-        match codebase_type {
+        match binary_option {
             BinaryOption::BuildFromSource {
                 repo_owner, branch, ..
             } => {
@@ -444,8 +444,8 @@ impl ExtraVarsDocBuilder {
         }
     }
 
-    pub fn add_node_url_or_version(&mut self, deployment_name: &str, codebase_type: &BinaryOption) {
-        match codebase_type {
+    pub fn add_node_url_or_version(&mut self, deployment_name: &str, binary_option: &BinaryOption) {
+        match binary_option {
             BinaryOption::BuildFromSource {
                 repo_owner, branch, ..
             } => {
@@ -467,8 +467,8 @@ impl ExtraVarsDocBuilder {
         }
     }
 
-    pub fn add_node_manager_url(&mut self, deployment_name: &str, codebase_type: &BinaryOption) {
-        match codebase_type {
+    pub fn add_node_manager_url(&mut self, deployment_name: &str, binary_option: &BinaryOption) {
+        match binary_option {
             BinaryOption::BuildFromSource {
                 repo_owner, branch, ..
             } => {
@@ -500,9 +500,9 @@ impl ExtraVarsDocBuilder {
     pub fn add_node_manager_daemon_url(
         &mut self,
         deployment_name: &str,
-        codebase_type: &BinaryOption,
+        binary_option: &BinaryOption,
     ) {
-        match codebase_type {
+        match binary_option {
             BinaryOption::BuildFromSource {
                 repo_owner, branch, ..
             } => {

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -80,7 +80,6 @@ impl DeployCmd {
         n += 1;
 
         let (genesis_multiaddr, _) = get_genesis_multiaddr(
-            &self.name,
             &self.testnet_deploy.ansible_runner,
             &self.testnet_deploy.ssh_client,
         )

--- a/src/error.rs
+++ b/src/error.rs
@@ -79,8 +79,6 @@ pub enum Error {
     SetupError,
     #[error("The SLACK_WEBHOOK_URL variable was not set")]
     SlackWebhookUrlNotSupplied,
-    #[error("Smoke test failed for this testnet: {0}")]
-    SmokeTestFailed(String),
     #[error("SSH command failed: {0}")]
     SshCommandFailed(String),
     #[error("After several retry attempts an SSH connection could not be established")]
@@ -93,8 +91,6 @@ pub enum Error {
         "The '{0}' binary was not found. It is required for the deploy process. Make sure it is installed."
     )]
     ToolBinaryNotFound(String),
-    #[error("{0}")]
-    UploadTestDataError(String),
     #[error(transparent)]
     VarError(#[from] std::env::VarError),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,6 +35,8 @@ pub enum Error {
     DigitalOceanPublicIpAddressNotFound,
     #[error("The '{0}' environment does not exist")]
     EnvironmentDoesNotExist(String),
+    #[error("The environment name is required")]
+    EnvironmentNameRequired,
     #[error("Command that executed with {0} failed. See output for details.")]
     ExternalCommandRunFailed(String),
     #[error("The provided inventory file is empty or does not exists {0}")]

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -141,7 +141,7 @@ impl DeploymentInventoryService {
             vm_list.push((entry.0.clone(), entry.1));
         }
         let (genesis_multiaddr, genesis_ip) =
-            get_genesis_multiaddr(name, &self.ansible_runner, &self.ssh_client).await?;
+            get_genesis_multiaddr(&self.ansible_runner, &self.ssh_client).await?;
 
         println!("Retrieving node manager inventory. This can take a minute.");
 
@@ -337,14 +337,12 @@ impl DeploymentInventory {
             }
             BinaryOption::Versioned {
                 faucet_version,
-                safe_version,
                 safenode_version,
                 safenode_manager_version,
             } => {
                 println!("Version Details");
                 println!("===============");
                 println!("faucet version: {}", faucet_version);
-                println!("safe version: {}", safe_version);
                 println!("safenode version: {}", safenode_version);
                 println!("safenode-manager version: {}", safenode_manager_version);
             }

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -1,0 +1,399 @@
+// Copyright (c) 2023, MaidSafe.
+// All rights reserved.
+//
+// This SAFE Network Software is licensed under the BSD-3-Clause license.
+// Please see the LICENSE file for more details.
+
+use crate::{
+    ansible::{
+        generate_environment_inventory, AnsibleInventoryType, AnsiblePlaybook, AnsibleRunner,
+    },
+    error::{Error, Result},
+    get_genesis_multiaddr,
+    ssh::SshClient,
+    terraform::TerraformRunner,
+    BinaryOption, CloudProvider, Node, TestnetDeploy,
+};
+use log::{debug, trace};
+use rand::Rng;
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::BTreeMap,
+    convert::From,
+    fs::File,
+    io::{BufReader, Write},
+    net::{IpAddr, SocketAddr},
+    path::PathBuf,
+};
+use walkdir::WalkDir;
+
+#[derive(Deserialize)]
+struct NodeManagerInventory {
+    daemon: Option<Daemon>,
+    nodes: Vec<Node>,
+}
+
+#[derive(Deserialize, Clone)]
+struct Daemon {
+    endpoint: Option<SocketAddr>,
+}
+
+pub struct DeploymentInventoryService {
+    pub ansible_runner: AnsibleRunner,
+    pub cloud_provider: CloudProvider,
+    pub inventory_file_path: PathBuf,
+    pub ssh_client: SshClient,
+    pub terraform_runner: TerraformRunner,
+    pub working_directory_path: PathBuf,
+}
+
+impl From<TestnetDeploy> for DeploymentInventoryService {
+    fn from(item: TestnetDeploy) -> Self {
+        let provider = match item.cloud_provider {
+            CloudProvider::Aws => "aws",
+            CloudProvider::DigitalOcean => "digital_ocean",
+        };
+        DeploymentInventoryService {
+            ansible_runner: item.ansible_runner.clone(),
+            cloud_provider: item.cloud_provider,
+            inventory_file_path: item
+                .working_directory_path
+                .join("ansible")
+                .join("inventory")
+                .join(format!("dev_inventory_{}.yml", provider)),
+            ssh_client: item.ssh_client.clone(),
+            terraform_runner: item.terraform_runner.clone(),
+            working_directory_path: item.working_directory_path.clone(),
+        }
+    }
+}
+
+impl DeploymentInventoryService {
+    /// Generate the inventory for the deployment.
+    ///
+    /// It will be cached for the purposes of quick display later and also for use with the test
+    /// data upload.
+    ///
+    /// The `force` flag is used when the `deploy` command runs, to make sure that a new inventory
+    /// is generated, because it's possible that an old one with the same environment name has been
+    /// cached.
+    pub async fn generate_inventory(
+        &self,
+        name: &str,
+        force: bool,
+        binary_option: BinaryOption,
+        node_instance_count: Option<u16>,
+    ) -> Result<DeploymentInventory> {
+        let inventory_path = get_data_directory()?.join(format!("{name}-inventory.json"));
+        if inventory_path.exists() && !force {
+            let inventory = DeploymentInventory::read(&inventory_path)?;
+            return Ok(inventory);
+        }
+
+        // This allows for the inventory to be generated without a Terraform workspace to be
+        // initialised, which is the case in the workflow for printing an inventory.
+        if !force {
+            let environments = self.terraform_runner.workspace_list()?;
+            if !environments.contains(&name.to_string()) {
+                return Err(Error::EnvironmentDoesNotExist(name.to_string()));
+            }
+        }
+
+        if force {
+            generate_environment_inventory(
+                name,
+                &self.inventory_file_path,
+                &self
+                    .working_directory_path
+                    .join("ansible")
+                    .join("inventory"),
+            )
+            .await?
+        }
+
+        let genesis_inventory = self
+            .ansible_runner
+            .get_inventory(AnsibleInventoryType::Genesis, false)
+            .await?;
+        let build_inventory = self
+            .ansible_runner
+            .get_inventory(AnsibleInventoryType::Build, false)
+            .await?;
+        let remaining_nodes_inventory = self
+            .ansible_runner
+            .get_inventory(AnsibleInventoryType::Nodes, false)
+            .await?;
+
+        // It also seems to be possible for a workspace and inventory files to still exist, but
+        // there to be no inventory items returned. Perhaps someone deleted the VMs manually. We
+        // only need to test the genesis node in this case, since that must always exist.
+        if genesis_inventory.is_empty() {
+            return Err(Error::EnvironmentDoesNotExist(name.to_string()));
+        }
+
+        let mut vm_list = Vec::new();
+        vm_list.push((genesis_inventory[0].0.clone(), genesis_inventory[0].1));
+        if !build_inventory.is_empty() {
+            vm_list.push((build_inventory[0].0.clone(), build_inventory[0].1));
+        }
+        for entry in remaining_nodes_inventory.iter() {
+            vm_list.push((entry.0.clone(), entry.1));
+        }
+        let (genesis_multiaddr, genesis_ip) =
+            get_genesis_multiaddr(name, &self.ansible_runner, &self.ssh_client).await?;
+
+        println!("Retrieving node manager inventory. This can take a minute.");
+
+        let node_manager_inventories = {
+            debug!("Fetching node manager inventory");
+            let temp_dir_path = tempfile::tempdir()?.into_path();
+            let temp_dir_json = serde_json::to_string(&temp_dir_path)?;
+
+            self.ansible_runner.run_playbook(
+                AnsiblePlaybook::NodeManagerInventory,
+                AnsibleInventoryType::Nodes,
+                Some(format!("{{ \"dest\": {temp_dir_json} }}")),
+            )?;
+            self.ansible_runner.run_playbook(
+                AnsiblePlaybook::NodeManagerInventory,
+                AnsibleInventoryType::Genesis,
+                Some(format!("{{ \"dest\": {temp_dir_json} }}")),
+            )?;
+
+            // collect the manager inventory file paths along with their respective ip addr
+            let manager_inventory_files = WalkDir::new(temp_dir_path)
+                .into_iter()
+                .flatten()
+                .filter_map(|entry| {
+                    if entry.file_type().is_file()
+                        && entry.path().extension().is_some_and(|ext| ext == "json")
+                    {
+                        // tempdir/<testnet_name>-node/var/safenode-manager/node_registry.json
+                        let mut vm_name = entry.path().to_path_buf();
+                        trace!("Found file with json extension: {vm_name:?}");
+                        vm_name.pop();
+                        vm_name.pop();
+                        vm_name.pop();
+                        // Extract the <testnet_name>-node string
+                        trace!("Extracting the vm name from the path");
+                        let vm_name = vm_name.file_name()?.to_str()?;
+                        trace!("Extracted vm name from path: {vm_name}");
+                        Some(entry.path().to_path_buf())
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<PathBuf>>();
+
+            manager_inventory_files
+                .par_iter()
+                .flat_map(|file_path| match get_node_manager_inventory(file_path) {
+                    Ok(inventory) => vec![Ok(inventory)],
+                    Err(err) => vec![Err(err)],
+                })
+                .collect::<Result<Vec<NodeManagerInventory>>>()?
+        };
+
+        // todo: filter out nodes that are running currently. Nodes can be restarted, which can lead to us collecting
+        // RPCs to nodes that do not exists.
+        let safenode_rpc_endpoints: BTreeMap<String, SocketAddr> = node_manager_inventories
+            .iter()
+            .flat_map(|inv| {
+                inv.nodes
+                    .iter()
+                    .flat_map(|node| node.peer_id.clone().map(|id| (id, node.rpc_socket_addr)))
+            })
+            .collect();
+
+        let safenodemand_endpoints: BTreeMap<String, SocketAddr> = node_manager_inventories
+            .iter()
+            .flat_map(|inv| {
+                inv.nodes.iter().flat_map(|node| {
+                    if let (Some(peer_id), Some(Some(daemon_socket_addr))) = (
+                        node.peer_id.clone(),
+                        inv.daemon.clone().map(|daemon| daemon.endpoint),
+                    ) {
+                        Some((peer_id, daemon_socket_addr))
+                    } else {
+                        None
+                    }
+                })
+            })
+            .collect();
+
+        // The scripts are relative to the `resources` directory, so we need to change the current
+        // working directory back to that location first.
+        std::env::set_current_dir(self.working_directory_path.clone())?;
+        println!("Retrieving sample peers. This can take a minute.");
+        // Todo: RPC into nodes to fetch the multiaddr.
+        let peers = remaining_nodes_inventory
+            .par_iter()
+            .filter_map(|(vm_name, ip_address)| {
+                let ip_address = *ip_address;
+                match self.ssh_client.run_script(
+                    ip_address,
+                    "safe",
+                    PathBuf::from("scripts").join("get_peer_multiaddr.sh"),
+                    true,
+                ) {
+                    Ok(output) => Some(output),
+                    Err(err) => {
+                        println!("Failed to SSH into {vm_name:?}: {ip_address} with err: {err:?}");
+                        None
+                    }
+                }
+            })
+            .flatten()
+            .collect::<Vec<_>>();
+
+        // The VM list includes the genesis node and the build machine, hence the subtraction of 2
+        // from the total VM count. After that, add one node for genesis, since this machine only
+        // runs a single node.
+        let node_count = {
+            let vms_to_ignore = if build_inventory.is_empty() { 1 } else { 2 };
+            let mut node_count =
+                (vm_list.len() - vms_to_ignore) as u16 * node_instance_count.unwrap_or(0);
+            node_count += 1;
+            node_count
+        };
+
+        let inventory = DeploymentInventory {
+            name: name.to_string(),
+            node_count,
+            binary_option,
+            vm_list,
+            rpc_endpoints: safenode_rpc_endpoints,
+            safenodemand_endpoints,
+            ssh_user: self.cloud_provider.get_ssh_user(),
+            genesis_multiaddr,
+            peers,
+            faucet_address: format!("{}:8000", genesis_ip),
+            uploaded_files: Vec::new(),
+        };
+        Ok(inventory)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DeploymentInventory {
+    pub name: String,
+    pub node_count: u16,
+    pub binary_option: BinaryOption,
+    pub vm_list: Vec<(String, IpAddr)>,
+    // Map of PeerId to SocketAddr
+    pub rpc_endpoints: BTreeMap<String, SocketAddr>,
+    // Map of PeerId to manager daemon SocketAddr
+    pub safenodemand_endpoints: BTreeMap<String, SocketAddr>,
+    pub ssh_user: String,
+    pub genesis_multiaddr: String,
+    pub peers: Vec<String>,
+    pub faucet_address: String,
+    pub uploaded_files: Vec<(String, String)>,
+}
+
+impl DeploymentInventory {
+    pub fn save(&self) -> Result<()> {
+        let path = get_data_directory()?.join(format!("{}-inventory.json", self.name));
+        let serialized_data = serde_json::to_string_pretty(self)?;
+        let mut file = File::create(path)?;
+        file.write_all(serialized_data.as_bytes())?;
+        Ok(())
+    }
+
+    pub fn read(file_path: &PathBuf) -> Result<Self> {
+        let data = std::fs::read_to_string(file_path)?;
+        let deserialized_data: DeploymentInventory = serde_json::from_str(&data)?;
+        Ok(deserialized_data)
+    }
+
+    pub fn add_uploaded_files(&mut self, uploaded_files: Vec<(String, String)>) {
+        self.uploaded_files.extend_from_slice(&uploaded_files);
+    }
+
+    pub fn get_random_peer(&self) -> String {
+        let mut rng = rand::thread_rng();
+        let i = rng.gen_range(0..self.peers.len());
+        let random_peer = &self.peers[i];
+        random_peer.to_string()
+    }
+
+    pub fn print_report(&self) -> Result<()> {
+        println!("**************************************");
+        println!("*                                    *");
+        println!("*          Inventory Report          *");
+        println!("*                                    *");
+        println!("**************************************");
+
+        println!("Name: {}", self.name);
+        match &self.binary_option {
+            BinaryOption::BuildFromSource {
+                repo_owner, branch, ..
+            } => {
+                println!("Branch Details");
+                println!("==============");
+                println!("Repo owner: {}", repo_owner);
+                println!("Branch name: {}", branch);
+            }
+            BinaryOption::Versioned {
+                faucet_version,
+                safe_version,
+                safenode_version,
+                safenode_manager_version,
+            } => {
+                println!("Version Details");
+                println!("===============");
+                println!("faucet version: {}", faucet_version);
+                println!("safe version: {}", safe_version);
+                println!("safenode version: {}", safenode_version);
+                println!("safenode-manager version: {}", safenode_manager_version);
+            }
+        }
+
+        for vm in self.vm_list.iter() {
+            println!("{}: {}", vm.0, vm.1);
+        }
+        println!("SSH user: {}", self.ssh_user);
+        let testnet_dir = get_data_directory()?;
+        println!("Sample Peers",);
+        println!("============");
+        for peer in self.peers.iter().take(10) {
+            println!("{peer}");
+        }
+        println!("The entire peer list can be found at {testnet_dir:?}",);
+
+        println!("\nGenesis multiaddr: {}", self.genesis_multiaddr);
+        println!("Faucet address: {}", self.faucet_address);
+        println!("Check the faucet:");
+        println!(
+            "safe --peer {} wallet get-faucet {}",
+            self.genesis_multiaddr, self.faucet_address
+        );
+
+        if !self.uploaded_files.is_empty() {
+            println!("Uploaded files:");
+            for file in self.uploaded_files.iter() {
+                println!("{}: {}", file.0, file.1);
+            }
+        }
+        Ok(())
+    }
+}
+
+pub fn get_data_directory() -> Result<PathBuf> {
+    let path = dirs_next::data_dir()
+        .ok_or_else(|| Error::CouldNotRetrieveDataDirectory)?
+        .join("safe")
+        .join("testnet-deploy");
+    if !path.exists() {
+        std::fs::create_dir_all(path.clone())?;
+    }
+    Ok(path)
+}
+
+fn get_node_manager_inventory(inventory_file_path: &PathBuf) -> Result<NodeManagerInventory> {
+    let file = File::open(inventory_file_path)?;
+    let reader = BufReader::new(file);
+    let inventory = serde_json::from_reader(reader)?;
+    Ok(inventory)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,19 +390,6 @@ impl TestnetDeploy {
             return Err(Error::EnvironmentDoesNotExist(name.to_string()));
         }
 
-        // The ansible runner will have its working directory set to this location. We need the
-        // same here to test the inventory paths, which are relative to the `ansible` directory.
-        let ansible_dir_path = self.working_directory_path.join("ansible");
-        std::env::set_current_dir(ansible_dir_path.clone())?;
-
-        let genesis_inventory_path = PathBuf::from("inventory")
-            .join(format!(".{}_genesis_inventory_digital_ocean.yml", name));
-        let remaining_nodes_inventory_path =
-            PathBuf::from("inventory").join(format!(".{}_node_inventory_digital_ocean.yml", name));
-        if !genesis_inventory_path.exists() || !remaining_nodes_inventory_path.exists() {
-            return Err(Error::EnvironmentDoesNotExist(name.to_string()));
-        }
-
         self.ansible_runner.run_playbook(
             AnsiblePlaybook::StartNodes,
             AnsibleInventoryType::Genesis,
@@ -424,23 +411,6 @@ impl TestnetDeploy {
 
         let environments = self.terraform_runner.workspace_list()?;
         if !environments.contains(&options.name.to_string()) {
-            return Err(Error::EnvironmentDoesNotExist(options.name.to_string()));
-        }
-
-        // The ansible runner will have its working directory set to this location. We need the
-        // same here to test the inventory paths, which are relative to the `ansible` directory.
-        let ansible_dir_path = self.working_directory_path.join("ansible");
-        std::env::set_current_dir(ansible_dir_path.clone())?;
-
-        let genesis_inventory_path = PathBuf::from("inventory").join(format!(
-            ".{}_genesis_inventory_digital_ocean.yml",
-            options.name
-        ));
-        let remaining_nodes_inventory_path = PathBuf::from("inventory").join(format!(
-            ".{}_node_inventory_digital_ocean.yml",
-            options.name
-        ));
-        if !genesis_inventory_path.exists() || !remaining_nodes_inventory_path.exists() {
             return Err(Error::EnvironmentDoesNotExist(options.name.to_string()));
         }
 
@@ -466,19 +436,6 @@ impl TestnetDeploy {
     pub async fn upgrade_node_manager(&self, name: &str, version: Version) -> Result<()> {
         let environments = self.terraform_runner.workspace_list()?;
         if !environments.contains(&name.to_string()) {
-            return Err(Error::EnvironmentDoesNotExist(name.to_string()));
-        }
-
-        // The ansible runner will have its working directory set to this location. We need the
-        // same here to test the inventory paths, which are relative to the `ansible` directory.
-        let ansible_dir_path = self.working_directory_path.join("ansible");
-        std::env::set_current_dir(ansible_dir_path.clone())?;
-
-        let genesis_inventory_path = PathBuf::from("inventory")
-            .join(format!(".{}_genesis_inventory_digital_ocean.yml", name));
-        let remaining_nodes_inventory_path =
-            PathBuf::from("inventory").join(format!(".{}_node_inventory_digital_ocean.yml", name));
-        if !genesis_inventory_path.exists() || !remaining_nodes_inventory_path.exists() {
             return Err(Error::EnvironmentDoesNotExist(name.to_string()));
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -513,9 +513,13 @@ impl TestnetDeploy {
             return Ok(());
         }
 
-        let environments = self.terraform_runner.workspace_list()?;
-        if !environments.contains(&name.to_string()) {
-            return Err(Error::EnvironmentDoesNotExist(name.to_string()));
+        // This allows for the inventory to be generated without a Terraform workspace to be
+        // initialised, which is the case in the workflow for printing an inventory.
+        if !force_regeneration {
+            let environments = self.terraform_runner.workspace_list()?;
+            if !environments.contains(&name.to_string()) {
+                return Err(Error::EnvironmentDoesNotExist(name.to_string()));
+            }
         }
 
         // The ansible runner will have its working directory set to this location. We need the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,6 @@ pub enum BinaryOption {
     /// Pre-built, versioned binaries will be fetched from S3.
     Versioned {
         faucet_version: Version,
-        safe_version: Version,
         safenode_version: Version,
         safenode_manager_version: Version,
     },
@@ -507,7 +506,7 @@ impl TestnetDeploy {
 /// Shared Helpers
 ///
 
-pub async fn get_genesis_multiaddr(name: &str, ansible_runner: &AnsibleRunner, ssh_client: &SshClient) -> Result<(String, IpAddr)> {
+pub async fn get_genesis_multiaddr(ansible_runner: &AnsibleRunner, ssh_client: &SshClient) -> Result<(String, IpAddr)> {
     let genesis_inventory = 
         ansible_runner
         .get_inventory(
@@ -700,13 +699,11 @@ pub async fn notify_slack(inventory: DeploymentInventory) -> Result<()> {
         }
         BinaryOption::Versioned {
             faucet_version,
-            safe_version,
             safenode_version,
             safenode_manager_version,
         } => {
             message.push_str("*Version Details*\n");
             message.push_str(&format!("faucet version: {}\n", faucet_version));
-            message.push_str(&format!("safe version: {}\n", safe_version));
             message.push_str(&format!("safenode version: {}\n", safenode_version));
             message.push_str(&format!(
                 "safenode-manager version: {}\n",

--- a/src/logs.rs
+++ b/src/logs.rs
@@ -227,21 +227,6 @@ impl TestnetDeploy {
             return Err(Error::EnvironmentDoesNotExist(name.to_string()));
         }
 
-        // The ansible runner will have its working directory set to this location. We need the
-        // same here to test the inventory paths, which are relative to the `ansible` directory.
-        let ansible_dir_path = self.working_directory_path.join("ansible");
-        std::env::set_current_dir(ansible_dir_path.clone())?;
-        // Somehow it might be possible that the workspace wasn't cleared out, but the environment
-        // was actually torn down and the generated inventory files were deleted. If the files
-        // don't exist, we can reasonably consider the environment non-existent.
-        let genesis_inventory_path =
-            PathBuf::from("inventory").join(format!(".{name}_genesis_inventory_digital_ocean.yml"));
-        let remaining_nodes_inventory_path =
-            PathBuf::from("inventory").join(format!(".{name}_node_inventory_digital_ocean.yml"));
-        if !genesis_inventory_path.exists() || !remaining_nodes_inventory_path.exists() {
-            return Err(Error::EnvironmentDoesNotExist(name.to_string()));
-        }
-
         let mut all_node_inventory = self
             .ansible_runner
             .get_inventory(AnsibleInventoryType::Genesis, false)

--- a/src/network_commands.rs
+++ b/src/network_commands.rs
@@ -54,7 +54,7 @@ pub async fn perform_fixed_interval_network_churn(
         .ok_or_eyre("Could not get the genesis VM's addr")?;
     let safenodemand_endpoints = inventory
         .safenodemand_endpoints
-        .values()
+        .iter()
         .filter(|addr| addr.ip() != genesis_ip)
         .cloned()
         .collect::<BTreeSet<_>>();
@@ -67,7 +67,7 @@ pub async fn perform_fixed_interval_network_churn(
             }
         });
         // subtract 1 node for genesis. And ignore build & genesis node.
-        (inventory.node_count as usize - 1) / (inventory.vm_list.len() - vms_to_ignore)
+        (inventory.peers.len() - 1) / (inventory.vm_list.len() - vms_to_ignore)
     };
 
     let max_concurrent_churns = std::cmp::min(concurrent_churns, nodes_per_vm);
@@ -133,7 +133,7 @@ pub async fn perform_random_interval_network_churn(
         .ok_or_eyre("Could not get the genesis VM's addr")?;
     let safenodemand_endpoints = inventory
         .safenodemand_endpoints
-        .values()
+        .iter()
         .filter(|addr| addr.ip() != genesis_ip)
         .cloned()
         .collect::<BTreeSet<_>>();
@@ -143,7 +143,7 @@ pub async fn perform_random_interval_network_churn(
 
     // print the time to churn all these nodes
     {
-        let total_num_nodes = inventory.node_count as usize - 1;
+        let total_num_nodes = inventory.peers.len() - 1;
         let n_timeframes_to_churn_all_nodes = if total_num_nodes % churn_count > 0 {
             total_num_nodes / churn_count + 1
         } else {

--- a/src/rpc_client.rs
+++ b/src/rpc_client.rs
@@ -16,6 +16,7 @@ pub struct NodeInfo {
     pub last_restart: u32,
 }
 
+#[derive(Clone)]
 pub struct RpcClient {
     pub binary_path: PathBuf,
     pub working_directory_path: PathBuf,

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 use tokio::io::AsyncWriteExt;
 use tokio_stream::StreamExt;
 
+#[derive(Clone)]
 pub struct S3Repository {}
 
 impl S3Repository {

--- a/src/terraform.rs
+++ b/src/terraform.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use std::path::PathBuf;
 
+#[derive(Clone)]
 pub struct TerraformRunner {
     pub binary_path: PathBuf,
     pub provider: CloudProvider,


### PR DESCRIPTION
- 2cbf1de **chore: remove terraform check on `inventory` cmd**

  It shouldn't be necessary to have an initialised Terraform workspace to get the inventory for
  deployment, which is the case when using a GHA workflow.

- 819abb5 **refactor: narrow binary option for deployment**

  We previously had an `SnCodebaseType` enum with three variants: `Main`, `Branch` and `Versioned`.
  Now that we can use the release repository to retrieve the latest versions for binaries, I didn't
  see the necessity for a third option; we simply use a version or we build from source. With that in
  mind, I renamed the enum to `BinaryOption` and provided `BuildFromSource` and `Versioned` variants.

  I don't think there should be any functional change here.

- 08e1d4f **refactor: introduce `inventory` module**

  I was finding the main `lib` module difficult to navigate, so I decided to move inventory-related
  code into its own module, and introduced a new `DeploymentInventoryService` struct for encapsulating
  the generation of inventory.

  I also made changes and additions in the `ansible` module, introducing concepts from our own domain
  rather than making it completely generic. We now pass enums for playbooks and inventory values, so
  we don't have to assemble paths all over the place. I think this makes the code more compact,
  readable and maintainable.

- 7604a20 **chore: remove `--safe-version` arg from `deploy`**

  We don't need to specify the client version when we are using a versioned deployment. It only gets
  used if we are running automated smoke tests, which we don't do at the moment anyway. In any case, I
  updated the `smoke-test` and `upload-test-data` commands to supply a `--safe-version` argument, in
  case we do end up using these again in the future.

  Also changed the use of the `Error` type in the `manage_test_data` module in favour of just using
  `eyre`. It's debatable that this whole crate should be changed to do this and remove the `lib`
  module.

- 8720c3f **chore: use the node registry to populate inventory**

  Now that we have access to the `sn_service_management` crate, we don't need small structs to
  represent a subset of data from the node registry. We can deserialize the fetched node registries
  directly to a `NodeRegistry` struct.

  Some other modifications:
  * Fix some Clippy warnings.
  * Rename `codebase_type` variables to `binary_option`.
  * Tidy up the sections in the printed report.
  * The `BinaryOption` is made optional when generating the inventory, because we only have access to
    it on the machine where the deployment initially ran. If it is not supplied, we just use the
    version numbers from the genesis node. We would lose the initial branch information if the testnet
    was deployed using a branch specification, but in most cases that should be for experimental
    testnets.
  * Remove `node_count` in favour of `peers.len()`.
  * For some reason `safenodemand_endpoints` was storing a peer ID and socket address pair, but the
    daemon doesn't have a peer ID, so I just removed this.
  * The peer multiaddresses are in the `NodeRegistry`, so we don't need to fetch these via SSH as an
    additional step.
    
- 8f6fc45 **chore: review feedback**

  * Change `inventory_type` argument to use a reference to `AnsibleInventoryType` to avoid cloning in
    loops.
  * Centralise check for the existence of inventory files.
  * Remove irrelevant documentation    