### PR TITLE
fix: dont try to find audit ip if no inventory

### DIFF
--- a/resources/ansible/roles/node/tasks/main.yml
+++ b/resources/ansible/roles/node/tasks/main.yml
@@ -65,8 +65,8 @@
 
 - name: calculate end port
   set_fact:
-    rpc_end_port: "{{ rpc_start_port | int + nodes_to_add | int - 1 }}"
-    metrics_end_port: "{{ metrics_start_port | int + nodes_to_add | int - 1 }}"
+    rpc_end_port: "{{ rpc_start_port | int + nodes_to_add | int }}"
+    metrics_end_port: "{{ metrics_start_port | int + nodes_to_add | int }}"
   when: nodes_to_add | default(0) | int > 0
 
 - name: add node services

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -139,18 +139,20 @@ impl DeploymentInventoryService {
                     .ansible_runner
                     .get_inventory(AnsibleInventoryType::Auditor, true)
                     .await?;
-                let auditor_ip = auditor_inventory[0].1;
                 // It also seems to be possible for a workspace and inventory files to still exist, but
                 // there to be no inventory items returned. Perhaps someone deleted the VMs manually. We
                 // only need to test the genesis node in this case, since that must always exist.
                 if genesis_inventory.is_empty() {
                     return Err(eyre!("The '{}' environment does not exist", name));
                 }
+                if auditor_inventory.is_empty() {
+                    let auditor_ip = auditor_inventory[0].1;
+                    vm_list.push((auditor_inventory[0].0.clone(), auditor_ip));
+                    optional_audit_ip = Some(auditor_ip);
+                }
 
                 vm_list.push((genesis_inventory[0].0.clone(), genesis_inventory[0].1));
-                vm_list.push((auditor_inventory[0].0.clone(), auditor_ip));
 
-                optional_audit_ip = Some(auditor_ip);
                 true
             }
 


### PR DESCRIPTION
Ensure that we count at least one node to add, otherwise rpc port calculation is off and we dont add any