### PR TITLE
chore: use 25 as default node count

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -119,7 +119,7 @@ enum Commands {
         #[arg(long)]
         network_contacts_file_name: Option<String>,
         /// The number of safenode services to run on each VM.
-        #[clap(long, default_value_t = 40)]
+        #[clap(long, default_value_t = 25)]
         node_count: u16,
         /// The number of node VMs to create.
         ///


### PR DESCRIPTION
This was the count used in the recent production deployment and it's also the value that's stated in the workflow documentation.