### PR TITLE
chore: redefine specs for new production environment

### DIFF
--- a/resources/terraform/testnet/digital-ocean/production.tfvars
+++ b/resources/terraform/testnet/digital-ocean/production.tfvars
@@ -1,5 +1,5 @@
-auditor_vm_count = 3
-bootstrap_droplet_size = "s-8vcpu-16gb-480gb-intel"
+auditor_vm_count = 1
+bootstrap_droplet_size = "s-4vcpu-8gb"
 bootstrap_node_vm_count = 50
 bootstrap_droplet_image_id = 157362431
 node_droplet_size = "s-2vcpu-4gb"


### PR DESCRIPTION
These new settings are based on analysis of the metrics we are collecting.

The specifications for generic nodes are retained. For bootstrap nodes, they are downsized to 4xCPU and 8GB of memory. The estimated cost reduction here is from $6400 to $2400 per month. On both types, the number of node services will remain the same.

The auditor count is reset to 1 for the new environment.