### PR TITLE
feat: provide `--beta-encryption-key` arg on `deploy` cmd

### DIFF
--- a/resources/ansible/roles/auditor/defaults/main.yml
+++ b/resources/ansible/roles/auditor/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
 binary_dir: /usr/local/bin
-beta_encryption_key: 49113d2083f57a976076adbe85decb75115820de1e6e74b47e0429338cef124a

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,7 @@ struct Opt {
     command: Commands,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Subcommand, Debug)]
 enum Commands {
     /// Clean a deployed testnet environment.
@@ -59,6 +60,11 @@ enum Commands {
         /// Set to run Ansible with more verbose output.
         #[arg(long)]
         ansible_verbose: bool,
+        /// Supply the beta encryption key for the auditor.
+        ///
+        /// If not used a default key will be supplied.
+        #[arg(long)]
+        beta_encryption_key: Option<String>,
         /// The branch of the Github repository to build from.
         ///
         /// If used, all binaries will be built from this branch. It is typically used for testing
@@ -501,6 +507,7 @@ async fn main() -> Result<()> {
         }
         Commands::Deploy {
             ansible_verbose,
+            beta_encryption_key,
             branch,
             env_variables,
             faucet_version,
@@ -579,6 +586,7 @@ async fn main() -> Result<()> {
                 logstash_details,
                 binary_option.clone(),
                 env_variables,
+                beta_encryption_key,
             );
             deploy_cmd.execute().await?;
 


### PR DESCRIPTION
A secret key can optionally be supplied, but otherwise, a default will be used. The default is moved out of Ansible and into the `testnet-deploy` binary. This is being provided to support supplying a key for the initial beta launch.

A Clippy warning related to a large enum variant was suppressed. There are quite a lot of arguments for the tool, but it doesn't seem like it's something problematic.