### PR TITLE
fix: provide full inventory path

### DIFF
--- a/src/ansible.rs
+++ b/src/ansible.rs
@@ -319,6 +319,7 @@ impl AnsibleRunner {
                 self.environment_name, provider
             )),
         };
+        let path = self.working_directory_path.join(path);
         match path.exists() {
             true => Ok(path),
             false => Err(Error::EnvironmentDoesNotExist(


### PR DESCRIPTION
The check only applied to a relative path, which is not necessary relative to the current working directory. Using the full path resolves the problem.