### PR TITLE
chore(logs): use common timestamp for all rg files

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -37,8 +37,11 @@ pub enum Error {
     EnvironmentDoesNotExist(String),
     #[error("The environment name is required")]
     EnvironmentNameRequired,
-    #[error("Command that executed with {0} failed. See output for details.")]
-    ExternalCommandRunFailed(String),
+    #[error("Command that executed with {binary} failed. See output for details.")]
+    ExternalCommandRunFailed {
+        binary: String,
+        exit_status: std::process::ExitStatus,
+    },
     #[error("The provided inventory file is empty or does not exists {0}")]
     EmptyInventory(PathBuf),
     #[error("To provision the remaining nodes the multiaddr of the genesis node must be supplied")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -619,7 +619,10 @@ pub fn run_external_command(
     if !output.success() {
         // Using `unwrap` here avoids introducing another error variant, which seems excessive.
         let binary_path = binary_path.to_str().unwrap();
-        return Err(Error::ExternalCommandRunFailed(binary_path.to_string()));
+        return Err(Error::ExternalCommandRunFailed {
+            binary: binary_path.to_string(),
+            exit_status: output,
+        });
     }
 
     Ok(output_lines)

--- a/src/main.rs
+++ b/src/main.rs
@@ -442,7 +442,7 @@ enum LogCommands {
         /// The ripgrep arguments that are directly passed to ripgrep. The text to search for should be put inside
         /// single quotes. The dir to search for is set automatically, so do not provide one.
         ///
-        /// Example command: `cargo run --release -- logs rg --name <name> --args "'ValidSpendRecordPutFromNetwork' -c"`
+        /// Example command: `cargo run --release -- logs rg --name <name> --args "'ValidSpendRecordPutFromNetwork' -z -a"`
         #[arg(short = 'a', long, allow_hyphen_values(true))]
         args: String,
         /// The name of the environment

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -97,8 +97,7 @@ impl SshClient {
             args,
             suppress_output,
             false,
-        )
-        .map_err(|_| Error::SshCommandFailed(command.to_string()))?;
+        )?;
         Ok(output)
     }
 


### PR DESCRIPTION
- Use common timestamp per rg run.
- Do not print error if no matches are found.
- write the rg command that was used inisde the output file.