### PR TITLE
chore: create nat gateway image for prod

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -32,6 +32,14 @@ build-staging-uploader-image:
     packer build -var 'size=s-2vcpu-4gb' node.pkr.hcl
   )
 
+build-prod-nat-gateway-image:
+  #!/usr/bin/env bash
+  (
+    cd resources/packer/node
+    packer init .
+    packer build -var 'size=s-1vcpu-2gb' node.pkr.hcl
+  )
+
 # This target has been copied from another repository. On other repositories, more than one
 # architecture is supported. If we want to extend for other architectures, we can do so.
 build-release-artifacts arch:

--- a/resources/packer/node/node.pkr.hcl
+++ b/resources/packer/node/node.pkr.hcl
@@ -17,7 +17,7 @@ variable "user_home" {
 
 variable "droplet_image" {
   type = string
-  default = "ubuntu-23-10-x64"
+  default = "ubuntu-22-04-x64"
 }
 
 variable "region" {

--- a/resources/scripts/install_ansible.sh
+++ b/resources/scripts/install_ansible.sh
@@ -23,5 +23,15 @@ for i in $(seq 1 $max_retries); do
   fi
 done
 
-apt-get install python3-pip -y
+for i in $(seq 1 $max_retries); do
+  apt-get install python3-pip -y
+  if [[ $? -eq 0 ]]; then
+    echo "Apt index updated successfully."
+    break
+  else
+    echo "Failed attempt $i. Retrying in $retry_delay seconds..."
+    sleep $retry_delay
+  fi
+done
+
 pip3 install ansible --prefix /usr

--- a/resources/terraform/testnet/digital-ocean/main.tf
+++ b/resources/terraform/testnet/digital-ocean/main.tf
@@ -53,7 +53,7 @@ resource "digitalocean_droplet" "genesis_bootstrap" {
 
 resource "digitalocean_droplet" "nat_gateway" {
   count    = var.setup_nat_gateway ? 1 : 0
-  image    = var.bootstrap_droplet_image_id // TODO: do we need new image?
+  image    = var.nat_gateway_droplet_image_id
   name     = "${terraform.workspace}-nat-gateway"
   region   = var.region
   size     = var.nat_gateway_droplet_size

--- a/resources/terraform/testnet/digital-ocean/production.tfvars
+++ b/resources/terraform/testnet/digital-ocean/production.tfvars
@@ -2,6 +2,7 @@ auditor_vm_count = 1
 bootstrap_droplet_size = "s-4vcpu-8gb"
 bootstrap_node_vm_count = 50
 bootstrap_droplet_image_id = 157362431
+nat_gateway_droplet_image_id = 166664184
 node_droplet_size = "s-2vcpu-4gb"
 node_vm_count = 79
 node_droplet_image_id = 157362431


### PR DESCRIPTION
Using the bootstrap image did not work for the production configuration because the prod bootstrap image is larger than the size of the machine we are trying to create for the gateway.

Had to change the Ubuntu version because it seems that Digital Ocean have now pulled the version we were using. Also had to add some extra retries into the Ansible installation script to get the image to build properly.