### PR TITLE
feat: vary machine sizes and counts for environment types

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,25 @@
+#!/usr/bin/env just --justfile
+
+build-staging-bootstrap-image:
+  #!/usr/bin/env bash
+  (
+    cd resources/packer/node
+    packer init .
+    packer build -var 'size=s-1vcpu-2gb' node.pkr.hcl
+  )
+
+build-staging-node-image:
+  #!/usr/bin/env bash
+  (
+    cd resources/packer/node
+    packer init .
+    packer build -var 'size=s-2vcpu-4gb' node.pkr.hcl
+  )
+
+build-staging-uploader-image:
+  #!/usr/bin/env bash
+  (
+    cd resources/packer/node
+    packer init .
+    packer build -var 'size=s-2vcpu-4gb' node.pkr.hcl
+  )

--- a/resources/packer/node/node.pkr.hcl
+++ b/resources/packer/node/node.pkr.hcl
@@ -55,11 +55,11 @@ build {
     destination = "/tmp/ansible-vault-password"
   }
   provisioner "shell" {
-    script = "../scripts/install_ansible.sh"
+    script = "../../scripts/install_ansible.sh"
   }
   provisioner "ansible-local" {
-    playbook_dir = "../ansible"
-    playbook_file = "../ansible/create_node_image.yml"
+    playbook_dir = "../../ansible"
+    playbook_file = "../../ansible/create_node_image.yml"
     extra_arguments = [
       "--vault-password-file=/tmp/ansible-vault-password",
       "--extra-vars",

--- a/resources/terraform/testnet/digital-ocean/dev.tfvars
+++ b/resources/terraform/testnet/digital-ocean/dev.tfvars
@@ -1,0 +1,9 @@
+bootstrap_droplet_size = "s-1vcpu-2gb"
+bootstrap_node_vm_count = 2
+bootstrap_droplet_image_id = 162461040
+node_droplet_size = "s-2vcpu-4gb"
+node_vm_count = 10
+node_droplet_image_id = 162460774
+uploader_droplet_size = "s-2vcpu-4gb"
+uploader_vm_count = 2
+uploader_droplet_image_id = 162461150

--- a/resources/terraform/testnet/digital-ocean/main.tf
+++ b/resources/terraform/testnet/digital-ocean/main.tf
@@ -11,20 +11,20 @@ terraform {
 }
 
 resource "digitalocean_droplet" "genesis_bootstrap" {
-  image    = var.node_droplet_image_id
+  image    = var.bootstrap_droplet_image_id
   name     = "${terraform.workspace}-genesis-bootstrap"
   region   = var.region
-  size     = var.boostrap_droplet_size
+  size     = var.bootstrap_droplet_size
   ssh_keys = var.droplet_ssh_keys
   tags     = ["environment:${terraform.workspace}", "type:genesis"]
 }
 
 resource "digitalocean_droplet" "bootstrap_node" {
   count    = var.bootstrap_node_vm_count
-  image    = var.node_droplet_image_id
+  image    = var.bootstrap_droplet_image_id
   name     = "${terraform.workspace}-bootstrap-node-${count.index + 1}"
   region   = var.region
-  size     = var.boostrap_droplet_size
+  size     = var.bootstrap_droplet_size
   ssh_keys = var.droplet_ssh_keys
   tags     = ["environment:${terraform.workspace}", "type:bootstrap_node"]
 }
@@ -41,10 +41,10 @@ resource "digitalocean_droplet" "node" {
 
 resource "digitalocean_droplet" "uploader" {
   count    = var.uploader_vm_count
-  image    = var.node_droplet_image_id
+  image    = var.uploader_droplet_image_id
   name     = "${terraform.workspace}-uploader-${count.index + 1}"
   region   = var.region
-  size     = var.node_droplet_size
+  size     = var.uploader_droplet_size
   ssh_keys = var.droplet_ssh_keys
   tags     = ["environment:${terraform.workspace}", "type:uploader"]
 }

--- a/resources/terraform/testnet/digital-ocean/production.tfvars
+++ b/resources/terraform/testnet/digital-ocean/production.tfvars
@@ -1,0 +1,9 @@
+bootstrap_droplet_size = "s-8vcpu-16gb-480gb-intel"
+bootstrap_node_vm_count = 50
+bootstrap_droplet_image_id = 157362431
+node_droplet_size = "s-2vcpu-4gb"
+node_vm_count = 79
+node_droplet_image_id = 157362431
+uploader_droplet_size = "s-2vcpu-4gb"
+uploader_vm_count = 5
+uploader_droplet_image_id = 157362431

--- a/resources/terraform/testnet/digital-ocean/staging.tfvars
+++ b/resources/terraform/testnet/digital-ocean/staging.tfvars
@@ -1,0 +1,9 @@
+bootstrap_droplet_size = "s-1vcpu-2gb"
+bootstrap_node_vm_count = 2
+bootstrap_droplet_image_id = 162461040
+node_droplet_size = "s-2vcpu-4gb"
+node_vm_count = 39
+node_droplet_image_id = 162460774
+uploader_droplet_size = "s-2vcpu-4gb"
+uploader_vm_count = 2
+uploader_droplet_image_id = 162461150

--- a/resources/terraform/testnet/digital-ocean/variables.tf
+++ b/resources/terraform/testnet/digital-ocean/variables.tf
@@ -18,30 +18,39 @@ variable "droplet_ssh_keys" {
 }
 
 variable "node_droplet_size" {
-  default = "s-2vcpu-4gb"
+  description = "The size of the droplet for generic nodes VMs"
 }
 
-variable "boostrap_droplet_size" {
-  default = "s-8vcpu-16gb-480gb-intel"
+variable "bootstrap_droplet_size" {
+  description = "The size of the droplet for bootstrap nodes VMs"
+}
+
+variable "uploader_droplet_size" {
+  description = "The size of the droplet for uploader VMs"
 }
 
 variable "build_machine_size" {
   default = "s-8vcpu-16gb"
 }
 
-# This corresponds to the 'safe_network-auditor-1715864456' image/snapshot.
 variable "auditor_droplet_image_id" {
   default = "156295663"
 }
 
-# This corresponds to the 'safe_network-build-1715854128' image/snapshot.
 variable "build_droplet_image_id" {
   default = "156286538"
 }
 
-# This corresponds to the 'safe_network-node-1717198184' image/snapshot.
+variable "bootstrap_droplet_image_id" {
+  description = "The ID of the bootstrap node droplet image. Varies per environment type."
+}
+
 variable "node_droplet_image_id" {
-  default = "157362431"
+  description = "The ID of the node droplet image. Varies per environment type."
+}
+
+variable "uploader_droplet_image_id" {
+  description = "The ID of the uploader droplet image. Varies per environment type."
 }
 
 variable "region" {
@@ -49,17 +58,17 @@ variable "region" {
 }
 
 variable "bootstrap_node_vm_count" {
-  default     = 25
+  default     = 2
   description = "The number of droplets to launch for bootstrap nodes"
 }
 
 variable "node_vm_count" {
-  default     = 25
+  default     = 10
   description = "The number of droplets to launch for nodes"
 }
 
 variable "uploader_vm_count" {
-  default     = 5
+  default     = 2
   description = "The number of droplets to launch for uploaders"
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,8 @@ pub enum Error {
     EnvironmentDoesNotExist(String),
     #[error("The environment name is required")]
     EnvironmentNameRequired,
+    #[error("Could not convert '{0}' to an EnvironmentType variant")]
+    EnvironmentNameFromStringError(String),
     #[error("Command that executed with {binary} failed. See output for details.")]
     ExternalCommandRunFailed {
         binary: String,
@@ -95,6 +97,12 @@ pub enum Error {
     LogsNotRetrievedError(String),
     #[error("The API response did not contain the expected '{0}' value")]
     MalformedDigitalOceanApiRespose(String),
+    #[error("Could not convert from DeployOptions to ProvisionOptions: bootstrap node count must have a value")]
+    MissingBootstrapNodeCount,
+    #[error(
+        "Could not convert from DeployOptions to ProvisionOptions: node count must have a value"
+    )]
+    MissingNodeCount,
     #[error(transparent)]
     ReqwestError(#[from] reqwest::Error),
     #[error(transparent)]

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -9,11 +9,11 @@ use crate::{
         generate_environment_inventory, provisioning::AnsibleProvisioner, AnsibleInventoryType,
         AnsibleRunner,
     },
-    get_genesis_multiaddr,
+    get_environment_type, get_genesis_multiaddr,
     s3::S3Repository,
     ssh::SshClient,
     terraform::TerraformRunner,
-    BinaryOption, CloudProvider, TestnetDeployer,
+    BinaryOption, CloudProvider, EnvironmentType, TestnetDeployer,
 };
 use color_eyre::{eyre::eyre, Result};
 use rand::seq::IteratorRandom;
@@ -282,11 +282,13 @@ impl DeploymentInventoryService {
 
         let (genesis_multiaddr, genesis_ip) =
             get_genesis_multiaddr(&self.ansible_runner, &self.ssh_client).await?;
+        let environment_type = get_environment_type(name, &self.s3_repository).await?;
         let inventory = DeploymentInventory {
             auditor_address: format!("{auditor_ip}:4242"),
             binary_option,
             bootstrap_node_vms: bootstrap_vm_list,
             bootstrap_peers,
+            environment_type,
             faucet_address: format!("{genesis_ip}:8000"),
             genesis_multiaddr,
             name: name.to_string(),
@@ -356,6 +358,7 @@ pub struct DeploymentInventory {
     pub binary_option: BinaryOption,
     pub bootstrap_node_vms: Vec<VirtualMachine>,
     pub bootstrap_peers: Vec<String>,
+    pub environment_type: EnvironmentType,
     pub faucet_address: String,
     pub genesis_multiaddr: String,
     pub misc_vms: Vec<VirtualMachine>,
@@ -379,6 +382,7 @@ impl DeploymentInventory {
             auditor_address: String::new(),
             bootstrap_node_vms: Vec::new(),
             bootstrap_peers: Vec::new(),
+            environment_type: EnvironmentType::Development,
             genesis_multiaddr: String::new(),
             faucet_address: String::new(),
             misc_vms: Vec::new(),

--- a/src/logstash.rs
+++ b/src/logstash.rs
@@ -224,7 +224,7 @@ impl LogstashDeploy {
         self.terraform_runner.workspace_select(name)?;
         println!("Running terraform apply...");
         self.terraform_runner
-            .apply(vec![("node_count".to_string(), vm_count.to_string())])?;
+            .apply(vec![("node_count".to_string(), vm_count.to_string())], None)?;
         Ok(())
     }
 
@@ -257,6 +257,7 @@ impl LogstashDeploy {
     pub async fn clean(&self, name: &str) -> Result<()> {
         do_clean(
             name,
+            None,
             self.working_directory_path.clone(),
             &self.terraform_runner,
             vec!["logstash".to_string()],

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -78,6 +78,14 @@ impl S3Repository {
         Ok(())
     }
 
+    pub async fn delete_object(&self, bucket_name: &str, object_key: &str) -> Result<()> {
+        let conf = aws_config::from_env().region("eu-west-2").load().await;
+        let client = Client::new(&conf);
+        self.do_delete_object(&client, bucket_name, object_key)
+            .await?;
+        Ok(())
+    }
+
     pub async fn delete_folder(&self, bucket_name: &str, folder_path: &str) -> Result<()> {
         let conf = aws_config::from_env().region("eu-west-2").load().await;
         let client = Client::new(&conf);
@@ -186,7 +194,8 @@ impl S3Repository {
         if let Some(objects) = output.contents {
             for object in objects {
                 let object_key = object.key.unwrap();
-                self.delete_object(client, bucket_name, &object_key).await?;
+                self.do_delete_object(client, bucket_name, &object_key)
+                    .await?;
             }
         }
 
@@ -231,7 +240,7 @@ impl S3Repository {
         Ok(())
     }
 
-    async fn delete_object(
+    async fn do_delete_object(
         &self,
         client: &Client,
         bucket_name: &str,

--- a/src/terraform.rs
+++ b/src/terraform.rs
@@ -41,11 +41,18 @@ impl TerraformRunner {
         Ok(runner)
     }
 
-    pub fn apply(&self, vars: Vec<(String, String)>) -> Result<()> {
+    pub fn apply(
+        &self,
+        vars: Vec<(String, String)>,
+        tfvars_filename: Option<String>,
+    ) -> Result<()> {
         let mut args = vec!["apply".to_string(), "-auto-approve".to_string()];
         for var in vars.iter() {
             args.push("-var".to_string());
             args.push(format!("{}={}", var.0, var.1));
+        }
+        if let Some(tfvars_filename) = tfvars_filename {
+            args.push(format!("-var-file={}", tfvars_filename));
         }
         run_external_command(
             self.binary_path.clone(),
@@ -57,11 +64,15 @@ impl TerraformRunner {
         Ok(())
     }
 
-    pub fn destroy(&self) -> Result<()> {
+    pub fn destroy(&self, tfvars_filename: Option<String>) -> Result<()> {
+        let mut args = vec!["destroy".to_string(), "-auto-approve".to_string()];
+        if let Some(tfvars_filename) = tfvars_filename {
+            args.push(format!("-var-file={}", tfvars_filename));
+        }
         run_external_command(
             self.binary_path.clone(),
             self.working_directory_path.clone(),
-            vec!["destroy".to_string(), "-auto-approve".to_string()],
+            args,
             false,
             false,
         )?;

--- a/src/upscale.rs
+++ b/src/upscale.rs
@@ -72,10 +72,14 @@ impl TestnetDeployer {
 
         self.create_or_update_infra(
             &options.current_inventory.name,
-            desired_bootstrap_node_vm_count,
-            desired_node_vm_count,
-            desired_uploader_vm_count,
+            Some(desired_bootstrap_node_vm_count),
+            Some(desired_node_vm_count),
+            Some(desired_uploader_vm_count),
             false,
+            &options
+                .current_inventory
+                .environment_type
+                .get_tfvars_filename(),
         )
         .await
         .map_err(|err| {


### PR DESCRIPTION
An `EnvironmentType` enum is introduced, with three variants: `Development`, `Staging`, and
`Production`. The intention is for the network being deployed to have a specification that resembles
either of these three possibilities. The variant determines the number of droplets, their size, and
image IDs, and the number of node services on each VM. These values are stored in `tfvars` files
that correspond to each of the variants.

The environment type selection is persisted in the deployment inventory by storing it in a file in a
new S3 bucket. This is used so that the correct tfvars file gets used during upscale operations.
Without this, there would be a risk that droplet sizes could change, which would cause droplets to
be recreated. The file is deleted when the deployment is cleaned. For the same reason,
`production.tfvars` file retains the previous droplet image IDs.

All of the count args on the `deploy` command are turned into options. These can still be used to
override the values in the tfvars files. With Terraform, variables provided by the `-var` argument
take precedence over values provided by `-var-file`. However, the droplet sizes and image IDs cannot
be varied.

There are now separate droplet images for staging and production, because DO prohibits the creation
of a droplet that is smaller in size than the image. So it's just easier to have separate images.
Right now, the development environment type will use the same droplet images as staging, but we
could potentially vary that if we need to. For these reasons, the default image IDs have been
removed. It doesn't make sense for there to be defaults; it depends on the environment type. The
same thing applies for droplet sizes. It may seem strange to declare the variables without defaults,
but Terraform requires that.