### PR TITLE
chore: introduce release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+name: release
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    if: |
+      github.repository_owner == 'maidsafe' &&
+      startsWith(github.event.head_commit.message, 'chore(release):')
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cargo-bins/cargo-binstall@main
+      - shell: bash
+        run: cargo binstall --no-confirm just
+      - uses: actions-rs/toolchain@v1
+        id: toolchain
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      # This method was copied from another repository, where we support multiple architectures. We
+      # will just leave the mechanism in place in this repository, even though we're only using one
+      # architecture. We can extend it later if need be.
+      - shell: bash
+        run: just build-release-artifacts "x86_64-unknown-linux-musl"
+      - uses: actions/upload-artifact@main
+        with:
+          name: testnet-deploy-x86_64-unknown-linux-musl
+          path: |
+            artifacts
+            !artifacts/.cargo-lock
+  release:
+    if: |
+      github.repository_owner == 'maidsafe' &&
+      startsWith(github.event.head_commit.message, 'chore(release):')
+    name: publish and release
+    runs-on: ubuntu-latest
+    needs: [build]
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.S3_DEPLOY_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DEPLOY_AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: eu-west-2
+      GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: "0"
+          token: ${{ secrets.RELEASE_PAT }}
+      - uses: actions/download-artifact@master
+        with:
+          name: testnet-deploy-x86_64-unknown-linux-musl
+          path: artifacts/x86_64-unknown-linux-musl/release
+      - name: configure git for release
+        shell: bash
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+      - uses: cargo-bins/cargo-binstall@main
+      - name: install tools
+        shell: bash
+        run: |
+          cargo binstall --no-confirm just
+          cargo binstall --no-confirm release-plz
+      - name: publish and release
+        shell: bash
+        run: |
+          cargo login ${{ secrets.CRATES_IO_TOKEN }}
+          release-plz release --git-token ${{ secrets.RELEASE_PAT }}
+          just package-release-assets
+          just upload-release-assets-to-s3

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -1,0 +1,50 @@
+name: bump version
+on:
+  push:
+    branches:
+      - main
+jobs:
+  bump_version:
+    if: |
+      github.repository_owner == 'maidsafe' &&
+      !startsWith(github.event.head_commit.message, 'chore(release):')
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: "0"
+          token: ${{ secrets.RELEASE_PAT }}
+      - uses: actions-rs/toolchain@v1
+        id: toolchain
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: configure git for release
+        shell: bash
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+      - uses: cargo-bins/cargo-binstall@main
+      - shell: bash
+        run: cargo binstall --no-confirm release-plz
+      - name: bump version
+        shell: bash
+        run: |
+          set -e
+          release-plz update
+          if [[ -z $(git status --porcelain) ]]; then
+            echo "No changes were detected. Exiting without bumping the version."
+            exit 0
+          fi
+          version=$(cat Cargo.toml | grep "^version" | awk -F '=' '{ print $2 }' | xargs)
+          commit_message="chore(release): $version"
+          git add --all
+          git commit -m "$commit_message"
+          echo "Generated release commit $commit_message"
+      - name: push version bump commit
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.RELEASE_PAT }}
+          branch: main
+          tags: true

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ resources/safe
 *.key
 *.csr
 .DS_Store
+
+/artifacts/
+/deploy/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
+authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 name = "sn-testnet-deploy"
+description = "Tool for creating Autonomi networks"
+readme = "README.md"
+repository = "https://github.com/maidsafe/sn-testnet-deploy"
 version = "0.1.0"
 edition = "2021"
 license = "BSD-3-Clause"

--- a/Justfile
+++ b/Justfile
@@ -23,3 +23,76 @@ build-staging-uploader-image:
     packer init .
     packer build -var 'size=s-2vcpu-4gb' node.pkr.hcl
   )
+
+# This target has been copied from another repository. On other repositories, more than one
+# architecture is supported. If we want to extend for other architectures, we can do so.
+build-release-artifacts arch:
+  #!/usr/bin/env bash
+  set -e
+
+  arch="{{arch}}"
+  supported_archs=(
+    "x86_64-unknown-linux-musl"
+  )
+
+  arch_supported=false
+  for supported_arch in "${supported_archs[@]}"; do
+    if [[ "$arch" == "$supported_arch" ]]; then
+      arch_supported=true
+      break
+    fi
+  done
+
+  if [[ "$arch_supported" == "false" ]]; then
+    echo "$arch is not supported."
+    exit 1
+  fi
+
+  if [[ "$arch" == "x86_64-unknown-linux-musl" ]]; then
+    if [[ "$(grep -E '^NAME="Ubuntu"' /etc/os-release)" ]]; then
+      # This is intended for use on a fresh Github Actions agent
+      sudo apt update -y
+      sudo apt install -y musl-tools
+    fi
+    rustup target add x86_64-unknown-linux-musl
+  fi
+
+  rm -rf artifacts
+  mkdir artifacts
+  cargo clean
+  cargo build --release --target $arch
+
+  find target/$arch/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
+  rm -f artifacts/.cargo-lock
+
+upload-release-assets-to-s3:
+  #!/usr/bin/env bash
+  set -e
+
+  cd deploy/testnet-deploy
+  for file in *.zip *.tar.gz; do
+    aws s3 cp "$file" "s3://sn-testnet-deploy/$file" --acl public-read
+  done
+
+package-release-assets:
+  #!/usr/bin/env bash
+  set -e
+
+  architectures=(
+    "x86_64-unknown-linux-musl"
+  )
+  bin="testnet-deploy"
+  version=$(cat Cargo.toml | grep "^version" | awk -F '=' '{ print $2 }' | xargs)
+
+  rm -rf deploy/$bin
+  find artifacts/ -name "$bin" -exec chmod +x '{}' \;
+  for arch in "${architectures[@]}" ; do
+    echo "Packaging for $arch..."
+    if [[ $arch == *"windows"* ]]; then bin_name="${bin}.exe"; else bin_name=$bin; fi
+    zip -j $bin-$version-$arch.zip artifacts/$arch/release/$bin_name
+    tar -C artifacts/$arch/release -zcvf $bin-$version-$arch.tar.gz $bin_name
+  done
+
+  mkdir -p deploy/$bin
+  mv *.tar.gz deploy/$bin
+  mv *.zip deploy/$bin

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,4 @@
+[workspace]
+changelog_update = false
+git_release_enable = false
+semver_check = false


### PR DESCRIPTION
The process here is copied from one of our other non-workspace repositories. It is slightly different here in that we only need to produce a binary for Linux, but otherwise it is the same.

The testnet tool also needs access to the Terraform and Ansible definitions, so it doesn't work as a binary in isolation. We can add a second step to somehow distribute these files along with it. For now, a tag of the repository can be checked out along with the binary.