### PR TITLE
feat: include the auditor in the `upscale` command

### DIFF
--- a/resources/ansible/node_manager_inventory.yml
+++ b/resources/ansible/node_manager_inventory.yml
@@ -4,9 +4,15 @@
   ignore_unreachable: yes
   max_fail_percentage: 10
   tasks:
+    - name: check if node registry file exists
+      stat:
+        path: "/var/safenode-manager/node_registry.json"
+      register: file_stat
+
     - name: fetch inventory file
       fetch:
         src: "/var/safenode-manager/node_registry.json"
         dest: "{{dest}}"
         flat: no
         validate_checksum: no
+      when: file_stat.stat.exists

--- a/resources/ansible/roles/node/tasks/main.yml
+++ b/resources/ansible/roles/node/tasks/main.yml
@@ -67,11 +67,16 @@
     metrics_port: "{{ initial_metrics_start_port | int + (current_node_count | default(0)) | int }}"
   when: nodes_to_add | default(0) | int > 0
 
+- name: set default value for use_port_range
+  set_fact:
+    use_port_range: false
+  when: use_port_range is not defined
+
 - name: calculate start port
   set_fact:
     rpc_start_port: "{{ initial_rpc_start_port | int + (current_node_count | default(0)) | int }}"
     metrics_start_port: "{{ initial_metrics_start_port | int + (current_node_count | default(0)) | int }}"
-  when: use_port_range
+  when: use_port_range | bool
 
 - name: calculate end port
   set_fact:

--- a/resources/terraform/testnet/digital-ocean/dev.tfvars
+++ b/resources/terraform/testnet/digital-ocean/dev.tfvars
@@ -1,3 +1,4 @@
+auditor_vm_count = 1
 bootstrap_droplet_size = "s-1vcpu-2gb"
 bootstrap_node_vm_count = 2
 bootstrap_droplet_image_id = 162461040

--- a/resources/terraform/testnet/digital-ocean/main.tf
+++ b/resources/terraform/testnet/digital-ocean/main.tf
@@ -60,8 +60,9 @@ resource "digitalocean_droplet" "build" {
 }
 
 resource "digitalocean_droplet" "auditor" {
+  count    = var.auditor_vm_count
   image    = var.auditor_droplet_image_id
-  name     = "${terraform.workspace}-auditor"
+  name     = "${terraform.workspace}-auditor-${count.index + 1}"
   region   = var.region
   size     = var.node_droplet_size
   backups  = true

--- a/resources/terraform/testnet/digital-ocean/production.tfvars
+++ b/resources/terraform/testnet/digital-ocean/production.tfvars
@@ -1,3 +1,4 @@
+auditor_vm_count = 2
 bootstrap_droplet_size = "s-8vcpu-16gb-480gb-intel"
 bootstrap_node_vm_count = 50
 bootstrap_droplet_image_id = 157362431

--- a/resources/terraform/testnet/digital-ocean/staging.tfvars
+++ b/resources/terraform/testnet/digital-ocean/staging.tfvars
@@ -1,3 +1,4 @@
+auditor_vm_count = 1
 bootstrap_droplet_size = "s-1vcpu-2gb"
 bootstrap_node_vm_count = 2
 bootstrap_droplet_image_id = 162461040

--- a/resources/terraform/testnet/digital-ocean/variables.tf
+++ b/resources/terraform/testnet/digital-ocean/variables.tf
@@ -13,7 +13,8 @@ variable "droplet_ssh_keys" {
     30878672, # Chris O'Neil
     31216015, # QA
     34183228, # GH Actions Automation
-    38596814  # sn-testnet-workflows automation
+    38596814, # sn-testnet-workflows automation
+    29586082
   ]
 }
 

--- a/resources/terraform/testnet/digital-ocean/variables.tf
+++ b/resources/terraform/testnet/digital-ocean/variables.tf
@@ -57,6 +57,11 @@ variable "region" {
   default = "lon1"
 }
 
