### PR TITLE
chore: try other ssh options

### DIFF
--- a/resources/ansible/ansible.cfg
+++ b/resources/ansible/ansible.cfg
@@ -1,8 +1,7 @@
 [defaults]
-callbacks_enabled = ./callback_plugins
 host_key_checking = False
 forks = 50
-timeout = 60
+timeout = 600
 
 [ssh_connection]
-ssh_args = -o ControlMaster=auto -o ControlPersist=30m -o ConnectTimeout=60
+ssh_args = -o ControlMaster=auto -o ControlPersist=30m -o ConnectTimeout=600 -o ServerAliveInterval=10 -o ServerAliveCountMax=60

--- a/resources/ansible/callback_plugins/show_hosts.py
+++ b/resources/ansible/callback_plugins/show_hosts.py
@@ -1,9 +1,0 @@
-from ansible.plugins.callback import CallbackBase
-
-class CallbackModule(CallbackBase):
-    CALLBACK_VERSION = 2.0
-    CALLBACK_TYPE = 'notification'
-    CALLBACK_NAME = 'show_hosts'
-
-    def v2_runner_on_start(self, host, task):
-        print(f"Running task '{task.get_name()}' on {host.name}")


### PR DESCRIPTION
Increase the timeout values to 10 minutes and specify a fairly small keep-alive interval.

Even though Ansible reports 'UNREACHABLE', I have managed to confirm that a connection does actually take place. The status of the node manager's registry was misleading me to believe no connection was established. The node manager does not update the registry for every node that is upgraded; it only updates it at the end of the whole operation. So, if it gets cut off, the registry makes it look like no nodes have changed version. I was able to confirm that they did change version, by running `safenode --version` for several of the individual binaries.

I am therefore trying a larger timeout, and trying to keep the connection alive by sending packets every 10 seconds.

The plugin for showing the host that Ansible is currently running against has served its purpose, so I'm now removing it.