### PR TITLE
feat: provide `bootstrap` command

### DIFF
--- a/resources/ansible/roles/build_safe_network_binary/tasks/main.yml
+++ b/resources/ansible/roles/build_safe_network_binary/tasks/main.yml
@@ -17,6 +17,19 @@
     export NETWORK_VERSION_MODE={{ protocol_version }}
     {% endif %}
 
+    {% if foundation_pk is defined and foundation_pk != "" %}
+    export FOUNDATION_PK={{ foundation_pk }}
+    {% endif %}
+    {% if genesis_pk is defined and genesis_pk != "" %}
+    export GENESIS_PK={{ genesis_pk }}
+    {% endif %}
+    {% if network_royalties_pk is defined and network_royalties_pk != "" %}
+    export NETWORK_ROYALTIES_PK={{ network_royalties_pk }}
+    {% endif %}
+    {% if payment_forward_pk is defined and payment_forward_pk != "" %}
+    export PAYMENT_FORWARD_PK={{ payment_forward_pk }}
+    {% endif %}
+
     {% if bin_name == 'safenode' and safenode_features_list != "" %}
     cargo build --target x86_64-unknown-linux-musl --release --bin {{bin_name}} --no-default-features --features={{safenode_features_list}}
     {% elif bin_name == 'faucet' %}

--- a/resources/terraform/testnet/digital-ocean/main.tf
+++ b/resources/terraform/testnet/digital-ocean/main.tf
@@ -11,6 +11,7 @@ terraform {
 }
 
 resource "digitalocean_droplet" "genesis_bootstrap" {
+  count    = var.genesis_vm_count
   image    = var.bootstrap_droplet_image_id
   name     = "${terraform.workspace}-genesis-bootstrap"
   region   = var.region

--- a/resources/terraform/testnet/digital-ocean/variables.tf
+++ b/resources/terraform/testnet/digital-ocean/variables.tf
@@ -58,6 +58,11 @@ variable "region" {
   default = "lon1"
 }
 
+variable "genesis_vm_count" {
+  default     = 1
+  description = "Set to 1 or 0 to control whether there is a genesis node"
+}
+
 variable "auditor_vm_count" {
   default     = 1
   description = "The number of auditor droplets"

--- a/src/ansible/extra_vars.rs
+++ b/src/ansible/extra_vars.rs
@@ -127,15 +127,14 @@ impl ExtraVarsDocBuilder {
                 );
                 Ok(())
             }
-            BinaryOption::Versioned { faucet_version, .. } => {
-                match faucet_version {
-                    Some(version) => {
-                        self.variables.push(("version".to_string(), version.to_string()));
-                        Ok(())
-                    }
-                    None => Err(Error::NoFaucetError),
+            BinaryOption::Versioned { faucet_version, .. } => match faucet_version {
+                Some(version) => {
+                    self.variables
+                        .push(("version".to_string(), version.to_string()));
+                    Ok(())
                 }
-            }
+                None => Err(Error::NoFaucetError),
+            },
         }
     }
 
@@ -245,19 +244,22 @@ impl ExtraVarsDocBuilder {
             }
             BinaryOption::Versioned {
                 sn_auditor_version, ..
-            } => {
-                match sn_auditor_version {
-                    Some(version) => {
-                        self.variables.push(("version".to_string(), version.to_string()));
-                        Ok(())
-                    }
-                    None => Err(Error::NoAuditorError),
+            } => match sn_auditor_version {
+                Some(version) => {
+                    self.variables
+                        .push(("version".to_string(), version.to_string()));
+                    Ok(())
                 }
-            }
+                None => Err(Error::NoAuditorError),
+            },
         }
     }
 