+variable "auditor_vm_count" {
+  default     = 1
+  description = "The number of auditor droplets"
+}
+
 variable "bootstrap_node_vm_count" {
   default     = 2
   description = "The number of droplets to launch for bootstrap nodes"

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -45,6 +45,7 @@ impl TestnetDeployer {
 
         self.create_or_update_infra(
             &options.name,
+            None,
             options.bootstrap_node_vm_count,
             options.node_vm_count,
             options.uploader_vm_count,

--- a/src/error.rs
+++ b/src/error.rs
@@ -61,6 +61,11 @@ pub enum Error {
     #[error(transparent)]
     InquireError(#[from] inquire::InquireError),
     #[error(
+        "The desired auditor VM count is smaller than the current count. \
+         This is invalid for an upscale operation."
+    )]
+    InvalidUpscaleDesiredAuditorVmCount,
+    #[error(
         "The desired bootstrap VM count is smaller than the current count. \
          This is invalid for an upscale operation."
     )]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -506,6 +506,15 @@ impl TestnetDeployer {
         Ok(())
     }
 
+    pub async fn plan(&self, environment_type: EnvironmentType) -> Result<()> {
+        println!("Selecting {} workspace...", self.environment_name);
+        self.terraform_runner
+            .workspace_select(&self.environment_name)?;
+        self.terraform_runner
+            .plan(Some(environment_type.get_tfvars_filename()))?;
+        Ok(())
+    }
+
     pub async fn start(&self) -> Result<()> {
         self.ansible_provisioner.start_nodes().await?;
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -506,12 +506,16 @@ impl TestnetDeployer {
         Ok(())
     }
 
-    pub async fn plan(&self, environment_type: EnvironmentType) -> Result<()> {
+    pub async fn plan(
+        &self,
+        vars: Option<Vec<(String, String)>>,
+        environment_type: EnvironmentType,
+    ) -> Result<()> {
         println!("Selecting {} workspace...", self.environment_name);
         self.terraform_runner
             .workspace_select(&self.environment_name)?;
         self.terraform_runner
-            .plan(Some(environment_type.get_tfvars_filename()))?;
+            .plan(vars, Some(environment_type.get_tfvars_filename()))?;
         Ok(())
     }
 
@@ -604,9 +608,11 @@ impl TestnetDeployer {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn create_or_update_infra(
         &self,
         name: &str,
+        auditor_vm_count: Option<u16>,
         bootstrap_node_vm_count: Option<u16>,
         node_vm_count: Option<u16>,
         uploader_vm_count: Option<u16>,
@@ -618,6 +624,10 @@ impl TestnetDeployer {
         self.terraform_runner.workspace_select(name)?;
 
         let mut args = Vec::new();
+        if let Some(auditor_vm_count) = auditor_vm_count {
+            args.push(("auditor_vm_count".to_string(), auditor_vm_count.to_string()));
+        }
+
         if let Some(bootstrap_node_vm_count) = bootstrap_node_vm_count {
             args.push((
                 "bootstrap_node_vm_count".to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,6 @@ use log::debug;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use sn_service_management::{NodeRegistry, ServiceStatus};
 use std::{
     fs::File,
     io::{BufRead, BufReader, BufWriter},
@@ -528,21 +527,13 @@ impl TestnetDeployer {
             .get_node_registries(&AnsibleInventoryType::Nodes)?;
         let genesis_node_registry = self
             .ansible_provisioner
-            .get_node_registries(&AnsibleInventoryType::Genesis)?[0]
+            .get_node_registries(&AnsibleInventoryType::Genesis)?
             .clone();
 
-        Self::print_banner("Bootstrap Nodes");
-        for (vm_name, registry) in bootstrap_node_registries.iter() {
-            Self::print_node_registry(vm_name, registry);
-        }
+        bootstrap_node_registries.print();
+        generic_node_registries.print();
+        genesis_node_registry.print();
 
-        Self::print_banner("Generic Nodes");
-        for (vm_name, registry) in generic_node_registries.iter() {
-            Self::print_node_registry(vm_name, registry);
-        }
-
-        Self::print_banner("Genesis Node");
-        Self::print_node_registry(&genesis_node_registry.0, &genesis_node_registry.1);
         Ok(())
     }
 
@@ -640,39 +631,6 @@ impl TestnetDeployer {
             .apply(args, Some(tfvars_filename.to_string()))?;
         print_duration(start.elapsed());
         Ok(())
-    }
-
-    fn format_status(status: &ServiceStatus) -> String {
-        match status {
-            ServiceStatus::Running => "RUNNING".to_string(),
-            ServiceStatus::Stopped => "STOPPED".to_string(),
-            ServiceStatus::Added => "ADDED".to_string(),
-            ServiceStatus::Removed => "REMOVED".to_string(),
-        }
-    }
-
-    fn print_node_registry(vm_name: &str, registry: &NodeRegistry) {
-        println!("{vm_name}:");
-        for node in registry.nodes.iter() {
-            println!(
-                "  {}: {} {}",
-                node.service_name,
-                node.version,
-                Self::format_status(&node.status)
-            );
-        }
-    }
-
-    fn print_banner(text: &str) {
-        let padding = 2;
-        let text_width = text.len() + padding * 2;
-        let border_chars = 2;
-        let total_width = text_width + border_chars;
-        let top_bottom = "═".repeat(total_width);
-
-        println!("╔{}╗", top_bottom);
-        println!("║ {:^width$} ║", text, width = text_width);
-        println!("╚{}╝", top_bottom);
     }
 }
 

--- a/src/terraform.rs
+++ b/src/terraform.rs
@@ -47,12 +47,12 @@ impl TerraformRunner {
         tfvars_filename: Option<String>,
     ) -> Result<()> {
         let mut args = vec!["apply".to_string(), "-auto-approve".to_string()];
+        if let Some(tfvars_filename) = tfvars_filename {
+            args.push(format!("-var-file={}", tfvars_filename));
+        }
         for var in vars.iter() {
             args.push("-var".to_string());
             args.push(format!("{}={}", var.0, var.1));
-        }
-        if let Some(tfvars_filename) = tfvars_filename {
-            args.push(format!("-var-file={}", tfvars_filename));
         }
         run_external_command(
             self.binary_path.clone(),
@@ -64,10 +64,20 @@ impl TerraformRunner {
         Ok(())
     }
 
-    pub fn plan(&self, tfvars_filename: Option<String>) -> Result<()> {
+    pub fn plan(
+        &self,
+        vars: Option<Vec<(String, String)>>,
+        tfvars_filename: Option<String>,
+    ) -> Result<()> {
         let mut args = vec!["plan".to_string()];
         if let Some(tfvars_filename) = tfvars_filename {
             args.push(format!("-var-file={}", tfvars_filename));
+        }
+        if let Some(vars) = vars {
+            for var in vars.iter() {
+                args.push("-var".to_string());
+                args.push(format!("{}={}", var.0, var.1));
+            }
         }
         run_external_command(
             self.binary_path.clone(),

--- a/src/terraform.rs
+++ b/src/terraform.rs
@@ -64,6 +64,21 @@ impl TerraformRunner {
         Ok(())
     }
 
+    pub fn plan(&self, tfvars_filename: Option<String>) -> Result<()> {
+        let mut args = vec!["plan".to_string()];
+        if let Some(tfvars_filename) = tfvars_filename {
+            args.push(format!("-var-file={}", tfvars_filename));
+        }
+        run_external_command(
+            self.binary_path.clone(),
+            self.working_directory_path.clone(),
+            args,
+            false,
+            false,
+        )?;
+        Ok(())
+    }
+
     pub fn destroy(&self, tfvars_filename: Option<String>) -> Result<()> {
         let mut args = vec!["destroy".to_string(), "-auto-approve".to_string()];
         if let Some(tfvars_filename) = tfvars_filename {


### PR DESCRIPTION
- 1a2af2c **feat: take failure into account for node registry retrieval**

  Sometimes, particularly on the production environment, the retrieval of node registries can fail.
  The suspicion is that it's because Telegraf is in the process of writing to the file, and therefore
  the file is incomplete, but, it's not completely clear. It seems to fail too often for that to be
  the case.

  Now we take the failure into account and return a list of the VMs for which we couldn't retrieve
  registries.

- 572e2d7 **fix: set use_port_range to default value**

  On subsequent playbook runs where no new nodes are being added, not setting this to a default value
  causes the later node manager task to fail, because it evaluates which arguments to use based on
  this setting.

- 424db79 **fix: do not error if node man inventory does not exist**

  In the case of a new machine, like a new auditor, where the auditor hasn't been deployed yet, there
  will be no node manager inventory file. Using this condition prevents the inventory generation from
  failing.

- 30c2c65 **feat: introduce a count attribute for the auditor VMs**

  We now require more than one auditor in the production environment.

  Luckily, Terraform deals with the count introduction in a graceful way, where the existing VM will
  only be renamed rather than re-created.

- e479a90 **feat: provide a `plan` command**

  Run `terraform plan` to view changes to infrastructure before deploying them.

  This can be useful to check changes to the production environment.

  An old SSH key is added back in, because unbelievably, if the SSH key list has changed, Terraform is
  forcing the VM to be re-created.

- 75f50de **feat: include the auditor in the `upscale` command**

  This is useful for deploying a new auditor VM in the production environment.

  It has `plan` and `infra_only` arguments. The former is to check the operation won't do anything
  untoward, and the latter is to only upscale the infrastructure, without doing an Ansible run.
