### PR TITLE
feat: provide `start-telegraf` command

### DIFF
--- a/resources/ansible/start_telegraf.yml
+++ b/resources/ansible/start_telegraf.yml
@@ -1,0 +1,10 @@
+---
+- name: ensure the telegraf service is started
+  hosts: all
+  become: True
+  tasks:
+    - name: stop telegraf service
+      systemd:
+        name: telegraf
+        enabled: yes
+        state: started

--- a/src/ansible/mod.rs
+++ b/src/ansible/mod.rs
@@ -111,6 +111,11 @@ pub enum AnsiblePlaybook {
     ///
     /// Useful to determine the state of all the nodes in a deployment.
     Status,
+    /// This playbook will start the Telegraf service on each machine.
+    ///
+    /// It can be necessary for running upgrades, since we will want to re-enable Telegraf after the
+    /// upgrade.
+    StartTelegraf,
     /// This playbook will stop the Telegraf service running on each machine.
     ///
     /// It can be necessary for running upgrades, since Telegraf will run `safenode-manager
@@ -149,6 +154,7 @@ impl AnsiblePlaybook {
             AnsiblePlaybook::Nodes => "nodes.yml".to_string(),
             AnsiblePlaybook::RpcClient => "safenode_rpc_client.yml".to_string(),
             AnsiblePlaybook::StartNodes => "start_nodes.yml".to_string(),
+            AnsiblePlaybook::StartTelegraf => "start_telegraf.yml".to_string(),
             AnsiblePlaybook::Status => "node_status.yml".to_string(),
             AnsiblePlaybook::StopTelegraf => "stop_telegraf.yml".to_string(),
             AnsiblePlaybook::UpgradeFaucet => "upgrade_faucet.yml".to_string(),

--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -11,6 +11,7 @@ use crate::{
     ansible::generate_custom_environment_inventory,
     deploy::DeployOptions,
     error::{Error, Result},
+    inventory::VirtualMachine,
     print_duration, BinaryOption, CloudProvider, LogFormat, SshClient, UpgradeOptions,
 };
 use log::{debug, trace};
@@ -372,7 +373,26 @@ impl AnsibleProvisioner {
         Ok(())
     }
 
-    pub async fn start_telegraf(&self) -> Result<()> {
+    pub async fn start_telegraf(
+        &self,
+        environment_name: &str,
+        custom_inventory: Option<Vec<VirtualMachine>>,
+    ) -> Result<()> {
+        if let Some(custom_inventory) = custom_inventory {
+            println!("Running the start telegraf playbook with a custom inventory");
+            generate_custom_environment_inventory(
+                &custom_inventory,
+                environment_name,
+                &self.ansible_runner.working_directory_path.join("inventory"),
+            )?;
+            self.ansible_runner.run_playbook(
+                AnsiblePlaybook::StartTelegraf,
+                AnsibleInventoryType::Custom,
+                None,
+            )?;
+            return Ok(());
+        }
+
         self.ansible_runner.run_playbook(
             AnsiblePlaybook::StartTelegraf,
             AnsibleInventoryType::Genesis,
@@ -391,7 +411,26 @@ impl AnsibleProvisioner {
         Ok(())
     }
 
-    pub async fn stop_telegraf(&self) -> Result<()> {
+    pub async fn stop_telegraf(
+        &self,
+        environment_name: &str,
+        custom_inventory: Option<Vec<VirtualMachine>>,
+    ) -> Result<()> {
+        if let Some(custom_inventory) = custom_inventory {
+            println!("Running the stop telegraf playbook with a custom inventory");
+            generate_custom_environment_inventory(
+                &custom_inventory,
+                environment_name,
+                &self.ansible_runner.working_directory_path.join("inventory"),
+            )?;
+            self.ansible_runner.run_playbook(
+                AnsiblePlaybook::StopTelegraf,
+                AnsibleInventoryType::Custom,
+                None,
+            )?;
+            return Ok(());
+        }
+
         self.ansible_runner.run_playbook(
             AnsiblePlaybook::StopTelegraf,
             AnsibleInventoryType::Genesis,

--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -372,6 +372,25 @@ impl AnsibleProvisioner {
         Ok(())
     }
 
+    pub async fn start_telegraf(&self) -> Result<()> {
+        self.ansible_runner.run_playbook(
+            AnsiblePlaybook::StartTelegraf,
+            AnsibleInventoryType::Genesis,
+            None,
+        )?;
+        self.ansible_runner.run_playbook(
+            AnsiblePlaybook::StartTelegraf,
+            AnsibleInventoryType::BootstrapNodes,
+            None,
+        )?;
+        self.ansible_runner.run_playbook(
+            AnsiblePlaybook::StartTelegraf,
+            AnsibleInventoryType::Nodes,
+            None,
+        )?;
+        Ok(())
+    }
+
     pub async fn stop_telegraf(&self) -> Result<()> {
         self.ansible_runner.run_playbook(
             AnsiblePlaybook::StopTelegraf,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -546,6 +546,11 @@ impl TestnetDeployer {
         Ok(())
     }
 
+    pub async fn start_telegraf(&self) -> Result<()> {
+        self.ansible_provisioner.start_telegraf().await?;
+        Ok(())
+    }
+
     pub async fn stop_telegraf(&self) -> Result<()> {
         self.ansible_provisioner.stop_telegraf().await?;
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -546,13 +546,20 @@ impl TestnetDeployer {
         Ok(())
     }
 
-    pub async fn start_telegraf(&self) -> Result<()> {
-        self.ansible_provisioner.start_telegraf().await?;
+    pub async fn start_telegraf(
+        &self,
+        custom_inventory: Option<Vec<VirtualMachine>>,
+    ) -> Result<()> {
+        self.ansible_provisioner
+            .start_telegraf(&self.environment_name, custom_inventory)
+            .await?;
         Ok(())
     }
 
-    pub async fn stop_telegraf(&self) -> Result<()> {
-        self.ansible_provisioner.stop_telegraf().await?;
+    pub async fn stop_telegraf(&self, custom_inventory: Option<Vec<VirtualMachine>>) -> Result<()> {
+        self.ansible_provisioner
+            .stop_telegraf(&self.environment_name, custom_inventory)
+            .await?;
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -270,6 +270,7 @@ enum Commands {
     /// Start all nodes in an environment.
     ///
     /// This can be useful if all nodes did not upgrade successfully.
+    #[clap(name = "start")]
     Start {
         /// Maximum number of forks Ansible will use to execute tasks on target hosts.
         #[clap(long, default_value_t = 50)]
@@ -282,7 +283,23 @@ enum Commands {
         provider: CloudProvider,
     },
     /// Get the status of all nodes in the environment.
+    #[clap(name = "status")]
     Status {
+        /// Maximum number of forks Ansible will use to execute tasks on target hosts.
+        #[clap(long, default_value_t = 50)]
+        forks: usize,
+        /// The name of the environment.
+        #[arg(short = 'n', long)]
+        name: String,
+        /// The cloud provider for the environment.
+        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
+        provider: CloudProvider,
+    },
+    /// Start the Telegraf service on all machines in the environment.
+    ///
+    /// This may be necessary for performing upgrades.
+    #[clap(name = "start-telegraf")]
+    StartTelegraf {
         /// Maximum number of forks Ansible will use to execute tasks on target hosts.
         #[clap(long, default_value_t = 50)]
         forks: usize,
@@ -1034,6 +1051,32 @@ async fn main() -> Result<()> {
             }
 
             testnet_deploy.start().await?;
+
+            Ok(())
+        }
+        Commands::StartTelegraf {
+            forks,
+            name,
+            provider,
+        } => {
+            let testnet_deploy = TestnetDeployBuilder::default()
+                .ansible_forks(forks)
+                .environment_name(&name)
+                .provider(provider.clone())
+                .build()?;
+
+            // This is required in the case where the command runs in a remote environment, where
+            // there won't be an existing inventory, which is required to retrieve the node
+            // registry files used to determine the status.
+            let inventory_service = DeploymentInventoryService::from(testnet_deploy.clone());
+            let inventory = inventory_service
+                .generate_or_retrieve_inventory(&name, true, None)
+                .await?;
+            if inventory.is_empty() {
+                return Err(eyre!("The {name} environment does not exist"));
+            }
+
+            testnet_deploy.start_telegraf().await?;
 
             Ok(())
         }


### PR DESCRIPTION
- f4b8b12 **feat: provide `start-telegraf` command**

  Restarts the Telegraf service across a deployment.

  We provide this so we can restart Telegraf services that were stopped for the upgrade. There is
  another command for upgrading the Telegraf configuration, which also starts the service, but
  sometimes it's not appropriate to deploy a new configuration.

- f710cd0 **feat: custom inventory for telegraf commands**

  This can also be useful for the upgrade process.
