### PR TITLE
Various Changes for Telegraf and Upgrades

### DIFF
--- a/resources/ansible/ansible.cfg
+++ b/resources/ansible/ansible.cfg
@@ -4,4 +4,4 @@ forks = 50
 timeout = 60
 
 [ssh_connection]
-ssh_args = -o ControlMaster=no -o ControlPersist=300s -o ConnectTimeout=60
+ssh_args = -o ControlMaster=auto -o ControlPersist=30m -o ConnectTimeout=60

--- a/resources/ansible/ansible.cfg
+++ b/resources/ansible/ansible.cfg
@@ -1,6 +1,7 @@
 [defaults]
 host_key_checking = False
 forks = 50
+timeout = 60
 
 [ssh_connection]
-timeout = 30
+ssh_args = -o ControlMaster=no -o ControlPersist=300s -o ConnectTimeout=60

--- a/resources/ansible/ansible.cfg
+++ b/resources/ansible/ansible.cfg
@@ -1,3 +1,6 @@
 [defaults]
 host_key_checking = False
 forks = 50
+
+[ssh_connection]
+timeout = 30

--- a/resources/ansible/node_status.yml
+++ b/resources/ansible/node_status.yml
@@ -1,0 +1,9 @@
+---
+- name: run safenode-manager status
+  hosts: all
+  become: False
+  max_fail_percentage: 10
+  ignore_unreachable: yes
+  tasks:
+    - name: run safenode-manager status
+      ansible.builtin.command: safenode-manager status

--- a/resources/ansible/roles/metrics/tasks/main.yml
+++ b/resources/ansible/roles/metrics/tasks/main.yml
@@ -27,6 +27,16 @@
     accept_hostkey: yes
   when: not repo_stat.stat.exists
 
+- name: update the network dashboard repo
+  git:
+    repo: "{{ network_dashboard_github_url }}"
+    dest: "{{ network_dashboard_repo_path }}"
+    version: main
+    key_file: "{{ network_dashboard_sk_path }}"
+    accept_hostkey: yes
+    force: yes
+  when: repo_stat.stat.exists
+
 - name: ensure _telegraf can run safenode-manager without a password
   lineinfile:
     path: /etc/sudoers

--- a/resources/ansible/stop_telegraf.yml
+++ b/resources/ansible/stop_telegraf.yml
@@ -1,0 +1,10 @@
+---
+- name: ensure the telegraf service is stopped
+  hosts: all
+  become: True
+  tasks:
+    - name: stop telegraf service
+      systemd:
+        name: telegraf
+        enabled: yes
+        state: stopped

--- a/resources/ansible/upgrade_telegraf_config.yml
+++ b/resources/ansible/upgrade_telegraf_config.yml
@@ -1,0 +1,12 @@
+---
+- name: upgrade the telegraf configuration
+  hosts: all
+  roles:
+    - role: metrics
+      become: True
+  tasks:
+    - name: restart telegraf service
+      systemd:
+        name: telegraf
+        enabled: yes
+        state: restarted

