### PR TITLE
Revert "chore: redefine specs for new production environment"

### DIFF
--- a/resources/terraform/testnet/digital-ocean/production.tfvars
+++ b/resources/terraform/testnet/digital-ocean/production.tfvars
@@ -1,5 +1,5 @@
-auditor_vm_count = 1
-bootstrap_droplet_size = "s-4vcpu-8gb"
+auditor_vm_count = 3
+bootstrap_droplet_size = "s-8vcpu-16gb-480gb-intel"
 bootstrap_node_vm_count = 50
 bootstrap_droplet_image_id = 157362431
 node_droplet_size = "s-2vcpu-4gb"


### PR DESCRIPTION
This reverts commit 6cf763fb7870e0be54b6ed7a364e1a8ed7e6c4d2.

I've had a request to add another auditor machine to the production setup, and therefore we need to return to the current sizes. We may also not be releasing as expected. The commit can be re-applied when we're ready to do the release.