-    pub fn add_safe_url_or_version(&mut self, deployment_name: &str, binary_option: &BinaryOption) -> Result<(), Error> {
+    pub fn add_safe_url_or_version(
+        &mut self,
+        deployment_name: &str,
+        binary_option: &BinaryOption,
+    ) -> Result<(), Error> {
         match binary_option {
             BinaryOption::BuildFromSource {
                 repo_owner, branch, ..
@@ -273,21 +275,19 @@ impl ExtraVarsDocBuilder {
                 );
                 Ok(())
             }
-            BinaryOption::Versioned { safe_version, .. } => {
-                match safe_version {
-                    Some(version) => {
-                        self.variables.push((
-                            "safe_archive_url".to_string(),
-                            format!(
-                                "{}/safe-{}-x86_64-unknown-linux-musl.tar.gz",
-                                SAFE_S3_BUCKET_URL, version
-                            ),
-                        ));
-                        Ok(())
-                    }
-                    None => Err(Error::NoUploadersError),
+            BinaryOption::Versioned { safe_version, .. } => match safe_version {
+                Some(version) => {
+                    self.variables.push((
+                        "safe_archive_url".to_string(),
+                        format!(
+                            "{}/safe-{}-x86_64-unknown-linux-musl.tar.gz",
+                            SAFE_S3_BUCKET_URL, version
+                        ),
+                    ));
+                    Ok(())
                 }
-            }
+                None => Err(Error::NoUploadersError),
+            },
         }
     }
 

--- a/src/ansible/extra_vars.rs
+++ b/src/ansible/extra_vars.rs
@@ -58,6 +58,7 @@ impl ExtraVarsDocBuilder {
                 branch,
                 safenode_features,
                 protocol_version,
+                network_keys,
             } => {
                 self.add_variable("custom_bin", "true");
                 self.add_variable("testnet_name", deployment_name);
@@ -68,6 +69,12 @@ impl ExtraVarsDocBuilder {
                 }
                 if let Some(protocol_version) = protocol_version {
                     self.add_variable("protocol_version", protocol_version);
+                }
+                if let Some(network_keys) = network_keys {
+                    self.add_variable("foundation_pk", &network_keys.0);
+                    self.add_variable("genesis_pk", &network_keys.1);
+                    self.add_variable("network_royalties_pk", &network_keys.2);
+                    self.add_variable("payment_forward_pk", &network_keys.3);
                 }
             }
             BinaryOption::Versioned { .. } => {

--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -661,7 +661,7 @@ impl AnsibleProvisioner {
             extra_vars.add_variable("action", "start");
         }
         extra_vars.add_node_manager_url(&options.name, &options.binary_option);
-        extra_vars.add_faucet_url_or_version(&options.name, &options.binary_option);
+        extra_vars.add_faucet_url_or_version(&options.name, &options.binary_option)?;
         Ok(extra_vars.build())
     }
 
@@ -695,7 +695,7 @@ impl AnsibleProvisioner {
                 .unwrap_or(&DEFAULT_BETA_ENCRYPTION_KEY.to_string()),
         );
         extra_vars.add_node_manager_url(&options.name, &options.binary_option);
-        extra_vars.add_sn_auditor_url_or_version(&options.name, &options.binary_option);
+        extra_vars.add_sn_auditor_url_or_version(&options.name, &options.binary_option)?;
         Ok(extra_vars.build())
     }
 
@@ -711,7 +711,7 @@ impl AnsibleProvisioner {
         extra_vars.add_variable("testnet_name", &options.name);
         extra_vars.add_variable("genesis_multiaddr", genesis_multiaddr);
         extra_vars.add_variable("faucet_address", &faucet_address);
-        extra_vars.add_safe_url_or_version(&options.name, &options.binary_option);
+        extra_vars.add_safe_url_or_version(&options.name, &options.binary_option)?;
         Ok(extra_vars.build())
     }
 

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,0 +1,107 @@
+// Copyright (c) 2023, MaidSafe.
+// All rights reserved.
+//
+// This SAFE Network Software is licensed under the BSD-3-Clause license.
+// Please see the LICENSE file for more details.
+
+use crate::{
+    ansible::provisioning::{NodeType, ProvisionOptions},
+    error::Result,
+    write_environment_details, BinaryOption, DeploymentType, EnvironmentDetails, EnvironmentType,
+    LogFormat, TestnetDeployer,
+};
+use colored::Colorize;
+
+#[derive(Clone)]
+pub struct BootstrapOptions {
+    pub binary_option: BinaryOption,
+    pub bootstrap_peer: String,
+    pub environment_type: EnvironmentType,
+    pub env_variables: Option<Vec<(String, String)>>,
+    pub log_format: Option<LogFormat>,
+    pub name: String,
+    pub node_count: u16,
+    pub node_vm_count: Option<u16>,
+}
+
+impl TestnetDeployer {
+    pub async fn bootstrap(&self, options: &BootstrapOptions) -> Result<()> {
+        let build_custom_binaries = {
+            match &options.binary_option {
+                BinaryOption::BuildFromSource { .. } => true,
+                BinaryOption::Versioned { .. } => false,
+            }
+        };
+
+        write_environment_details(
+            &self.s3_repository,
+            &options.name,
+            &EnvironmentDetails {
+                environment_type: options.environment_type.clone(),
+                deployment_type: DeploymentType::Bootstrap,
+            },
+        )
+        .await?;
+
+        self.create_or_update_infra(
+            &options.name,
+            Some(0),
+            Some(0),
+            Some(0),
+            options.node_vm_count,
+            Some(0),
+            build_custom_binaries,
+            &options.environment_type.get_tfvars_filename(),
+        )
+        .await
+        .map_err(|err| {
+            println!("Failed to create infra {err:?}");
+            err
+        })?;
+
+        let mut n = 1;
+        let total = if build_custom_binaries { 2 } else { 1 };
+
+        let provision_options = ProvisionOptions::from(options.clone());
+        if build_custom_binaries {
+            self.ansible_provisioner
+                .print_ansible_run_banner(n, total, "Build Custom Binaries");
+            self.ansible_provisioner
+                .build_safe_network_binaries(&provision_options)
+                .await
+                .map_err(|err| {
+                    println!("Failed to build safe network binaries {err:?}");
+                    err
+                })?;
+            n += 1;
+        }
+
+        self.ansible_provisioner
+            .print_ansible_run_banner(n, total, "Provision Normal Nodes");
+        match self
+            .ansible_provisioner
+            .provision_nodes(
+                &provision_options,
+                &options.bootstrap_peer,
+                NodeType::Normal,
+            )
+            .await
+        {
+            Ok(()) => {
+                println!("Provisioned normal nodes");
+            }
+            Err(e) => {
+                println!("Failed to provision: {e:?}");
+                println!("{}", "WARNING!".yellow());
+                println!("Some nodes failed to provision without error.");
+                println!(
+                    "This usually means a small number of nodes failed to start on a few VMs."
+                );
+                println!("However, most of the time the deployment will still be usable.");
+                println!("See the output from Ansible to determine which VMs had failures.");
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,6 +33,8 @@ pub enum Error {
     DigitalOceanUnexpectedResponse(u16, String),
     #[error("The public IP address was not obtainable from the API response")]
     DigitalOceanPublicIpAddressNotFound,
+    #[error("Could not retrieve environment details for '{0}'")]
+    EnvironmentDetailsNotFound(String),
     #[error("The '{0}' environment does not exist")]
     EnvironmentDoesNotExist(String),
     #[error("The environment name is required")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -108,6 +108,12 @@ pub enum Error {
         "Could not convert from DeployOptions to ProvisionOptions: node count must have a value"
     )]
     MissingNodeCount,
+    #[error("This deployment does not have an auditor. It may be a bootstrap deployment.")]
+    NoAuditorError,
+    #[error("This deployment does not have a faucet. It may be a bootstrap deployment.")]
+    NoFaucetError,
+    #[error("This deployment does not have any uploaders. It may be a bootstrap deployment.")]
+    NoUploadersError,
     #[error(transparent)]
     ReqwestError(#[from] reqwest::Error),
     #[error(transparent)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -92,6 +92,8 @@ pub enum Error {
          This is invalid for an upscale operation."
     )]
     InvalidUpscaleDesiredUploaderVmCount,
+    #[error("Options were used that are not applicable to a bootstrap deployment")]
+    InvalidUpscaleOptionsForBootstrapDeployment,
     #[error(transparent)]
     Io(#[from] std::io::Error),
     #[error("Failed to list objects in S3 bucket with prefix '{prefix}': {error}")]
@@ -112,6 +114,8 @@ pub enum Error {
     MissingNodeCount,
     #[error("This deployment does not have an auditor. It may be a bootstrap deployment.")]
     NoAuditorError,
+    #[error("Could not obtain a multiaddr from the node inventory")]
+    NodeAddressNotFound,
     #[error("This deployment does not have a faucet. It may be a bootstrap deployment.")]
     NoFaucetError,
     #[error("This deployment does not have any uploaders. It may be a bootstrap deployment.")]

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -559,11 +559,19 @@ impl DeploymentInventory {
     }
 
     pub fn bootstrap_node_count(&self) -> usize {
-        self.bootstrap_peers.len() / self.bootstrap_node_vms.len()
+        if self.bootstrap_node_vms.is_empty() {
+            0
+        } else {
+            self.bootstrap_peers.len() / self.bootstrap_node_vms.len()
+        }
     }
 
     pub fn node_count(&self) -> usize {
-        self.node_peers.len() / self.node_vms.len()
+        if self.node_vms.is_empty() {
+            0
+        } else {
+            self.node_peers.len() / self.node_vms.len()
+        }
     }
 
     pub fn print_report(&self) -> Result<()> {
@@ -614,7 +622,7 @@ impl DeploymentInventory {
                     "sn_auditor version: {}",
                     sn_auditor_version
                         .as_ref()
-                        .map_or("none".to_string(), |v| v.to_string())
+                        .map_or("N/A".to_string(), |v| v.to_string())
                 );
                 println!();
             }

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -682,20 +682,22 @@ impl DeploymentInventory {
                         println!("{peer}");
                     }
                 });
-            println!(
-                "Genesis: {}",
-                self.genesis_multiaddr
-                    .as_ref()
-                    .map_or("N/A", |genesis| genesis)
-            );
-            let inventory_file_path =
-                get_data_directory()?.join(format!("{}-inventory.json", self.name));
-            println!(
-                "The entire peer list can be found at {}",
-                inventory_file_path.to_string_lossy()
-            );
             println!();
         }
+
+        println!(
+            "Genesis: {}",
+            self.genesis_multiaddr
+                .as_ref()
+                .map_or("N/A", |genesis| genesis)
+        );
+        let inventory_file_path =
+            get_data_directory()?.join(format!("{}-inventory.json", self.name));
+        println!(
+            "The full inventory is at {}",
+            inventory_file_path.to_string_lossy()
+        );
+        println!();
 
         if let Some(faucet_address) = &self.faucet_address {
             println!("==============");

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -291,11 +291,11 @@ impl DeploymentInventoryService {
             let sn_auditor_version = &auditor_node_registry.auditor.as_ref().unwrap().version;
 
             BinaryOption::Versioned {
-                safe_version: "0.0.1".parse()?, // todo: store safe version in the safenodeman registry?
-                faucet_version: faucet_version.parse()?,
+                safe_version: Some("0.0.1".parse()?), // todo: store safe version in the safenodeman registry?
+                faucet_version: Some(faucet_version.parse()?),
                 safenode_version: safenode_version.parse()?,
                 safenode_manager_version: safenode_manager_version.parse()?,
-                sn_auditor_version: sn_auditor_version.parse()?,
+                sn_auditor_version: Some(sn_auditor_version.parse()?),
             }
         };
 
@@ -552,11 +552,11 @@ impl DeploymentInventory {
                 println!("===============");
                 println!("Version Details");
                 println!("===============");
-                println!("faucet version: {faucet_version}");
-                println!("safe version: {safe_version}");
-                println!("safenode version: {safenode_version}");
-                println!("safenode-manager version: {safenode_manager_version}");
-                println!("sn_auditor version: {sn_auditor_version}");
+                println!("faucet version: {}", faucet_version.as_ref().map_or("none".to_string(), |v| v.to_string()));
+                println!("safe version: {}", safe_version.as_ref().map_or("none".to_string(), |v| v.to_string()));
+                println!("safenode version: {}", safenode_version);
+                println!("safenode-manager version: {}", safenode_manager_version);
+                println!("sn_auditor version: {}", sn_auditor_version.as_ref().map_or("none".to_string(), |v| v.to_string()));
                 println!();
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,11 +156,11 @@ pub enum BinaryOption {
     },
     /// Pre-built, versioned binaries will be fetched from S3.
     Versioned {
-        faucet_version: Version,
-        safe_version: Version,
+        faucet_version: Option<Version>,
+        safe_version: Option<Version>,
         safenode_version: Version,
         safenode_manager_version: Version,
-        sn_auditor_version: Version,
+        sn_auditor_version: Option<Version>,
     },
 }
 
@@ -870,14 +870,14 @@ pub async fn notify_slack(inventory: DeploymentInventory) -> Result<()> {
             ref sn_auditor_version,
         } => {
             message.push_str("*Version Details*\n");
-            message.push_str(&format!("faucet version: {}\n", faucet_version));
-            message.push_str(&format!("safe version: {}\n", safe_version));
-            message.push_str(&format!("safenode version: {}\n", safenode_version));
+            message.push_str(&format!("faucet version: {}\n", faucet_version.as_ref().map_or("None".to_string(), |v| v.to_string())));
+            message.push_str(&format!("safe version: {}\n", safe_version.as_ref().map_or("None".to_string(), |v| v.to_string())));
+            message.push_str(&format!("safenode version: {}\n", safenode_version.to_string()));
             message.push_str(&format!(
                 "safenode-manager version: {}\n",
-                safenode_manager_version
+                safenode_manager_version.to_string()
             ));
-            message.push_str(&format!("sn_auditor version: {}\n", sn_auditor_version));
+            message.push_str(&format!("sn_auditor version: {}\n", sn_auditor_version.as_ref().map_or("None".to_string(), |v| v.to_string())));
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,11 +185,12 @@ pub struct DeployOptions {
 pub enum BinaryOption {
     /// Binaries will be built from source.
     BuildFromSource {
-        repo_owner: String,
         branch: String,
+        network_keys: Option<(String, String, String, String)>,
+        protocol_version: Option<String>,
+        repo_owner: String,
         /// A comma-separated list that will be passed to the `--features` argument.
         safenode_features: Option<String>,
-        protocol_version: Option<String>,
     },
     /// Pre-built, versioned binaries will be fetched from S3.
     Versioned {
@@ -911,6 +912,7 @@ pub async fn notify_slack(inventory: DeploymentInventory) -> Result<()> {
             ref safenode_version,
             ref safenode_manager_version,
             ref sn_auditor_version,
+            ..
         } => {
             message.push_str("*Version Details*\n");
             message.push_str(&format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -659,6 +659,8 @@ enum Commands {
         ///
         /// If there are currently 10 VMs running, and you want there to be 20, use 20 as the
         /// value, not 10 as a delta.
+        ///
+        /// This option is not applicable to a bootstrap deployment.
         #[clap(long, verbatim_doc_comment)]
         desired_auditor_vm_count: Option<u16>,
         /// The desired number of safenode services to be running on each bootstrap VM after the
@@ -669,12 +671,16 @@ enum Commands {
         ///
         /// Note: bootstrap VMs normally only use a single node service, so you probably want this
         /// value to be 1.
+        ///
+        /// This option is not applicable to a bootstrap deployment.
         #[clap(long, verbatim_doc_comment)]
         desired_bootstrap_node_count: Option<u16>,
         /// The desired number of bootstrap VMs to be running after the scale.
         ///
         /// If there are currently 10 VMs running, and you want there to be 20, use 20 as the
         /// value, not 10 as a delta.
+        ///
+        /// This option is not applicable to a bootstrap deployment.
         #[clap(long, verbatim_doc_comment)]
         desired_bootstrap_node_vm_count: Option<u16>,
         /// Set to only use Terraform to upscale the VMs and not run Ansible.
@@ -713,6 +719,8 @@ enum Commands {
         ///
         /// If there are currently 10 VMs running, and you want there to be 25, the value used
         /// should be 25, rather than 15 as a delta to reach 25.
+        ///
+        /// This option is not applicable to a bootstrap deployment.
         #[clap(long, verbatim_doc_comment)]
         desired_uploader_vm_count: Option<u16>,
         /// The cloud provider for the network.

--- a/src/main.rs
+++ b/src/main.rs
@@ -972,8 +972,10 @@ async fn main() -> Result<()> {
                         AnsiblePlaybook::FundUploaders,
                         AnsibleInventoryType::Uploaders,
                         Some(build_fund_faucet_extra_vars_doc(
-                            &inventory.get_genesis_ip()?,
-                            &inventory.genesis_multiaddr,
+                            &inventory.get_genesis_ip().ok_or_else(||
+                                eyre!("Genesis node not found. Most likely this is a bootstrap deployment."))?,
+                            &inventory.genesis_multiaddr.clone().ok_or_else(||
+                                eyre!("Genesis node not found. Most likely this is a bootstrap deployment."))?,
                         )?),
                     )?;
                 }
@@ -1210,7 +1212,7 @@ async fn main() -> Result<()> {
 
             testnet_deploy.init().await?;
             testnet_deploy
-                .plan(None, inventory.environment_type)
+                .plan(None, inventory.environment_details.environment_type)
                 .await?;
             Ok(())
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1725,11 +1725,11 @@ async fn get_binary_option(
         let sn_auditor_version =
             get_version_from_option(sn_auditor_version, &ReleaseType::SnAuditor).await?;
         BinaryOption::Versioned {
-            faucet_version,
-            safe_version,
+            faucet_version: Some(faucet_version),
+            safe_version: Some(safe_version),
             safenode_version,
             safenode_manager_version,
-            sn_auditor_version,
+            sn_auditor_version: Some(sn_auditor_version),
         }
     } else {
         // Unwraps are justified here because it's already been asserted that both must have

--- a/src/manage_test_data.rs
+++ b/src/manage_test_data.rs
@@ -128,7 +128,10 @@ impl TestDataClient {
             }
         }
 
-        let faucet_addr: SocketAddr = inventory.faucet_address.parse()?;
+        let faucet_addr: SocketAddr = inventory.faucet_address
+            .as_ref()
+            .ok_or_eyre("Faucet address is not set in the inventory")?
+            .parse()?;
         let random_peer = inventory
             .get_random_peer()
             .ok_or_eyre("No peers available")?;

--- a/src/manage_test_data.rs
+++ b/src/manage_test_data.rs
@@ -128,7 +128,8 @@ impl TestDataClient {
             }
         }
 
-        let faucet_addr: SocketAddr = inventory.faucet_address
+        let faucet_addr: SocketAddr = inventory
+            .faucet_address
             .as_ref()
             .ok_or_eyre("Faucet address is not set in the inventory")?
             .parse()?;

--- a/src/upscale.rs
+++ b/src/upscale.rs
@@ -102,7 +102,7 @@ impl TestnetDeployer {
             ];
             self.plan(
                 Some(vars),
-                options.current_inventory.environment_type.clone(),
+                options.current_inventory.environment_details.environment_type.clone(),
             )
             .await?;
             return Ok(());
@@ -117,6 +117,7 @@ impl TestnetDeployer {
             false,
             &options
                 .current_inventory
+                .environment_details
                 .environment_type
                 .get_tfvars_filename(),
         )

--- a/src/upscale.rs
+++ b/src/upscale.rs
@@ -8,7 +8,7 @@ use crate::{
     ansible::provisioning::{NodeType, ProvisionOptions},
     ansible::AnsibleInventoryType,
     error::{Error, Result},
-    get_genesis_multiaddr, DeploymentInventory, TestnetDeployer,
+    get_genesis_multiaddr, DeploymentInventory, DeploymentType, TestnetDeployer,
 };
 use colored::Colorize;
 use log::debug;
@@ -102,7 +102,11 @@ impl TestnetDeployer {
             ];
             self.plan(
                 Some(vars),
-                options.current_inventory.environment_details.environment_type.clone(),
+                options
+                    .current_inventory
+                    .environment_details
+                    .environment_type
+                    .clone(),
             )
             .await?;
             return Ok(());
@@ -110,6 +114,16 @@ impl TestnetDeployer {
 
         self.create_or_update_infra(
             &options.current_inventory.name,
+            Some(
+                match options
+                    .current_inventory
+                    .environment_details
+                    .deployment_type
+                {
+                    DeploymentType::New => 1,
+                    DeploymentType::Bootstrap => 0,
+                },
+            ),
             Some(desired_auditor_vm_count),
             Some(desired_bootstrap_node_vm_count),
             Some(desired_node_vm_count),


### PR DESCRIPTION
- b7abcff **refactor: make some version numbers optional**

  To setup a command that will deploy a new set of nodes that are bootstrapped from an existing
  deployment, the auditor, faucet and safe versions will be set to optional.

  The bootstrapped deployment will just supply some extra nodes, so it won't have a genesis node, a
  faucet, an auditor, or any uploaders.

- 0f867d7 **feat: extend deployment inventory with deployment type**

  The inventory for a deployment now stores the type of the deployment, in addition to the environment
  type.

  The deployment type is either `New` or `Bootstrap`, where the latter is a deployment that bootstraps
  from one of the peers in an existing deployment. In the bootstrap deployment, there will be no
  genesis, bootstrap, uploader or auditor VMs.

- 88fb100 **feat: provide `bootstrap` command**

  This command creates a new deployment that uses a peer from an existing network to bootstrap from
  said network.

  Only generic VMs and nodes are created. There is no genesis node, no bootstrap nodes, no faucet,
  auditor, or uploaders.

- 51cf83e **feat: specify network keys for custom builds**

  Optional network key arguments are added to the `bootstrap` and `deploy` commands. If these
  arguments are used when building a custom binary, the binary will be built with these keys.

  Since the keys are really a set, all of them must be specified, or the commands will error.

- 932e813 **chore: always print the genesis multiaddr**

  Addresses PR feedback that was requested.

  It's possible for there to be zero bootstrap nodes on a custom deployment, so that can't be used as
  a way to determine whether to print the genesis node details.

- 0b47d41 **feat: vary `upscale` cmd by deployment type**

  The command needs to behave differently depending on whether the environment being scaled is a new
  deployment or a bootstrap.

  We check for the options that don't apply to the bootstrap type and also vary the provisioning
  accordingly.