### PR TITLE
feat: merge bootstrap and 'normal' nodes into one environment

### DIFF
--- a/resources/ansible/roles/metrics/tasks/main.yml
+++ b/resources/ansible/roles/metrics/tasks/main.yml
@@ -38,14 +38,20 @@
   replace:
     path: "{{ network_dashboard_repo_path }}/telegraf/EnvironmentFile/telegraf"
     regexp: 'SAFENODE_TESTNET_NAME=UNDEFINED'
-    replace: 'SAFENODE_TESTNET_NAME={{ testnet_name }}'
+    replace: 'SAFENODE_TESTNET_NAME={{ testnet_name | upper }}'
+
+- name: replace SAFENODE_HOST_ROLE value
+  replace:
+    path: "{{ network_dashboard_repo_path }}/telegraf/EnvironmentFile/telegraf"
+    regexp: 'SAFENODE_HOST_ROLE=UNDEFINED'
+    replace: 'SAFENODE_HOST_ROLE={{ node_type | upper }}'
 
 # The real branch name will be supplied later, when it is available in `safenode`.
 - name: replace SAFENODE_BRANCH_NAME value
   replace:
     path: "{{ network_dashboard_repo_path }}/telegraf/EnvironmentFile/telegraf"
     regexp: "SAFENODE_BRANCH_NAME=UNDEFINED"
-    replace: "SAFENODE_BRANCH_NAME=stable"
+    replace: "SAFENODE_BRANCH_NAME=STABLE"
 
 # The real commit hash will be supplied later, when it is available in `safenode`.
 - name: replace SAFENODE_BRANCH_COMMIT value

--- a/resources/terraform/testnet/digital-ocean/main.tf
+++ b/resources/terraform/testnet/digital-ocean/main.tf
@@ -39,6 +39,16 @@ resource "digitalocean_droplet" "node" {
   tags     = ["environment:${terraform.workspace}", "type:node"]
 }
 
+resource "digitalocean_droplet" "uploader" {
+  count    = var.uploader_vm_count
+  image    = var.node_droplet_image_id
+  name     = "${terraform.workspace}-uploader-${count.index + 1}"
+  region   = var.region
+  size     = var.node_droplet_size
+  ssh_keys = var.droplet_ssh_keys
+  tags     = ["environment:${terraform.workspace}", "type:uploader"]
+}
+
 resource "digitalocean_droplet" "build" {
   count    = var.use_custom_bin ? 1 : 0
   image    = var.build_droplet_image_id

--- a/resources/terraform/testnet/digital-ocean/variables.tf
+++ b/resources/terraform/testnet/digital-ocean/variables.tf
@@ -18,19 +18,16 @@ variable "droplet_ssh_keys" {
   ]
 }
 
