### PR TITLE
feat: provide `--safe-version` arg for `upscale` cmd

### DIFF
--- a/resources/terraform/testnet/digital-ocean/dev.tfvars
+++ b/resources/terraform/testnet/digital-ocean/dev.tfvars
@@ -2,6 +2,7 @@ auditor_vm_count = 1
 bootstrap_droplet_size = "s-1vcpu-2gb"
 bootstrap_node_vm_count = 2
 bootstrap_droplet_image_id = 162461040
+nat_gateway_droplet_image_id = 166664184
 node_droplet_size = "s-2vcpu-4gb"
 node_vm_count = 10
 node_droplet_image_id = 162460774

--- a/resources/terraform/testnet/digital-ocean/staging.tfvars
+++ b/resources/terraform/testnet/digital-ocean/staging.tfvars
@@ -2,6 +2,7 @@ auditor_vm_count = 1
 bootstrap_droplet_size = "s-1vcpu-2gb"
 bootstrap_node_vm_count = 2
 bootstrap_droplet_image_id = 162461040
+nat_gateway_droplet_image_id = 166664184
 node_droplet_size = "s-2vcpu-4gb"
 node_vm_count = 39
 node_droplet_image_id = 162460774

--- a/src/ansible/extra_vars.rs
+++ b/src/ansible/extra_vars.rs
@@ -266,7 +266,22 @@ impl ExtraVarsDocBuilder {
         &mut self,
         deployment_name: &str,
         binary_option: &BinaryOption,
+        safe_version: Option<String>,
     ) -> Result<(), Error> {
+        // This applies when upscaling the uploaders.
+        // In that scenario, the safe version in the binary option is not set to the correct value
+        // because it is not recorded in the inventory.
+        if let Some(version) = safe_version {
+            self.variables.push((
+                "safe_archive_url".to_string(),
+                format!(
+                    "{}/safe-{}-x86_64-unknown-linux-musl.tar.gz",
+                    SAFE_S3_BUCKET_URL, version
+                ),
+            ));
+            return Ok(());
+        }
+
         match binary_option {
             BinaryOption::BuildFromSource {
                 repo_owner, branch, ..

--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -63,6 +63,10 @@ pub struct ProvisionOptions {
     pub private_node_count: u16,
     pub private_node_vms: Vec<VirtualMachine>,
     pub public_rpc: bool,
+    /// The safe version is also in the binary option, but only for an initial deployment.
+    /// For the upscale, it needs to be provided explicitly, because currently it is not
+    /// recorded in the inventory.
+    pub safe_version: Option<String>,
 }
 
 impl From<BootstrapOptions> for ProvisionOptions {
@@ -83,6 +87,7 @@ impl From<BootstrapOptions> for ProvisionOptions {
             private_node_count: bootstrap_options.private_node_count,
             private_node_vms: Vec::new(),
             public_rpc: false,
+            safe_version: None,
         }
     }
 }
@@ -105,6 +110,7 @@ impl From<DeployOptions> for ProvisionOptions {
             public_rpc: deploy_options.public_rpc,
             private_node_count: deploy_options.private_node_count,
             private_node_vms: Vec::new(),
+            safe_version: None,
         }
     }
 }
@@ -923,7 +929,11 @@ impl AnsibleProvisioner {
             "safe_downloader_instances",
             &options.downloaders_count.to_string(),
         );
-        extra_vars.add_safe_url_or_version(&options.name, &options.binary_option)?;
+        extra_vars.add_safe_url_or_version(
+            &options.name,
+            &options.binary_option,
+            options.safe_version.clone(),
+        )?;
         Ok(extra_vars.build())
     }
 

--- a/src/upscale.rs
+++ b/src/upscale.rs
@@ -30,6 +30,7 @@ pub struct UpscaleOptions {
     pub infra_only: bool,
     pub plan: bool,
     pub public_rpc: bool,
+    pub safe_version: Option<String>,
 }
 
 impl TestnetDeployer {
@@ -205,6 +206,7 @@ impl TestnetDeployer {
             private_node_count: desired_private_node_count,
             private_node_vms: Vec::new(),
             public_rpc: options.public_rpc,
+            safe_version: options.safe_version.clone(),
         };
         let mut node_provision_failed = false;
 


### PR DESCRIPTION
Since we don't record the versioning information that was used with the initial deployment, if we are going to upscale the uploaders, we need to supply the version we want to use for the `safe` binary.

This is a simple solution for now. In the future we could record the binary information in the environment information that is on S3.