### PR TITLE
feat: take failure into account for node registry retrieval

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,6 @@ use log::debug;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use sn_service_management::{NodeRegistry, ServiceStatus};
 use std::{
     fs::File,
     io::{BufRead, BufReader, BufWriter},
@@ -528,21 +527,13 @@ impl TestnetDeployer {
             .get_node_registries(&AnsibleInventoryType::Nodes)?;
         let genesis_node_registry = self
             .ansible_provisioner
-            .get_node_registries(&AnsibleInventoryType::Genesis)?[0]
+            .get_node_registries(&AnsibleInventoryType::Genesis)?
             .clone();
 
-        Self::print_banner("Bootstrap Nodes");
-        for (vm_name, registry) in bootstrap_node_registries.iter() {
-            Self::print_node_registry(vm_name, registry);
-        }
+        bootstrap_node_registries.print();
+        generic_node_registries.print();
+        genesis_node_registry.print();
 
-        Self::print_banner("Generic Nodes");
-        for (vm_name, registry) in generic_node_registries.iter() {
-            Self::print_node_registry(vm_name, registry);
-        }
-
-        Self::print_banner("Genesis Node");
-        Self::print_node_registry(&genesis_node_registry.0, &genesis_node_registry.1);
         Ok(())
     }
 
@@ -640,39 +631,6 @@ impl TestnetDeployer {
             .apply(args, Some(tfvars_filename.to_string()))?;
         print_duration(start.elapsed());
         Ok(())
-    }
-
-    fn format_status(status: &ServiceStatus) -> String {
-        match status {
-            ServiceStatus::Running => "RUNNING".to_string(),
-            ServiceStatus::Stopped => "STOPPED".to_string(),
-            ServiceStatus::Added => "ADDED".to_string(),
-            ServiceStatus::Removed => "REMOVED".to_string(),
-        }
-    }
-
-    fn print_node_registry(vm_name: &str, registry: &NodeRegistry) {
-        println!("{vm_name}:");
-        for node in registry.nodes.iter() {
-            println!(
-                "  {}: {} {}",
-                node.service_name,
-                node.version,
-                Self::format_status(&node.status)
-            );
-        }
-    }
-
-    fn print_banner(text: &str) {
-        let padding = 2;
-        let text_width = text.len() + padding * 2;
-        let border_chars = 2;
-        let total_width = text_width + border_chars;
-        let top_bottom = "═".repeat(total_width);
-
-        println!("╔{}╗", top_bottom);
-        println!("║ {:^width$} ║", text, width = text_width);
-        println!("╚{}╝", top_bottom);
     }
 }
 


### PR DESCRIPTION
Sometimes, particularly on the production environment, the retrieval of node registries can fail. The suspicion is that it's because Telegraf is in the process of writing to the file, and therefore the file is incomplete, but, it's not completely clear.

Now we take the failure into account and return a list of the VMs for which we couldn't retrieve registries.