### PR TITLE
feat: upload network contacts to s3

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -47,6 +47,8 @@ pub enum Error {
     GenesisListenAddress,
     #[error("Failed to retrieve '{0}' from '{1}")]
     GetS3ObjectError(String, String),
+    #[error("Failed to retrieve filename")]
+    FilenameNotRetrieved,
     #[error(transparent)]
     FsExtraError(#[from] fs_extra::error::Error),
     #[error(transparent)]
@@ -67,6 +69,8 @@ pub enum Error {
     ReqwestError(#[from] reqwest::Error),
     #[error(transparent)]
     RegexError(#[from] regex::Error),
+    #[error("Failed to upload {0} to S3 bucket {1}")]
+    PutS3ObjectError(String, String),
     #[error("Safe client command failed: {0}")]
     SafeCmdError(String),
     #[error("Failed to download the safe or safenode binary")]


### PR DESCRIPTION
When a deployment completes, the network contacts will automatically be uploaded to S3. By default, the file will have the same name as the environment, but an optional argument allows it to be specified.

During the deployment, it's possible that some nodes don't start. These are indicated by "-" entries in the peer list. The process ensures they will not be added to the contacts list.