### PR TITLE
refactor: `DeployCmd` -> `DeployOptions`

### DIFF
--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -7,7 +7,7 @@
 use crate::{
     ansible::{AnsibleInventoryType, AnsiblePlaybook, ExtraVarsDocBuilder},
     error::{Error, Result},
-    get_genesis_multiaddr, print_duration, BinaryOption, LogFormat, TestnetDeploy,
+    get_genesis_multiaddr, print_duration, BinaryOption, LogFormat, TestnetDeployer,
 };
 use colored::Colorize;
 use std::{
@@ -19,60 +19,30 @@ use tokio::time::sleep;
 const DEFAULT_BETA_ENCRYPTION_KEY: &str =
     "49113d2083f57a976076adbe85decb75115820de1e6e74b47e0429338cef124a";
 
-pub struct DeployCmd {
-    beta_encryption_key: Option<String>,
-    binary_option: BinaryOption,
-    env_variables: Option<Vec<(String, String)>>,
-    log_format: Option<LogFormat>,
-    logstash_details: Option<(String, Vec<SocketAddr>)>,
-    name: String,
-    node_count: u16,
-    bootstrap_peer: Option<String>,
-    public_rpc: bool,
-    testnet_deploy: TestnetDeploy,
-    vm_count: u16,
+pub struct DeployOptions {
+    pub beta_encryption_key: Option<String>,
+    pub binary_option: BinaryOption,
+    pub bootstrap_peer: Option<String>,
+    pub env_variables: Option<Vec<(String, String)>>,
+    pub log_format: Option<LogFormat>,
+    pub logstash_details: Option<(String, Vec<SocketAddr>)>,
+    pub name: String,
+    pub node_count: u16,
+    pub public_rpc: bool,
+    pub vm_count: u16,
 }
 
-impl DeployCmd {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        testnet_deploy: TestnetDeploy,
-        name: String,
-        node_count: u16,
-        vm_count: u16,
-        peer: Option<String>,
-        public_rpc: bool,
-        log_format: Option<LogFormat>,
-        logstash_details: Option<(String, Vec<SocketAddr>)>,
-        binary_option: BinaryOption,
-        env_variables: Option<Vec<(String, String)>>,
-        beta_encryption_key: Option<String>,
-    ) -> Self {
-        Self {
-            testnet_deploy,
-            name,
-            node_count,
-            vm_count,
-            bootstrap_peer: peer,
-            public_rpc,
-            log_format,
-            logstash_details,
-            binary_option,
-            env_variables,
-            beta_encryption_key,
-        }
-    }
-
-    pub async fn execute(self) -> Result<()> {
+impl TestnetDeployer {
+    pub async fn deploy(&self, options: &DeployOptions) -> Result<()> {
         let build_custom_binaries = {
-            match &self.binary_option {
+            match &options.binary_option {
                 BinaryOption::BuildFromSource { .. } => true,
                 BinaryOption::Versioned { .. } => false,
             }
         };
 
-        let is_fresh_network = self.bootstrap_peer.is_none();
-        self.create_infra(build_custom_binaries, is_fresh_network)
+        let is_fresh_network = options.bootstrap_peer.is_none();
+        self.create_infra(options, build_custom_binaries, is_fresh_network)
             .await
             .map_err(|err| {
                 println!("Failed to create infra {err:?}");
@@ -83,34 +53,34 @@ impl DeployCmd {
         let total = if build_custom_binaries { 6 } else { 5 };
         if build_custom_binaries {
             self.print_ansible_run_banner(n, total, "Build Custom Binaries");
-            self.build_safe_network_binaries().await.map_err(|err| {
-                println!("Failed to build safe network binaries {err:?}");
-                err
-            })?;
+            self.build_safe_network_binaries(options)
+                .await
+                .map_err(|err| {
+                    println!("Failed to build safe network binaries {err:?}");
+                    err
+                })?;
             n += 1;
         }
 
-        let initial_point_of_contact = if let Some(contact) = &self.bootstrap_peer {
+        let initial_point_of_contact = if let Some(contact) = &options.bootstrap_peer {
             println!("Using bootstrap peer: {contact}, waiting 60s for initital inventory spin up");
             sleep(Duration::from_secs(60)).await;
 
             contact.clone()
         } else {
             self.print_ansible_run_banner(n, total, "Provision Genesis Node");
-            self.provision_genesis_node().await.map_err(|err| {
+            self.provision_genesis_node(options).await.map_err(|err| {
                 println!("Failed to provision genesis node {err:?}");
                 err
             })?;
             n += 1;
-            let (genesis_multiaddr, _) = get_genesis_multiaddr(
-                &self.testnet_deploy.ansible_runner,
-                &self.testnet_deploy.ssh_client,
-            )
-            .await
-            .map_err(|err| {
-                println!("Failed to get genesis multiaddr {err:?}");
-                err
-            })?;
+            let (genesis_multiaddr, _) =
+                get_genesis_multiaddr(&self.ansible_runner, &self.ssh_client)
+                    .await
+                    .map_err(|err| {
+                        println!("Failed to get genesis multiaddr {err:?}");
+                        err
+                    })?;
             println!("Obtained multiaddr for genesis node: {genesis_multiaddr}");
 
             genesis_multiaddr
@@ -119,7 +89,7 @@ impl DeployCmd {
         let mut node_provision_failed = false;
         self.print_ansible_run_banner(n, total, "Provision Remaining Nodes");
         match self
-            .provision_remaining_nodes(&initial_point_of_contact)
+            .provision_remaining_nodes(options, &initial_point_of_contact)
             .await
         {
             Ok(()) => {
@@ -133,7 +103,7 @@ impl DeployCmd {
 
         if is_fresh_network {
             self.print_ansible_run_banner(n, total, "Deploy Faucet");
-            self.provision_faucet(&initial_point_of_contact)
+            self.provision_faucet(options, &initial_point_of_contact)
                 .await
                 .map_err(|err| {
                     println!("Failed to provision faucet {err:?}");
@@ -141,14 +111,14 @@ impl DeployCmd {
                 })?;
             n += 1;
             self.print_ansible_run_banner(n, total, "Provision RPC Client on Genesis Node");
-            self.provision_safenode_rpc_client(&initial_point_of_contact)
+            self.provision_safenode_rpc_client(options, &initial_point_of_contact)
                 .await
                 .map_err(|err| {
                     println!("Failed to provision safenode rpc client {err:?}");
                     err
                 })?;
             self.print_ansible_run_banner(n, total, "Provision Auditor");
-            self.provision_sn_auditor(&initial_point_of_contact)
+            self.provision_sn_auditor(options, &initial_point_of_contact)
                 .await
                 .map_err(|err| {
                     println!("Failed to provision sn_auditor {err:?}");
@@ -168,148 +138,87 @@ impl DeployCmd {
         Ok(())
     }
 
-    async fn create_infra(&self, enable_build_vm: bool, is_fresh_network: bool) -> Result<()> {
+    async fn create_infra(
+        &self,
+        options: &DeployOptions,
+        enable_build_vm: bool,
+        is_fresh_network: bool,
+    ) -> Result<()> {
         let start = Instant::now();
-        println!("Selecting {} workspace...", self.name);
-        self.testnet_deploy
-            .terraform_runner
-            .workspace_select(&self.name)?;
+        println!("Selecting {} workspace...", options.name);
+        self.terraform_runner.workspace_select(&options.name)?;
         let args = vec![
             ("fresh_testnet".to_string(), is_fresh_network.to_string()),
-            ("node_count".to_string(), self.vm_count.to_string()),
+            ("node_count".to_string(), options.vm_count.to_string()),
             ("use_custom_bin".to_string(), enable_build_vm.to_string()),
         ];
         println!("Running terraform apply...");
-        self.testnet_deploy.terraform_runner.apply(args)?;
+        self.terraform_runner.apply(args)?;
         print_duration(start.elapsed());
         Ok(())
     }
 
-    async fn build_safe_network_binaries(&self) -> Result<()> {
-        let start = Instant::now();
-        println!("Obtaining IP address for build VM...");
-        let build_inventory = self
-            .testnet_deploy
-            .ansible_runner
-            .get_inventory(AnsibleInventoryType::Build, true)
-            .await?;
-        let build_ip = build_inventory[0].1;
-        self.testnet_deploy.ssh_client.wait_for_ssh_availability(
-            &build_ip,
-            &self.testnet_deploy.cloud_provider.get_ssh_user(),
-        )?;
-
-        println!("Running ansible against build VM...");
-        let extra_vars = self.build_binaries_extra_vars_doc()?;
-        self.testnet_deploy.ansible_runner.run_playbook(
-            AnsiblePlaybook::Build,
-            AnsibleInventoryType::Build,
-            Some(extra_vars),
-        )?;
-        print_duration(start.elapsed());
-        Ok(())
-    }
-
-    pub async fn provision_genesis_node(&self) -> Result<()> {
+    async fn provision_genesis_node(&self, options: &DeployOptions) -> Result<()> {
         let start = Instant::now();
         let genesis_inventory = self
-            .testnet_deploy
             .ansible_runner
             .get_inventory(AnsibleInventoryType::Genesis, true)
             .await?;
         let genesis_ip = genesis_inventory[0].1;
-        self.testnet_deploy.ssh_client.wait_for_ssh_availability(
-            &genesis_ip,
-            &self.testnet_deploy.cloud_provider.get_ssh_user(),
-        )?;
-        self.testnet_deploy.ansible_runner.run_playbook(
+        self.ssh_client
+            .wait_for_ssh_availability(&genesis_ip, &self.cloud_provider.get_ssh_user())?;
+        self.ansible_runner.run_playbook(
             AnsiblePlaybook::Genesis,
             AnsibleInventoryType::Genesis,
-            Some(self.build_node_extra_vars_doc(None, None)?),
+            Some(self.build_node_extra_vars_doc(options, None, None)?),
         )?;
         print_duration(start.elapsed());
         Ok(())
     }
 
-    pub async fn provision_faucet(&self, genesis_multiaddr: &str) -> Result<()> {
+    pub async fn provision_remaining_nodes(
+        &self,
+        options: &DeployOptions,
+        initial_contact_peer: &str,
+    ) -> Result<()> {
         let start = Instant::now();
-        println!("Running ansible against genesis node to deploy faucet...");
-        self.testnet_deploy.ansible_runner.run_playbook(
-            AnsiblePlaybook::Faucet,
-            AnsibleInventoryType::Genesis,
-            Some(self.build_faucet_extra_vars_doc(genesis_multiaddr)?),
-        )?;
-        print_duration(start.elapsed());
-        Ok(())
-    }
-
-    pub async fn provision_safenode_rpc_client(&self, genesis_multiaddr: &str) -> Result<()> {
-        let start = Instant::now();
-        println!("Running ansible against genesis node to start safenode_rpc_client service...");
-        self.testnet_deploy.ansible_runner.run_playbook(
-            AnsiblePlaybook::RpcClient,
-            AnsibleInventoryType::Genesis,
-            Some(self.build_safenode_rpc_client_extra_vars_doc(genesis_multiaddr)?),
-        )?;
-        print_duration(start.elapsed());
-        Ok(())
-    }
-
-    pub async fn provision_sn_auditor(&self, genesis_multiaddr: &str) -> Result<()> {
-        let start = Instant::now();
-        println!("Running ansible against auditor machine to start sn_auditor service...");
-        self.testnet_deploy.ansible_runner.run_playbook(
-            AnsiblePlaybook::Auditor,
-            AnsibleInventoryType::Auditor,
-            Some(
-                self.build_sn_auditor_extra_vars_doc(
-                    genesis_multiaddr,
-                    self.beta_encryption_key
-                        .as_ref()
-                        .unwrap_or(&DEFAULT_BETA_ENCRYPTION_KEY.to_string()),
-                )?,
-            ),
-        )?;
-        print_duration(start.elapsed());
-        Ok(())
-    }
-
-    pub async fn provision_remaining_nodes(&self, initial_contact_peer: &str) -> Result<()> {
-        let start = Instant::now();
-        self.testnet_deploy.ansible_runner.run_playbook(
+        self.ansible_runner.run_playbook(
             AnsiblePlaybook::Nodes,
             AnsibleInventoryType::Nodes,
             Some(self.build_node_extra_vars_doc(
+                options,
                 Some(initial_contact_peer.to_string()),
-                Some(self.node_count),
+                Some(options.node_count),
             )?),
         )?;
         print_duration(start.elapsed());
         Ok(())
     }
 
+    ///
     /// Helpers
-
+    ///
     fn print_ansible_run_banner(&self, n: usize, total: usize, s: &str) {
         let ansible_run_msg = format!("Ansible Run {} of {}: ", n, total);
         let line = "=".repeat(s.len() + ansible_run_msg.len());
         println!("{}\n{}{}\n{}", line, ansible_run_msg, s, line);
     }
 
-    fn build_binaries_extra_vars_doc(&self) -> Result<String> {
+    fn build_binaries_extra_vars_doc(&self, options: &DeployOptions) -> Result<String> {
         let mut extra_vars = ExtraVarsDocBuilder::default();
-        extra_vars.add_build_variables(&self.name, &self.binary_option);
+        extra_vars.add_build_variables(&options.name, &options.binary_option);
         Ok(extra_vars.build())
     }
 
     fn build_node_extra_vars_doc(
         &self,
+        options: &DeployOptions,
         bootstrap_node: Option<String>,
         node_instance_count: Option<u16>,
     ) -> Result<String> {
         let mut extra_vars = ExtraVarsDocBuilder::default();
-        extra_vars.add_variable("provider", &self.testnet_deploy.cloud_provider.to_string());
-        extra_vars.add_variable("testnet_name", &self.name);
+        extra_vars.add_variable("provider", &self.cloud_provider.to_string());
+        extra_vars.add_variable("testnet_name", &options.name);
         if bootstrap_node.is_some() {
             extra_vars.add_variable(
                 "genesis_multiaddr",
@@ -322,22 +231,22 @@ impl DeployCmd {
                 &node_instance_count.unwrap_or(20).to_string(),
             );
         }
-        if let Some(log_format) = self.log_format {
+        if let Some(log_format) = options.log_format {
             extra_vars.add_variable("log_format", log_format.as_str());
         }
-        if self.public_rpc {
+        if options.public_rpc {
             extra_vars.add_variable("public_rpc", "true");
         }
 
-        extra_vars.add_node_url_or_version(&self.name, &self.binary_option);
-        extra_vars.add_node_manager_url(&self.name, &self.binary_option);
-        extra_vars.add_node_manager_daemon_url(&self.name, &self.binary_option);
+        extra_vars.add_node_url_or_version(&options.name, &options.binary_option);
+        extra_vars.add_node_manager_url(&options.name, &options.binary_option);
+        extra_vars.add_node_manager_daemon_url(&options.name, &options.binary_option);
 
-        if let Some(env_vars) = &self.env_variables {
+        if let Some(env_vars) = &options.env_variables {
             extra_vars.add_env_variable_list("env_variables", env_vars.clone());
         }
 
-        if let Some((logstash_stack_name, logstash_hosts)) = &self.logstash_details {
+        if let Some((logstash_stack_name, logstash_hosts)) = &options.logstash_details {
             extra_vars.add_variable("logstash_stack_name", logstash_stack_name);
             extra_vars.add_list_variable(
                 "logstash_hosts",
@@ -351,37 +260,121 @@ impl DeployCmd {
         Ok(extra_vars.build())
     }
 
-    fn build_faucet_extra_vars_doc(&self, genesis_multiaddr: &str) -> Result<String> {
+    async fn provision_faucet(
+        &self,
+        options: &DeployOptions,
+        genesis_multiaddr: &str,
+    ) -> Result<()> {
+        let start = Instant::now();
+        println!("Running ansible against genesis node to deploy faucet...");
+        self.ansible_runner.run_playbook(
+            AnsiblePlaybook::Faucet,
+            AnsibleInventoryType::Genesis,
+            Some(self.build_faucet_extra_vars_doc(options, genesis_multiaddr)?),
+        )?;
+        print_duration(start.elapsed());
+        Ok(())
+    }
+
+    async fn provision_safenode_rpc_client(
+        &self,
+        options: &DeployOptions,
+        genesis_multiaddr: &str,
+    ) -> Result<()> {
+        let start = Instant::now();
+        println!("Running ansible against genesis node to start safenode_rpc_client service...");
+        self.ansible_runner.run_playbook(
+            AnsiblePlaybook::RpcClient,
+            AnsibleInventoryType::Genesis,
+            Some(self.build_safenode_rpc_client_extra_vars_doc(options, genesis_multiaddr)?),
+        )?;
+        print_duration(start.elapsed());
+        Ok(())
+    }
+
+    async fn provision_sn_auditor(
+        &self,
+        options: &DeployOptions,
+        genesis_multiaddr: &str,
+    ) -> Result<()> {
+        let start = Instant::now();
+        println!("Running ansible against auditor machine to start sn_auditor service...");
+        self.ansible_runner.run_playbook(
+            AnsiblePlaybook::Auditor,
+            AnsibleInventoryType::Auditor,
+            Some(self.build_sn_auditor_extra_vars_doc(options, genesis_multiaddr)?),
+        )?;
+        print_duration(start.elapsed());
+        Ok(())
+    }
+
+    async fn build_safe_network_binaries(&self, options: &DeployOptions) -> Result<()> {
+        let start = Instant::now();
+        println!("Obtaining IP address for build VM...");
+        let build_inventory = self
+            .ansible_runner
+            .get_inventory(AnsibleInventoryType::Build, true)
+            .await?;
+        let build_ip = build_inventory[0].1;
+        self.ssh_client
+            .wait_for_ssh_availability(&build_ip, &self.cloud_provider.get_ssh_user())?;
+
+        println!("Running ansible against build VM...");
+        let extra_vars = self.build_binaries_extra_vars_doc(options)?;
+        self.ansible_runner.run_playbook(
+            AnsiblePlaybook::Build,
+            AnsibleInventoryType::Build,
+            Some(extra_vars),
+        )?;
+        print_duration(start.elapsed());
+        Ok(())
+    }
+
+    fn build_faucet_extra_vars_doc(
+        &self,
+        options: &DeployOptions,
+        genesis_multiaddr: &str,
+    ) -> Result<String> {
         let mut extra_vars = ExtraVarsDocBuilder::default();
-        extra_vars.add_variable("provider", &self.testnet_deploy.cloud_provider.to_string());
-        extra_vars.add_variable("testnet_name", &self.name);
+        extra_vars.add_variable("provider", &self.cloud_provider.to_string());
+        extra_vars.add_variable("testnet_name", &options.name);
         extra_vars.add_variable("genesis_multiaddr", genesis_multiaddr);
-        extra_vars.add_node_manager_url(&self.name, &self.binary_option);
-        extra_vars.add_faucet_url_or_version(&self.name, &self.binary_option);
+        extra_vars.add_node_manager_url(&options.name, &options.binary_option);
+        extra_vars.add_faucet_url_or_version(&options.name, &options.binary_option);
         Ok(extra_vars.build())
     }
 
-    fn build_safenode_rpc_client_extra_vars_doc(&self, genesis_multiaddr: &str) -> Result<String> {
+    fn build_safenode_rpc_client_extra_vars_doc(
+        &self,
+        options: &DeployOptions,
+        genesis_multiaddr: &str,
+    ) -> Result<String> {
         let mut extra_vars = ExtraVarsDocBuilder::default();
-        extra_vars.add_variable("provider", &self.testnet_deploy.cloud_provider.to_string());
-        extra_vars.add_variable("testnet_name", &self.name);
+        extra_vars.add_variable("provider", &self.cloud_provider.to_string());
+        extra_vars.add_variable("testnet_name", &options.name);
         extra_vars.add_variable("genesis_multiaddr", genesis_multiaddr);
-        extra_vars.add_rpc_client_url_or_version(&self.name, &self.binary_option);
+        extra_vars.add_rpc_client_url_or_version(&options.name, &options.binary_option);
         Ok(extra_vars.build())
     }
 
     fn build_sn_auditor_extra_vars_doc(
         &self,
+        options: &DeployOptions,
         genesis_multiaddr: &str,
-        beta_encryption_key: &str,
     ) -> Result<String> {
         let mut extra_vars: ExtraVarsDocBuilder = ExtraVarsDocBuilder::default();
-        extra_vars.add_variable("provider", &self.testnet_deploy.cloud_provider.to_string());
-        extra_vars.add_variable("testnet_name", &self.name);
+        extra_vars.add_variable("provider", &self.cloud_provider.to_string());
+        extra_vars.add_variable("testnet_name", &options.name);
         extra_vars.add_variable("genesis_multiaddr", genesis_multiaddr);
-        extra_vars.add_variable("beta_encryption_key", beta_encryption_key);
-        extra_vars.add_node_manager_url(&self.name, &self.binary_option);
-        extra_vars.add_sn_auditor_url_or_version(&self.name, &self.binary_option);
+        extra_vars.add_variable(
+            "beta_encryption_key",
+            options
+                .beta_encryption_key
+                .as_ref()
+                .unwrap_or(&DEFAULT_BETA_ENCRYPTION_KEY.to_string()),
+        );
+        extra_vars.add_node_manager_url(&options.name, &options.binary_option);
+        extra_vars.add_sn_auditor_url_or_version(&options.name, &options.binary_option);
         Ok(extra_vars.build())
     }
 }

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -12,7 +12,7 @@ use crate::{
     s3::S3Repository,
     ssh::SshClient,
     terraform::TerraformRunner,
-    BinaryOption, CloudProvider, TestnetDeploy,
+    BinaryOption, CloudProvider, TestnetDeployer,
 };
 use color_eyre::{eyre::eyre, Result};
 use log::{debug, trace};
@@ -44,8 +44,8 @@ pub struct DeploymentInventoryService {
     pub working_directory_path: PathBuf,
 }
 
-impl From<TestnetDeploy> for DeploymentInventoryService {
-    fn from(item: TestnetDeploy) -> Self {
+impl From<TestnetDeployer> for DeploymentInventoryService {
+    fn from(item: TestnetDeployer) -> Self {
         let provider = match item.cloud_provider {
             CloudProvider::Aws => "aws",
             CloudProvider::DigitalOcean => "digital_ocean",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,7 @@ impl TestnetDeployBuilder {
         self
     }
 
-    pub fn build(&self) -> Result<TestnetDeploy> {
+    pub fn build(&self) -> Result<TestnetDeployer> {
         let provider = self
             .provider
             .as_ref()
@@ -298,7 +298,7 @@ impl TestnetDeployBuilder {
             std::fs::remove_file(safe_path)?;
         }
 
-        let testnet = TestnetDeploy::new(
+        let testnet = TestnetDeployer::new(
             ansible_runner,
             provider.clone(),
             &self.environment_name,
@@ -314,7 +314,7 @@ impl TestnetDeployBuilder {
 }
 
 #[derive(Clone)]
-pub struct TestnetDeploy {
+pub struct TestnetDeployer {
     pub ansible_runner: AnsibleRunner,
     pub cloud_provider: CloudProvider,
     pub environment_name: String,
@@ -326,7 +326,7 @@ pub struct TestnetDeploy {
     pub working_directory_path: PathBuf,
 }
 
-impl TestnetDeploy {
+impl TestnetDeployer {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         ansible_runner: AnsibleRunner,
@@ -337,7 +337,7 @@ impl TestnetDeploy {
         ssh_client: SshClient,
         terraform_runner: TerraformRunner,
         working_directory_path: PathBuf,
-    ) -> Result<TestnetDeploy> {
+    ) -> Result<TestnetDeployer> {
         if environment_name.is_empty() {
             return Err(Error::EnvironmentNameRequired);
         }
@@ -345,7 +345,7 @@ impl TestnetDeploy {
             .join("ansible")
             .join("inventory")
             .join("dev_inventory_digital_ocean.yml");
-        Ok(TestnetDeploy {
+        Ok(TestnetDeployer {
             ansible_runner,
             cloud_provider,
             environment_name: environment_name.to_string(),

--- a/src/logs.rs
+++ b/src/logs.rs
@@ -9,7 +9,7 @@ use crate::{
     error::{Error, Result},
     get_progress_bar, run_external_command,
     s3::S3Repository,
-    TestnetDeploy,
+    TestnetDeployer,
 };
 use fs_extra::dir::{copy, remove, CopyOptions};
 use log::debug;
@@ -21,7 +21,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-impl TestnetDeploy {
+impl TestnetDeployer {
     pub async fn rsync_logs(&self, name: &str, resources_only: bool) -> Result<()> {
         // take root_dir at the top as `get_all_node_inventory` changes the working dir.
         let root_dir = std::env::current_dir()?;


### PR DESCRIPTION
The `TestnetDeploy` struct is also renamed to `TestnetDeployer`, which is a better indicator that this struct contains behaviour rather than just state.

The `DeployCmd` is renamed to `DeployOptions`, and the behaviour for executing the deployment is moved back into `TestnetDeployer`. We still define the `deploy` function in a separate file, which is worth it because there is quite a lot of code. We can take advantage of the fact that Rust allows us to implement the behaviour of a struct across multiple files.

The reason for the refactor is because I always found it a bit odd that a large object like `TestnetDeployer` was being passed into a command object. In most situations, commands are objects that only have state, providing the parameters for some operation that is generally performed by the command's corresponding handler. The command handler has the heavy dependencies that are used to execute the operation. In our case, the command handler is `TestnetDeployer`.