### PR TITLE
feat: provide commands for controlling uploaders

### DIFF
--- a/resources/ansible/roles/uploaders/tasks/main.yml
+++ b/resources/ansible/roles/uploaders/tasks/main.yml
@@ -40,11 +40,20 @@
   throttle: 1
   when: not safe_binary.stat.exists
 
-- name: start the uploader script
-  shell: "nohup /home/safe/upload-random-data.sh {{ genesis_multiaddr }} > nohup.out 2>&1 &"
-  args:
-    chdir: /home/safe/
-    executable: /bin/bash
+- name: create systemd service file
+  ansible.builtin.template:
+    src: safe_uploader.service.j2
+    dest: /etc/systemd/system/safe_uploader.service
+    owner: root
+    group: root
+    mode: '0644'
   become: yes
-  become_user: safe
+  when: not safe_binary.stat.exists
+
+- name: start and enable safe_uploader service
+  ansible.builtin.systemd:
+    name: safe_uploader
+    state: started
+    enabled: yes
+  become: yes
   when: not safe_binary.stat.exists

--- a/resources/ansible/roles/uploaders/templates/safe_uploader.service.j2
+++ b/resources/ansible/roles/uploaders/templates/safe_uploader.service.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description=Upload Random Data Service
+After=network.target
+
+[Service]
+ExecStart=/home/safe/upload-random-data.sh {{ genesis_multiaddr }}
+User=safe
+Group=safe
+Restart=always
+WorkingDirectory=/home/safe
+
+[Install]
+WantedBy=multi-user.target

--- a/resources/ansible/start_uploaders.yml
+++ b/resources/ansible/start_uploaders.yml
@@ -1,0 +1,10 @@
+---
+- name: ensure the safe uploader service is started
+  hosts: all
+  become: True
+  tasks:
+    - name: start safe uploader service
+      systemd:
+        name: safe_uploader
+        enabled: yes
+        state: started

--- a/resources/ansible/stop_uploaders.yml
+++ b/resources/ansible/stop_uploaders.yml
@@ -1,0 +1,10 @@
+---
+- name: ensure the safe uploader service is stopped
+  hosts: all
+  become: True
+  tasks:
+    - name: stop safe uploader service
+      systemd:
+        name: safe_uploader
+        enabled: yes
+        state: stopped

--- a/resources/terraform/testnet/digital-ocean/production.tfvars
+++ b/resources/terraform/testnet/digital-ocean/production.tfvars
@@ -1,5 +1,5 @@
-auditor_vm_count = 3
-bootstrap_droplet_size = "s-8vcpu-16gb-480gb-intel"
+auditor_vm_count = 1
+bootstrap_droplet_size = "s-4vcpu-8gb"
 bootstrap_node_vm_count = 50
 bootstrap_droplet_image_id = 157362431
 node_droplet_size = "s-2vcpu-4gb"

--- a/src/ansible/mod.rs
+++ b/src/ansible/mod.rs
@@ -116,11 +116,15 @@ pub enum AnsiblePlaybook {
     /// It can be necessary for running upgrades, since we will want to re-enable Telegraf after the
     /// upgrade.
     StartTelegraf,
+    /// This playbook will start the uploaders on each machine.
+    StartUploaders,
     /// This playbook will stop the Telegraf service running on each machine.
     ///
     /// It can be necessary for running upgrades, since Telegraf will run `safenode-manager
     /// status`, which writes to the registry file and can interfere with an upgrade.
     StopTelegraf,
+    /// This playbook will stop the uploaders on each machine.
+    StopUploaders,
     /// The upgrade faucet playbook will upgrade the faucet to the latest version.
     ///
     /// Use in combination with `AnsibleInventoryType::Genesis`.
@@ -155,8 +159,10 @@ impl AnsiblePlaybook {
             AnsiblePlaybook::RpcClient => "safenode_rpc_client.yml".to_string(),
             AnsiblePlaybook::StartNodes => "start_nodes.yml".to_string(),
             AnsiblePlaybook::StartTelegraf => "start_telegraf.yml".to_string(),
+            AnsiblePlaybook::StartUploaders => "start_uploaders.yml".to_string(),
             AnsiblePlaybook::Status => "node_status.yml".to_string(),
             AnsiblePlaybook::StopTelegraf => "stop_telegraf.yml".to_string(),
+            AnsiblePlaybook::StopUploaders => "stop_uploaders.yml".to_string(),
             AnsiblePlaybook::UpgradeFaucet => "upgrade_faucet.yml".to_string(),
             AnsiblePlaybook::UpgradeNodeManager => "upgrade_node_manager.yml".to_string(),
             AnsiblePlaybook::UpgradeNodes => "upgrade_nodes.yml".to_string(),


### PR DESCRIPTION
- 53771f6 **refactor: run uploaders in a service**

  Rather than using `nohup` to run the uploader script in the background, we can easily wrap it in a
  systemd service, which makes it easy to control the uploaders.

- 5710238 **chore: reapply new production specs**

  We have decided to go with the release, and the `PROD-01` auditor was provided.

- 45cab47 **feat: provide commands for controlling uploaders**

  These two commands can be used by workflows for starting and stopping the uploaders for a given
  environment.