### PR TITLE
feat: provide an `upgrade-uploader-telegraf-config` cmd

### DIFF
--- a/resources/ansible/roles/uploader-metrics/tasks/main.yml
+++ b/resources/ansible/roles/uploader-metrics/tasks/main.yml
@@ -75,11 +75,18 @@
     dest: /etc/telegraf/telegraf.conf
     remote_src: yes
 
-- name: copy telegraf multi node config file
+- name: copy telegraf uploader config file
   copy:
     src: "{{ network_dashboard_repo_path }}/telegraf/ConfigurationFile/uploaders/telegraf_safe_uploader_node.conf"
     dest: /etc/telegraf/telegraf.d/telegraf_safe_uploader_node.conf
     remote_src: yes
+
+- name: add telegraf user to sudoers for safe command
+  lineinfile:
+    path: /etc/sudoers
+    line: '_telegraf ALL=(safe) NOPASSWD: /usr/local/bin/safe'
+    validate: '/usr/sbin/visudo -cf %s'
+    state: present
 
 - name: start telegraf service
   systemd:

--- a/resources/ansible/upgrade_node_telegraf_config.yml
+++ b/resources/ansible/upgrade_node_telegraf_config.yml
@@ -1,5 +1,5 @@
 ---
-- name: upgrade the telegraf configuration
+- name: upgrade the node telegraf configuration
   hosts: all
   roles:
     - role: node-metrics

--- a/resources/ansible/upgrade_uploader_telegraf_config.yml
+++ b/resources/ansible/upgrade_uploader_telegraf_config.yml
@@ -1,0 +1,12 @@
+---
+- name: upgrade the uploader telegraf configuration
+  hosts: all
+  roles:
+    - role: uploader-metrics
+      become: True
+  tasks:
+    - name: restart telegraf service
+      systemd:
+        name: telegraf
+        enabled: yes
+        state: restarted

