### PR TITLE
feat: provide `chunk-size` argument on the `deploy` cmd

### DIFF
--- a/resources/ansible/roles/build_safe_network_binary/tasks/main.yml
+++ b/resources/ansible/roles/build_safe_network_binary/tasks/main.yml
@@ -17,6 +17,10 @@
     export NETWORK_VERSION_MODE={{ protocol_version }}
     {% endif %}
 
+    {% if chunk_size is defined and chunk_size != "" %}
+    export MAX_CHUNK_SIZE={{ chunk_size }}
+    {% endif %}
+
     {% if foundation_pk is defined and foundation_pk != "" %}
     export FOUNDATION_PK={{ foundation_pk }}
     {% endif %}

--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -51,6 +51,7 @@ pub struct ProvisionOptions {
     pub beta_encryption_key: Option<String>,
     pub binary_option: BinaryOption,
     pub bootstrap_node_count: u16,
+    pub chunk_size: Option<u64>,
     pub downloaders_count: u16,
     pub env_variables: Option<Vec<(String, String)>>,
     pub log_format: Option<LogFormat>,
@@ -70,6 +71,7 @@ impl From<BootstrapOptions> for ProvisionOptions {
             beta_encryption_key: None,
             binary_option: bootstrap_options.binary_option,
             bootstrap_node_count: 0,
+            chunk_size: None,
             downloaders_count: 0,
             env_variables: bootstrap_options.env_variables,
             log_format: bootstrap_options.log_format,
@@ -91,6 +93,7 @@ impl From<DeployOptions> for ProvisionOptions {
             beta_encryption_key: deploy_options.beta_encryption_key,
             binary_option: deploy_options.binary_option,
             bootstrap_node_count: deploy_options.bootstrap_node_count,
+            chunk_size: deploy_options.chunk_size,
             downloaders_count: deploy_options.downloaders_count,
             env_variables: deploy_options.env_variables,
             log_format: deploy_options.log_format,
@@ -927,6 +930,9 @@ impl AnsibleProvisioner {
     fn build_binaries_extra_vars_doc(&self, options: &ProvisionOptions) -> Result<String> {
         let mut extra_vars = ExtraVarsDocBuilder::default();
         extra_vars.add_build_variables(&options.name, &options.binary_option);
+        if let Some(chunk_size) = options.chunk_size {
+            extra_vars.add_variable("chunk_size", &chunk_size.to_string());
+        }
         Ok(extra_vars.build())
     }
 

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -22,6 +22,7 @@ pub struct DeployOptions {
     pub binary_option: BinaryOption,
     pub bootstrap_node_count: u16,
     pub bootstrap_node_vm_count: Option<u16>,
+    pub chunk_size: Option<u64>,
     pub current_inventory: DeploymentInventory,
     pub downloaders_count: u16,
     pub environment_type: EnvironmentType,

--- a/src/main.rs
+++ b/src/main.rs
@@ -231,6 +231,11 @@ enum Commands {
         /// argument.
         #[clap(long)]
         bootstrap_node_vm_count: Option<u16>,
+        /// Specify the chunk size for the custom binaries using a 64-bit integer.
+        ///
+        /// This option only applies if the --branch and --repo-owner arguments are used.
+        #[clap(long, value_parser = parse_chunk_size)]
+        chunk_size: Option<u64>,
         /// If set to a non-zero value, the uploaders will also be accompanied by the specified
         /// number of downloaders.
         ///
@@ -1168,6 +1173,7 @@ async fn main() -> Result<()> {
             branch,
             bootstrap_node_count,
             bootstrap_node_vm_count,
+            chunk_size,
             downloaders_count,
             environment_type,
             env_variables,
@@ -1275,6 +1281,7 @@ async fn main() -> Result<()> {
                     bootstrap_node_count: bootstrap_node_count
                         .unwrap_or(environment_type.get_default_bootstrap_node_count()),
                     bootstrap_node_vm_count,
+                    chunk_size,
                     current_inventory: inventory,
                     downloaders_count,
                     environment_type: environment_type.clone(),
@@ -2281,6 +2288,15 @@ fn build_fund_faucet_extra_vars_doc(
     extra_vars.add_variable("genesis_addr", &genesis_ip.to_string());
     extra_vars.add_variable("genesis_multiaddr", genesis_multiaddr);
     Ok(extra_vars.build())
+}
+
+fn parse_chunk_size(val: &str) -> Result<u64> {
+    let size = val.parse::<u64>()?;
+    if size == 0 {
+        Err(eyre!("chunk_size must be a positive integer"))
+    } else {
+        Ok(size)
+    }
 }
 
 fn validate_and_get_pks(

--- a/src/upscale.rs
+++ b/src/upscale.rs
@@ -190,6 +190,7 @@ impl TestnetDeployer {
             beta_encryption_key: None,
             binary_option: options.current_inventory.binary_option.clone(),
             bootstrap_node_count: desired_bootstrap_node_count,
+            chunk_size: None,
             downloaders_count: options.downloaders_count,
             env_variables: None,
             log_format: None,


### PR DESCRIPTION
This is necessary for the chunk size experiments.

The value will be passed to the role that builds binaries.