--- a/src/ansible/mod.rs
+++ b/src/ansible/mod.rs
@@ -104,6 +104,10 @@ pub enum AnsiblePlaybook {
     ///
     /// Use in combination with `AnsibleInventoryType::Genesis` or `AnsibleInventoryType::Nodes`.
     StartNodes,
+    /// Run `safenode-manager status` on the machine.
+    ///
+    /// Useful to determine the state of all the nodes in a deployment.
+    Status,
     /// This playbook will stop the Telegraf service running on each machine.
     ///
     /// It can be necessary for running upgrades, since Telegraf will run `safenode-manager
@@ -140,6 +144,7 @@ impl AnsiblePlaybook {
             AnsiblePlaybook::Nodes => "nodes.yml".to_string(),
             AnsiblePlaybook::RpcClient => "safenode_rpc_client.yml".to_string(),
             AnsiblePlaybook::StartNodes => "start_nodes.yml".to_string(),
+            AnsiblePlaybook::Status => "node_status.yml".to_string(),
             AnsiblePlaybook::StopTelegraf => "stop_telegraf.yml".to_string(),
             AnsiblePlaybook::UpgradeFaucet => "upgrade_faucet.yml".to_string(),
             AnsiblePlaybook::UpgradeNodeManager => "upgrade_node_manager.yml".to_string(),

--- a/src/ansible/mod.rs
+++ b/src/ansible/mod.rs
@@ -128,6 +128,8 @@ pub enum AnsiblePlaybook {
     ///
     /// Use in combination with `AnsibleInventoryType::Genesis` or `AnsibleInventoryType::Nodes`.
     UpgradeNodes,
+    /// Update the Telegraf configuration to the latest version in the repository.
+    UpgradeTelegrafConfig,
     /// The uploader playbook will setup the uploader scripts on the uploader VMs.
     ///
     /// Use in combination with `AnsibleInventoryType::Uploaders`.
@@ -152,6 +154,7 @@ impl AnsiblePlaybook {
             AnsiblePlaybook::UpgradeFaucet => "upgrade_faucet.yml".to_string(),
             AnsiblePlaybook::UpgradeNodeManager => "upgrade_node_manager.yml".to_string(),
             AnsiblePlaybook::UpgradeNodes => "upgrade_nodes.yml".to_string(),
+            AnsiblePlaybook::UpgradeTelegrafConfig => "upgrade_telegraf_config.yml".to_string(),
             AnsiblePlaybook::Uploaders => "uploaders.yml".to_string(),
         }
     }

--- a/src/ansible/mod.rs
+++ b/src/ansible/mod.rs
@@ -104,6 +104,11 @@ pub enum AnsiblePlaybook {
     ///
     /// Use in combination with `AnsibleInventoryType::Genesis` or `AnsibleInventoryType::Nodes`.
     StartNodes,
+    /// This playbook will stop the Telegraf service running on each machine.
+    ///
+    /// It can be necessary for running upgrades, since Telegraf will run `safenode-manager
+    /// status`, which writes to the registry file and can interfere with an upgrade.
+    StopTelegraf,
     /// The upgrade faucet playbook will upgrade the faucet to the latest version.
     ///
     /// Use in combination with `AnsibleInventoryType::Genesis`.
@@ -135,6 +140,7 @@ impl AnsiblePlaybook {
             AnsiblePlaybook::Nodes => "nodes.yml".to_string(),
             AnsiblePlaybook::RpcClient => "safenode_rpc_client.yml".to_string(),
             AnsiblePlaybook::StartNodes => "start_nodes.yml".to_string(),
+            AnsiblePlaybook::StopTelegraf => "stop_telegraf.yml".to_string(),
             AnsiblePlaybook::UpgradeFaucet => "upgrade_faucet.yml".to_string(),
             AnsiblePlaybook::UpgradeNodeManager => "upgrade_node_manager.yml".to_string(),
             AnsiblePlaybook::UpgradeNodes => "upgrade_nodes.yml".to_string(),

--- a/src/ansible/mod.rs
+++ b/src/ansible/mod.rs
@@ -331,7 +331,7 @@ impl AnsibleRunner {
             args.push(extra_vars);
         }
         if self.ansible_verbose_mode {
-            args.push("-v".to_string());
+            args.push("-vvvvv".to_string());
         }
         args.push("--forks".to_string());
         args.push(self.ansible_forks.to_string());

--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -325,6 +325,25 @@ impl AnsibleProvisioner {
         Ok(())
     }
 
+    pub async fn stop_telegraf(&self) -> Result<()> {
+        self.ansible_runner.run_playbook(
+            AnsiblePlaybook::StopTelegraf,
+            AnsibleInventoryType::Genesis,
+            None,
+        )?;
+        self.ansible_runner.run_playbook(
+            AnsiblePlaybook::StopTelegraf,
+            AnsibleInventoryType::BootstrapNodes,
+            None,
+        )?;
+        self.ansible_runner.run_playbook(
+            AnsiblePlaybook::StopTelegraf,
+            AnsibleInventoryType::Nodes,
+            None,
+        )?;
+        Ok(())
+    }
+
     pub async fn upgrade_nodes(&self, options: &UpgradeOptions) -> Result<()> {
         match self.ansible_runner.run_playbook(
             AnsiblePlaybook::UpgradeNodes,

--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -325,6 +325,25 @@ impl AnsibleProvisioner {
         Ok(())
     }
 
+    pub async fn status(&self) -> Result<()> {
+        self.ansible_runner.run_playbook(
+            AnsiblePlaybook::Status,
+            AnsibleInventoryType::Genesis,
+            None,
+        )?;
+        self.ansible_runner.run_playbook(
+            AnsiblePlaybook::Status,
+            AnsibleInventoryType::BootstrapNodes,
+            None,
+        )?;
+        self.ansible_runner.run_playbook(
+            AnsiblePlaybook::Status,
+            AnsibleInventoryType::Nodes,
+            None,
+        )?;
+        Ok(())
+    }
+
     pub async fn stop_telegraf(&self) -> Result<()> {
         self.ansible_runner.run_playbook(
             AnsiblePlaybook::StopTelegraf,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -443,7 +443,14 @@ impl TestnetDeployer {
         Ok(())
     }
 
+    /// Get the status of all nodes in a network.
+    ///
+    /// First, a playbook runs `safenode-manager status` against all the machines, to get the
+    /// current state of all the nodes. Then all the node registry files are retrieved and
+    /// deserialized to a `NodeRegistry`, allowing us to output the status of each node on each VM.
     pub async fn status(&self) -> Result<()> {
+        self.ansible_provisioner.status().await?;
+
         let bootstrap_node_registries = self
             .ansible_provisioner
             .get_node_registries(&AnsibleInventoryType::BootstrapNodes)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -495,6 +495,11 @@ impl TestnetDeployer {
         Ok(())
     }
 
+    pub async fn upgrade_telegraf(&self, name: &str) -> Result<()> {
+        self.ansible_provisioner.upgrade_telegraf(name).await?;
+        Ok(())
+    }
+
     pub async fn clean(&self) -> Result<()> {
         do_clean(
             &self.environment_name,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -470,6 +470,11 @@ impl TestnetDeployer {
         Ok(())
     }
 
+    pub async fn stop_telegraf(&self) -> Result<()> {
+        self.ansible_provisioner.stop_telegraf().await?;
+        Ok(())
+    }
+
     pub async fn upgrade(&self, options: UpgradeOptions) -> Result<()> {
         self.ansible_provisioner.upgrade_nodes(&options).await?;
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ use crate::{
         AnsibleRunner,
     },
     error::{Error, Result},
-    inventory::DeploymentInventory,
+    inventory::{DeploymentInventory, VirtualMachine},
     rpc_client::RpcClient,
     s3::S3Repository,
     ssh::SshClient,
@@ -159,6 +159,7 @@ impl LogFormat {
 #[derive(Clone)]
 pub struct UpgradeOptions {
     pub ansible_verbose: bool,
+    pub custom_inventory: Option<Vec<VirtualMachine>>,
     pub env_variables: Option<Vec<(String, String)>>,
     pub faucet_version: Option<String>,
     pub force_faucet: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -278,6 +278,21 @@ enum Commands {
         #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
         provider: CloudProvider,
     },
+    /// Stop the Telegraf service on all machines in the environment.
+    ///
+    /// This may be necessary for performing upgrades.
+    #[clap(name = "stop-telegraf")]
+    StopTelegraf {
+        /// Maximum number of forks Ansible will use to execute tasks on target hosts.
+        #[clap(long, default_value_t = 50)]
+        forks: usize,
+        /// The name of the environment.
+        #[arg(short = 'n', long)]
+        name: String,
+        /// The cloud provider for the environment.
+        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
+        provider: CloudProvider,
+    },
     /// Upgrade the node binaries of a testnet environment to the latest version.
     Upgrade {
         /// Set to run Ansible with more verbose output.
@@ -1005,6 +1020,32 @@ async fn main() -> Result<()> {
             }
 
             testnet_deploy.status().await?;
+            Ok(())
+        }
+        Commands::StopTelegraf {
+            forks,
+            name,
+            provider,
+        } => {
+            let testnet_deploy = TestnetDeployBuilder::default()
+                .ansible_forks(forks)
+                .environment_name(&name)
+                .provider(provider.clone())
+                .build()?;
+
+            // This is required in the case where the command runs in a remote environment, where
+            // there won't be an existing inventory, which is required to retrieve the node
+            // registry files used to determine the status.
+            let inventory_service = DeploymentInventoryService::from(testnet_deploy.clone());
+            let inventory = inventory_service
+                .generate_or_retrieve_inventory(&name, true, None)
+                .await?;
+            if inventory.is_empty() {
+                return Err(eyre!("The {name} environment does not exist"));
+            }
+
+            testnet_deploy.stop_telegraf().await?;
+
             Ok(())
         }
         Commands::Upgrade {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1066,7 +1066,6 @@ async fn main() -> Result<()> {
             // using the smaller fork value.
             let testnet_deploy = TestnetDeployBuilder::default()
                 .ansible_forks(50)
-                .ansible_verbose_mode(ansible_verbose)
                 .environment_name(&name)
                 .provider(provider.clone())
                 .build()?;
@@ -1102,7 +1101,6 @@ async fn main() -> Result<()> {
             // Recreate the deployer with an increased number of forks for retrieving the status.
             let testnet_deploy = TestnetDeployBuilder::default()
                 .ansible_forks(50)
-                .ansible_verbose_mode(ansible_verbose)
                 .environment_name(&name)
                 .provider(provider.clone())
                 .build()?;


### PR DESCRIPTION
- 5f23b97 **feat: provide `stop-telegraf` command**

  The Telegraf service is currently using `safenode-manager status`, which causes the registry file to
  be re-written. This could interfere with an upgrade process.

  A longer term solution would be to provide some kind of status command which is read only.

- 42076f0 **chore: increase ansible timeout**

  During the production upgrade process we were seeing a lot of failed connection attempts. Going to
  see if increasing the timeout will make any difference.

- 978b36b **feat: extend `status` command to run `safenode-manager status`**

  Adding this in means the command can run at any point in time and the current state will be
  obtained, not the state when the node manager last ran.

- c7ccbb1 **feat: more reliable ssh configuration**

  Increase the timeout for both Ansible and SSH, and try a larger value for `ControlPersist`. If
  `ConnectTimeout` was lower than the Ansible `timeout` value, I think it would effectively override
  the Ansible value. Also attempting to turn of `ControlMaster`.

  Also, specify `-vvvvv` when `--ansible-verbose` is used so that we can get the full SSH specification.

- 2e54659 **feat: provide `--custom-inventory` arg for `upgrade` cmd**

  Use this argument to pass a list of particular VMs for the upgrade to run against. It can be used to
  target VMs that were 'unreachable' in previous runs. It saves time by narrowing the scope of
  machines to run against.

  It works by looking up the IP addresses of the VMs named using the argument, then writing those IP
  addresses out to a custom inventory file.

- 1de5a4f **chore: try large value for control persist**

  Even when using the custom inventory with only 3 VMs, I am still having problems connecting to the
  hosts. Trying a very large value for `ControlPersist`, which I saw someone use on a Github issue.

  Also setting the `ControlMaster` back to auto here.

- 5fc6f02 **feat: provide `upgrade-telegraf` command**

  Runs a playbook that will get the latest changes from the metrics repository then restart Telegraf
  based on that configuration.