--- a/src/ansible/mod.rs
+++ b/src/ansible/mod.rs
@@ -143,8 +143,10 @@ pub enum AnsiblePlaybook {
     ///
     /// Use in combination with `AnsibleInventoryType::Genesis` or `AnsibleInventoryType::Nodes`.
     UpgradeNodes,
-    /// Update the Telegraf configuration to the latest version in the repository.
+    /// Update the node Telegraf configuration to the latest version in the repository.
     UpgradeNodeTelegrafConfig,
+    /// Update the uploader Telegraf configuration to the latest version in the repository.
+    UpgradeUploaderTelegrafConfig,
     /// The uploader playbook will setup the uploader scripts on the uploader VMs.
     ///
     /// Use in combination with `AnsibleInventoryType::Uploaders`.
@@ -177,6 +179,9 @@ impl AnsiblePlaybook {
             AnsiblePlaybook::UpgradeNodes => "upgrade_nodes.yml".to_string(),
             AnsiblePlaybook::UpgradeNodeTelegrafConfig => {
                 "upgrade_node_telegraf_config.yml".to_string()
+            }
+            AnsiblePlaybook::UpgradeUploaderTelegrafConfig => {
+                "upgrade_uploader_telegraf_config.yml".to_string()
             }
             AnsiblePlaybook::Uploaders => "uploaders.yml".to_string(),
         }

--- a/src/ansible/mod.rs
+++ b/src/ansible/mod.rs
@@ -144,7 +144,7 @@ pub enum AnsiblePlaybook {
     /// Use in combination with `AnsibleInventoryType::Genesis` or `AnsibleInventoryType::Nodes`.
     UpgradeNodes,
     /// Update the Telegraf configuration to the latest version in the repository.
-    UpgradeTelegrafConfig,
+    UpgradeNodeTelegrafConfig,
     /// The uploader playbook will setup the uploader scripts on the uploader VMs.
     ///
     /// Use in combination with `AnsibleInventoryType::Uploaders`.
@@ -175,7 +175,9 @@ impl AnsiblePlaybook {
             AnsiblePlaybook::UpgradeFaucet => "upgrade_faucet.yml".to_string(),
             AnsiblePlaybook::UpgradeNodeManager => "upgrade_node_manager.yml".to_string(),
             AnsiblePlaybook::UpgradeNodes => "upgrade_nodes.yml".to_string(),
-            AnsiblePlaybook::UpgradeTelegrafConfig => "upgrade_telegraf_config.yml".to_string(),
+            AnsiblePlaybook::UpgradeNodeTelegrafConfig => {
+                "upgrade_node_telegraf_config.yml".to_string()
+            }
             AnsiblePlaybook::Uploaders => "uploaders.yml".to_string(),
         }
     }

--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -460,14 +460,14 @@ impl AnsibleProvisioner {
         Ok(())
     }
 
-    pub async fn upgrade_telegraf(&self, name: &str) -> Result<()> {
+    pub async fn upgrade_node_telegraf(&self, name: &str) -> Result<()> {
         self.ansible_runner.run_playbook(
-            AnsiblePlaybook::UpgradeTelegrafConfig,
+            AnsiblePlaybook::UpgradeNodeTelegrafConfig,
             AnsibleInventoryType::BootstrapNodes,
             Some(self.build_telegraf_upgrade(name, &NodeType::Bootstrap)?),
         )?;
         self.ansible_runner.run_playbook(
-            AnsiblePlaybook::UpgradeTelegrafConfig,
+            AnsiblePlaybook::UpgradeNodeTelegrafConfig,
             AnsibleInventoryType::Nodes,
             Some(self.build_telegraf_upgrade(name, &NodeType::Normal)?),
         )?;

--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -464,12 +464,21 @@ impl AnsibleProvisioner {
         self.ansible_runner.run_playbook(
             AnsiblePlaybook::UpgradeNodeTelegrafConfig,
             AnsibleInventoryType::BootstrapNodes,
-            Some(self.build_telegraf_upgrade(name, &NodeType::Bootstrap)?),
+            Some(self.build_node_telegraf_upgrade(name, &NodeType::Bootstrap)?),
         )?;
         self.ansible_runner.run_playbook(
             AnsiblePlaybook::UpgradeNodeTelegrafConfig,
             AnsibleInventoryType::Nodes,
-            Some(self.build_telegraf_upgrade(name, &NodeType::Normal)?),
+            Some(self.build_node_telegraf_upgrade(name, &NodeType::Normal)?),
+        )?;
+        Ok(())
+    }
+
+    pub async fn upgrade_uploader_telegraf(&self, name: &str) -> Result<()> {
+        self.ansible_runner.run_playbook(
+            AnsiblePlaybook::UpgradeUploaderTelegrafConfig,
+            AnsibleInventoryType::Uploaders,
+            Some(self.build_uploader_telegraf_upgrade(name)?),
         )?;
         Ok(())
     }
@@ -712,10 +721,16 @@ impl AnsibleProvisioner {
         Ok(extra_vars.build())
     }
 
-    fn build_telegraf_upgrade(&self, name: &str, node_type: &NodeType) -> Result<String> {
+    fn build_node_telegraf_upgrade(&self, name: &str, node_type: &NodeType) -> Result<String> {
         let mut extra_vars: ExtraVarsDocBuilder = ExtraVarsDocBuilder::default();
         extra_vars.add_variable("testnet_name", name);
         extra_vars.add_variable("node_type", &node_type.to_string());
+        Ok(extra_vars.build())
+    }
+
+    fn build_uploader_telegraf_upgrade(&self, name: &str) -> Result<String> {
+        let mut extra_vars: ExtraVarsDocBuilder = ExtraVarsDocBuilder::default();
+        extra_vars.add_variable("testnet_name", name);
         Ok(extra_vars.build())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -588,6 +588,13 @@ impl TestnetDeployer {
         Ok(())
     }
 
+    pub async fn upgrade_uploader_telegraf(&self, name: &str) -> Result<()> {
+        self.ansible_provisioner
+            .upgrade_uploader_telegraf(name)
+            .await?;
+        Ok(())
+    }
+
     pub async fn clean(&self) -> Result<()> {
         let environment_type =
             get_environment_type(&self.environment_name, &self.s3_repository).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -583,8 +583,8 @@ impl TestnetDeployer {
         Ok(())
     }
 
-    pub async fn upgrade_telegraf(&self, name: &str) -> Result<()> {
-        self.ansible_provisioner.upgrade_telegraf(name).await?;
+    pub async fn upgrade_node_telegraf(&self, name: &str) -> Result<()> {
+        self.ansible_provisioner.upgrade_node_telegraf(name).await?;
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -443,8 +443,8 @@ enum Commands {
         version: String,
     },
     /// Upgrade the Telegraf configuration on an environment.
-    #[clap(name = "upgrade-telegraf")]
-    UpgradeTelegraf {
+    #[clap(name = "upgrade-node-telegraf-config")]
+    UpgradeNodeTelegrafConfig {
         /// Maximum number of forks Ansible will use to execute tasks on target hosts.
         #[clap(long, default_value_t = 50)]
         forks: usize,
@@ -1448,7 +1448,7 @@ async fn main() -> Result<()> {
                 .await?;
             Ok(())
         }
-        Commands::UpgradeTelegraf {
+        Commands::UpgradeNodeTelegrafConfig {
             forks,
             name,
             provider,
@@ -1470,7 +1470,7 @@ async fn main() -> Result<()> {
                 return Err(eyre!("The {name} environment does not exist"));
             }
 
-            testnet_deploy.upgrade_telegraf(&name).await?;
+            testnet_deploy.upgrade_node_telegraf(&name).await?;
 
             Ok(())
         }


### PR DESCRIPTION
- 14b5b0c **refactor: rename upgrade telegraf command**

  We will now have two different commands for upgrading the Telegraf configurations, one for the node
  configuration and the other for uploaders.

- b6b3cec **feat: provide an `upgrade-uploader-telegraf-config` cmd**

  This is almost identical to the other Telegraf command.
