### PR TITLE
chore: set the correct end port

### DIFF
--- a/resources/ansible/roles/node/tasks/main.yml
+++ b/resources/ansible/roles/node/tasks/main.yml
@@ -65,8 +65,8 @@
 
 - name: calculate end port
   set_fact:
-    rpc_end_port: "{{ rpc_start_port | int + nodes_to_add | int }}"
-    metrics_end_port: "{{ metrics_start_port | int + nodes_to_add | int }}"
+    rpc_end_port: "{{ rpc_start_port | int + nodes_to_add | int - 1 | int }}"
+    metrics_end_port: "{{ metrics_start_port | int + nodes_to_add | int - 1 | int }}"
   when: nodes_to_add | default(0) | int > 0
 
 - name: add node services


### PR DESCRIPTION
- Safenode manager now caries out the same validation steps for all the ports passed to it.
- Earlier, only `node-port` was validated, thus this went unnoticed.