### PR TITLE
feat: provide `fund-uploaders` command

### DIFF
--- a/resources/ansible/fund_uploaders.yml
+++ b/resources/ansible/fund_uploaders.yml
@@ -1,0 +1,20 @@
+---
+- name: fund uploaders
+  hosts: all
+  become: yes
+  become_user: safe
+  vars:
+    genesis_multiaddr: "{{ genesis_multiaddr }}"
+    genesis_addr: "{{ genesis_addr }}"
+
+  tasks:
+    - name: get funds
+      command:
+        cmd: "safe --peer {{ genesis_multiaddr }} wallet get-faucet {{ genesis_addr }}:8000"
+      register: faucet_result
+      changed_when: faucet_result.rc == 0
+      failed_when: faucet_result.rc != 0
+
+    - name: display result
+      debug:
+        var: faucet_result.stdout_lines

--- a/src/ansible/mod.rs
+++ b/src/ansible/mod.rs
@@ -72,6 +72,8 @@ pub enum AnsiblePlaybook {
     ///
     /// Use in combination with `AnsibleInventoryType::Genesis`.
     Faucet,
+    /// This playbook will fund the uploaders using the faucet.
+    FundUploaders,
     /// The genesis playbook will use the node manager to setup the genesis node, which the other
     /// nodes will bootstrap against.
     ///
@@ -156,6 +158,7 @@ impl AnsiblePlaybook {
             AnsiblePlaybook::Build => "build.yml".to_string(),
             AnsiblePlaybook::Genesis => "genesis_node.yml".to_string(),
             AnsiblePlaybook::Faucet => "faucet.yml".to_string(),
+            AnsiblePlaybook::FundUploaders => "fund_uploaders.yml".to_string(),
             AnsiblePlaybook::Logs => "logs.yml".to_string(),
             AnsiblePlaybook::Logstash => "logstash.yml".to_string(),
             AnsiblePlaybook::NodeManagerInventory => "node_manager_inventory.yml".to_string(),

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -15,7 +15,10 @@ use crate::{
     terraform::TerraformRunner,
     BinaryOption, CloudProvider, EnvironmentType, TestnetDeployer,
 };
-use color_eyre::{eyre::eyre, Result};
+use color_eyre::{
+    eyre::{eyre, OptionExt},
+    Result,
+};
 use rand::seq::IteratorRandom;
 use serde::{Deserialize, Serialize};
 use sn_service_management::{NodeRegistry, ServiceStatus};
@@ -646,6 +649,14 @@ impl DeploymentInventory {
             }
         }
         Ok(())
+    }
+
+    pub fn get_genesis_ip(&self) -> Result<IpAddr> {
+        self.misc_vms
+            .iter()
+            .find(|(name, _)| name.contains("genesis"))
+            .map(|(_, ip)| *ip)
+            .ok_or_eyre("Genesis node not found in inventory. This is a critical error.")
     }
 }
 


### PR DESCRIPTION
This is a tedious manual chore that can easily be done automatically.

The command relies on the faucet being started, so that command has to be used first.