-variable "droplet_size" {
+variable "node_droplet_size" {
   default = "s-2vcpu-4gb"
 }
+
 variable "boostrap_droplet_size" {
   default = "s-8vcpu-16gb-480gb-intel"
 }
 
 variable "build_machine_size" {
   default = "s-8vcpu-16gb"
-}
-
-variable "fresh_testnet" {
-  default = "false"
 }
 
 # This corresponds to the 'safe_network-auditor-1715864456' image/snapshot.
@@ -52,8 +49,12 @@ variable "region" {
   default = "lon1"
 }
 
-# 25*80 = 2k. A good node sample size. Should provide enough bandwidth per droplet to survive on defualt limits.
-variable "node_count" {
+variable "bootstrap_node_vm_count" {
+  default     = 25
+  description = "The number of droplets to launch for bootstrap nodes"
+}
+
+variable "node_vm_count" {
   default     = 25
   description = "The number of droplets to launch for the nodes"
 }

--- a/resources/terraform/testnet/digital-ocean/variables.tf
+++ b/resources/terraform/testnet/digital-ocean/variables.tf
@@ -56,7 +56,12 @@ variable "bootstrap_node_vm_count" {
 
 variable "node_vm_count" {
   default     = 25
-  description = "The number of droplets to launch for the nodes"
+  description = "The number of droplets to launch for nodes"
+}
+
+variable "uploader_vm_count" {
+  default     = 5
+  description = "The number of droplets to launch for uploaders"
 }
 
 variable "use_custom_bin" {

--- a/src/ansible.rs
+++ b/src/ansible.rs
@@ -145,6 +145,8 @@ pub enum AnsibleInventoryType {
     //
     // Only one machine will be returned in this inventory.
     Auditor,
+    // Use to run a playbook against all bootstrap nodes.
+    BootstrapNodes,
     // Use to run a playbook against the build machine.
     //
     // This is a larger machine that is used for building binaries from source.
@@ -316,6 +318,10 @@ impl AnsibleRunner {
                 ".{}_auditor_inventory_{}.yml",
                 self.environment_name, provider
             )),
+            AnsibleInventoryType::Nodes => PathBuf::from("inventory").join(format!(
+                ".{}_node_inventory_{}.yml",
+                self.environment_name, provider
+            )),
             AnsibleInventoryType::Build => PathBuf::from("inventory").join(format!(
                 ".{}_build_inventory_{}.yml",
                 self.environment_name, provider
@@ -328,8 +334,8 @@ impl AnsibleRunner {
                 ".{}_logstash_inventory_{}.yml",
                 self.environment_name, provider
             )),
-            AnsibleInventoryType::Nodes => PathBuf::from("inventory").join(format!(
-                ".{}_node_inventory_{}.yml",
+            AnsibleInventoryType::BootstrapNodes => PathBuf::from("inventory").join(format!(
+                ".{}_bootstrap_node_inventory_{}.yml",
                 self.environment_name, provider
             )),
         };
@@ -621,7 +627,7 @@ pub async fn generate_environment_inventory(
     output_inventory_dir_path: &Path,
 ) -> Result<()> {
     let mut generated_inventory_paths = vec![];
-    let inventory_files = ["build", "genesis", "node", "auditor"];
+    let inventory_files = ["bootstrap_node", "build", "genesis", "node", "auditor"];
     for inventory_type in inventory_files.iter() {
         let src_path = base_inventory_path;
         let dest_path = output_inventory_dir_path.join(format!(

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -19,6 +19,7 @@ const DEFAULT_BETA_ENCRYPTION_KEY: &str =
 pub struct DeployOptions {
     pub beta_encryption_key: Option<String>,
     pub binary_option: BinaryOption,
+    pub bootstrap_node_count: u16,
     pub bootstrap_node_vm_count: u16,
     pub current_inventory: DeploymentInventory,
     pub env_variables: Option<Vec<(String, String)>>,
@@ -202,9 +203,12 @@ impl TestnetDeployer {
         node_type: NodeType,
     ) -> Result<()> {
         let start = Instant::now();
-        let inventory_type = match node_type {
-            NodeType::Bootstrap => AnsibleInventoryType::BootstrapNodes,
-            NodeType::Normal => AnsibleInventoryType::Nodes,
+        let (inventory_type, node_count) = match node_type {
+            NodeType::Bootstrap => (
+                AnsibleInventoryType::BootstrapNodes,
+                options.bootstrap_node_count,
+            ),
+            NodeType::Normal => (AnsibleInventoryType::Nodes, options.node_count),
         };
 
         self.ansible_runner.run_playbook(
@@ -213,7 +217,7 @@ impl TestnetDeployer {
             Some(self.build_node_extra_vars_doc(
                 options,
                 Some(initial_contact_peer.to_string()),
-                Some(options.node_count),
+                Some(node_count),
             )?),
         )?;
         print_duration(start.elapsed());

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -28,6 +28,7 @@ pub struct DeployOptions {
     pub node_count: u16,
     pub node_vm_count: u16,
     pub public_rpc: bool,
+    pub uploader_vm_count: u16,
 }
 
 enum NodeType {
@@ -163,6 +164,10 @@ impl TestnetDeployer {
             (
                 "node_vm_count".to_string(),
                 options.node_vm_count.to_string(),
+            ),
+            (
+                "uploader_vm_count".to_string(),
+                options.uploader_vm_count.to_string(),
             ),
             ("use_custom_bin".to_string(), enable_build_vm.to_string()),
         ];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,10 +21,7 @@ pub mod ssh;
 pub mod terraform;
 
 use crate::{
-    ansible::{
-        generate_environment_inventory, AnsibleInventoryType, AnsiblePlaybook, AnsibleRunner,
-        ExtraVarsDocBuilder,
-    },
+    ansible::{AnsibleInventoryType, AnsiblePlaybook, AnsibleRunner, ExtraVarsDocBuilder},
     error::{Error, Result},
     inventory::DeploymentInventory,
     rpc_client::RpcClient,
@@ -396,16 +393,6 @@ impl TestnetDeployer {
             permissions.set_mode(0o755); // rwxr-xr-x
             std::fs::set_permissions(&rpc_client_path, permissions)?;
         }
-
-        generate_environment_inventory(
-            &self.environment_name,
-            &self.inventory_file_path,
-            &self
-                .working_directory_path
-                .join("ansible")
-                .join("inventory"),
-        )
-        .await?;
 
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,6 +185,9 @@ enum Commands {
         /// arguments. You can only supply version numbers or a custom branch, not both.
         #[arg(long, verbatim_doc_comment)]
         sn_auditor_version: Option<String>,
+        /// The number of uploader VMs to create.
+        #[clap(long, default_value_t = 5)]
+        uploader_vm_count: u16,
     },
     Inventory {
         /// If set to true, the inventory will be regenerated.
@@ -540,6 +543,7 @@ async fn main() -> Result<()> {
             safenode_version,
             safenode_manager_version,
             sn_auditor_version,
+            uploader_vm_count,
         } => {
             let binary_option = get_binary_option(
                 branch,
@@ -612,6 +616,7 @@ async fn main() -> Result<()> {
                     node_count,
                     node_vm_count,
                     public_rpc,
+                    uploader_vm_count,
                 })
                 .await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,12 +65,11 @@ enum Commands {
         /// If not used a default key will be supplied.
         #[arg(long)]
         beta_encryption_key: Option<String>,
-        /// Peer multiaddress to connect to.
-        /// This is useful to connect to a specific preexisting peer
+        /// The number of bootstrap node VMs to create.
         ///
-        /// If this is supplied then no genesis node will be started.
-        #[arg(long)]
-        bootstrap_peer: Option<String>,
+        /// Each VM will run many safenode services.
+        #[clap(long, default_value_t = 10)]
+        bootstrap_node_vm_count: u16,
         /// The branch of the Github repository to build from.
         ///
         /// If used, all binaries will be built from this branch. It is typically used for testing
@@ -80,14 +79,15 @@ enum Commands {
         ///
         /// The --branch and --repo-owner arguments are mutually exclusive with the binary version
         /// arguments. You can only supply version numbers or a custom branch, not both.
-        #[arg(long)]
+        #[arg(long, verbatim_doc_comment)]
         branch: Option<String>,
         /// Provide environment variables for the safenode service.
         ///
-        /// This is useful to set the safenode's log levels. Each variable should be comma separated without any space.
+        /// This is useful to set the safenode's log levels. Each variable should be comma
+        /// separated without any space.
         ///
         /// Example: --env SN_LOG=all,RUST_LOG=libp2p=debug
-        #[clap(name = "env", long, use_value_delimiter = true, value_parser = parse_environment_variables)]
+        #[clap(name = "env", long, use_value_delimiter = true, value_parser = parse_environment_variables, verbatim_doc_comment)]
         env_variables: Option<Vec<(String, String)>>,
         /// Supply a version number to be used for the faucet binary.
         ///
@@ -95,7 +95,7 @@ enum Commands {
         ///
         /// The version arguments are mutually exclusive with the --branch and --repo-owner arguments.
         /// You can only supply version numbers or a custom branch, not both.
-        #[arg(long)]
+        #[arg(long, verbatim_doc_comment)]
         faucet_version: Option<String>,
         /// Specify the logging format for the nodes.
         ///
@@ -115,17 +115,22 @@ enum Commands {
         /// If not used, the contacts file will have the same name as the environment.
         #[arg(long)]
         network_contacts_file_name: Option<String>,
-        /// The number of safenode processes to run on each VM.
+        /// The number of safenode services to run on each VM.
         #[clap(long, default_value_t = 40)]
         node_count: u16,
-        /// Protocol version is used to partition the network and would not allow nodes with different protocol versions
-        /// to join us.
+        /// The number of node VMs to create.
         ///
-        /// If set to 'restricted' then the branch name is used as the protocol version string else the passed in value
-        /// is used as the version string.
+        /// Each VM will run many safenode services.
+        #[clap(long, default_value_t = 10)]
+        node_vm_count: u16,
+        /// Protocol version is used to partition the network and will not allow nodes with
+        /// different protocol versions to join.
         ///
-        /// The protocol version argument is mutually exclusive with the --safenode-version argument.
-        #[arg(long)]
+        /// If set to 'restricted', the branch name is used as the protocol version; otherwise the
+        /// version is set to the value supplied.
+        ///
+        /// This argument is mutually exclusive with the --safenode-version argument.
+        #[arg(long, verbatim_doc_comment)]
         protocol_version: Option<String>,
         /// The cloud provider to deploy to.
         ///
@@ -134,8 +139,9 @@ enum Commands {
         provider: CloudProvider,
         /// If set to true, the RPC of the node will be accessible remotely.
         ///
-        /// By default, the safenode RPC is only accessible via the 'localhost' and is not exposed for security reasons.
-        #[clap(long, default_value_t = false)]
+        /// By default, the safenode RPC is only accessible via the 'localhost' and is not exposed for
+        /// security reasons.
+        #[clap(long, default_value_t = false, verbatim_doc_comment)]
         public_rpc: bool,
         /// The owner/org of the Github repository to build from.
         ///
@@ -146,14 +152,14 @@ enum Commands {
         ///
         /// The --branch and --repo-owner arguments are mutually exclusive with the binary version
         /// arguments. You can only supply version numbers or a custom branch, not both.
-        #[arg(long)]
+        #[arg(long, verbatim_doc_comment)]
         repo_owner: Option<String>,
         /// The features to enable on the safenode binary.
         ///
         /// If not provided, the default feature set specified for the safenode binary are used.
         ///
         /// The features argument is mutually exclusive with the --safenode-version argument.
-        #[clap(long)]
+        #[clap(long, verbatim_doc_comment)]
         safenode_features: Option<Vec<String>>,
         /// Supply a version number for the safenode binary.
         ///
@@ -161,7 +167,7 @@ enum Commands {
         ///
         /// The version arguments are mutually exclusive with the --branch and --repo-owner
         /// arguments. You can only supply version numbers or a custom branch, not both.
-        #[arg(long)]
+        #[arg(long, verbatim_doc_comment)]
         safenode_version: Option<String>,
         /// Supply a version number for the safenode-manager binary.
         ///
@@ -169,7 +175,7 @@ enum Commands {
         ///
         /// The version arguments are mutually exclusive with the --branch and --repo-owner
         /// arguments. You can only supply version numbers or a custom branch, not both.
-        #[arg(long)]
+        #[arg(long, verbatim_doc_comment)]
         safenode_manager_version: Option<String>,
         /// Supply a version number for the sn_auditor binary.
         ///
@@ -177,21 +183,10 @@ enum Commands {
         ///
         /// The version arguments are mutually exclusive with the --branch and --repo-owner
         /// arguments. You can only supply version numbers or a custom branch, not both.
-        #[arg(long)]
+        #[arg(long, verbatim_doc_comment)]
         sn_auditor_version: Option<String>,
-        /// The number of node VMs to create.
-        ///
-        /// Each VM will run many safenode processes.
-        #[clap(long, default_value_t = 10)]
-        vm_count: u16,
     },
     Inventory {
-        /// Peer multiaddress to connect to.
-        /// This is useful to connect to a specific preexisting peer
-        ///
-        /// To inventory an extensions network, a contact must be suopplied here
-        #[arg(long)]
-        bootstrap_peer: Option<String>,
         /// If set to true, the inventory will be regenerated.
         ///
         /// This is useful if the testnet was created on another machine.
@@ -528,6 +523,7 @@ async fn main() -> Result<()> {
             ansible_verbose,
             beta_encryption_key,
             branch,
+            bootstrap_node_vm_count,
             env_variables,
             faucet_version,
             log_format,
@@ -535,7 +531,7 @@ async fn main() -> Result<()> {
             name,
             network_contacts_file_name,
             node_count,
-            bootstrap_peer,
+            node_vm_count,
             protocol_version,
             provider,
             public_rpc,
@@ -544,7 +540,6 @@ async fn main() -> Result<()> {
             safenode_version,
             safenode_manager_version,
             sn_auditor_version,
-            vm_count,
         } => {
             let binary_option = get_binary_option(
                 branch,
@@ -563,6 +558,11 @@ async fn main() -> Result<()> {
                 .environment_name(&name)
                 .provider(provider.clone())
                 .build()?;
+
+            let inventory_service = DeploymentInventoryService::from(testnet_deployer.clone());
+            let inventory = inventory_service
+                .generate_or_retrieve_inventory(&name, true, Some(binary_option.clone()))
+                .await?;
 
             match testnet_deployer.init().await {
                 Ok(_) => {}
@@ -603,20 +603,20 @@ async fn main() -> Result<()> {
                 .deploy(&DeployOptions {
                     beta_encryption_key,
                     binary_option: binary_option.clone(),
-                    bootstrap_peer: bootstrap_peer.clone(),
+                    bootstrap_node_vm_count,
+                    current_inventory: inventory,
                     env_variables,
                     log_format,
                     logstash_details,
                     name: name.clone(),
                     node_count,
+                    node_vm_count,
                     public_rpc,
-                    vm_count,
                 })
                 .await?;
 
-            let inventory_service = DeploymentInventoryService::from(testnet_deployer);
             let inventory = inventory_service
-                .generate_inventory(&name, true, Some(binary_option), bootstrap_peer)
+                .generate_or_retrieve_inventory(&name, true, Some(binary_option.clone()))
                 .await?;
             inventory.print_report()?;
             inventory.save()?;
@@ -632,7 +632,6 @@ async fn main() -> Result<()> {
             name,
             network_contacts_file_name,
             provider,
-            bootstrap_peer,
         } => {
             let testnet_deploy = TestnetDeployBuilder::default()
                 .environment_name(&name)
@@ -641,7 +640,7 @@ async fn main() -> Result<()> {
 
             let inventory_service = DeploymentInventoryService::from(testnet_deploy);
             let inventory = inventory_service
-                .generate_inventory(&name, force_regeneration, None, bootstrap_peer)
+                .generate_or_retrieve_inventory(&name, force_regeneration, None)
                 .await?;
             inventory.print_report()?;
             inventory.save()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,9 @@ enum Commands {
         /// If not used a default key will be supplied.
         #[arg(long)]
         beta_encryption_key: Option<String>,
+        /// The number of safenode services to run on each bootstrap VM.
+        #[clap(long, default_value_t = 1)]
+        bootstrap_node_count: u16,
         /// The number of bootstrap node VMs to create.
         ///
         /// Each VM will run many safenode services.
@@ -317,7 +320,6 @@ enum Commands {
         /// Supply a version for the binary to be upgraded to.
         ///
         /// There should be no 'v' prefix.
-        /// The name of the environment
         #[arg(short = 'v', long)]
         version: String,
     },
@@ -526,6 +528,7 @@ async fn main() -> Result<()> {
             ansible_verbose,
             beta_encryption_key,
             branch,
+            bootstrap_node_count,
             bootstrap_node_vm_count,
             env_variables,
             faucet_version,
@@ -607,6 +610,7 @@ async fn main() -> Result<()> {
                 .deploy(&DeployOptions {
                     beta_encryption_key,
                     binary_option: binary_option.clone(),
+                    bootstrap_node_count,
                     bootstrap_node_vm_count,
                     current_inventory: inventory,
                     env_variables,

--- a/src/manage_test_data.rs
+++ b/src/manage_test_data.rs
@@ -125,11 +125,7 @@ impl TestDataClient {
             }
         }
 
-        let faucet_addr = inventory.faucet_address.clone().ok_or_else(|| {
-            eyre!("No faucet deployed for this inventory. (It was launched using existing bootstrap peers)")
-        })?;
-
-        let faucet_addr: SocketAddr = faucet_addr.parse()?;
+        let faucet_addr: SocketAddr = inventory.faucet_address.parse()?;
         let random_peer = inventory.get_random_peer();
         self.safe_client
             .wallet_get_faucet(&random_peer, faucet_addr)?;


### PR DESCRIPTION
- 9ad4ba3 **feat: merge bootstrap and 'normal' nodes into one environment**

  Terraform now deploys two different types of nodes: bootstrap and 'normal', where the former are
  a set of larger machines that are used for an initial bootstrap. Being deployed as two different
  types means they can be scaled independently, and this can be controlled by two arguments on the
  `deploy` command: `--bootstrap-node-vm-count` and `--node-vm-count`.

  Merging the nodes into one environment also removes the need for the `--bootstrap-peer` argument. If
  we want to extend our deployment with more machines of either type, we can run the `deploy` command
  again with updated values for the node counts, and any peers we need will already be in the
  inventory.

  Two aspects of inventory management were also changed. First, inventory generation was updated to
  retrieve the bootstrap node information. Secondly, we update the deploy process to try and fetch
  inventory at the beginning of the deployment, as well as generating it at the end. On an initial
  run, an empty inventory will be returned, but on deploys to add new machines, the retrieved
  inventory will represent the current state. This inventory can then be used to disable certain
  things we don't need to run on subsequent deploys, e.g., provisioning the faucet.

  Tests performed:
  ✅ Initial `deploy --bootstrap-node-vm-count 10 --node-vm-count 10` uses 10 VMs for each
  ✅ Next `deploy --bootstrap-node-vm-count 15 --node-vm-count 10` adds 5 bootstrap nodes and leaves
     normal nodes at 10
  ✅ Next `deploy --bootstrap-node-vm-count 15 --node-vm-count 15` adds 5 nodes and leaves bootstrap
     nodes at 15
  ✅ Next `deploy --bootstrap-node-vm-count 10 --node-vm-count 15` removes 5 bootstrap VMs and leaves
     nodes at 15
  ✅ Next `deploy --bootstrap-node-vm-count 10 --node-vm-count 10` removes 5 node VMs and leaves
     bootstrap nodes at 10

- 1a01996 **feat: `deploy` extended to provide uploaders**

  The Terraform definition is updated to provide file uploader machines and they are tagged as a
  separate type, in anticipation that they can be scaled and provisioned as a separate group. However,
  this is all we are providing at this point. The automated provisioning will come later.

- d15c600 **feat: retry when generating inventory**

  It seems the inventory generation can randomly fail at times. A small retry loop is added, and if
  the attempts don't succeed, the program will not return an error. It will advise the use of the
  `inventory` command or workflow. It's more likely than not that there is some intermittent failure
  connecting to machines rather than something actually being wrong with the inventory generation
  process. Therefore, we don't need to throw out a whole deploy, especially if it was a large one. We
  can try to get the inventory again with the print workflow.

- 0eb5f94 **feat: provide `--bootstrap-node-count` argument**

  This allows the number of nodes on the bootstrap and normal VMs to vary independently of each other,
  which is necessary because the bootstrap machines are intended to have a much lower number.

- 1d16b76 **feat: set node type for use in metrics collection**

  The metrics configuration has been modified to make use of a `SAFENODE_HOST_ROLE` which
  differentiates a bootstrap node from a generic node.

  The values of all the `SAFENODE_` variables are also converted to uppercase.