### PR TITLE
feat: provide `--additional-volume-size` arg for `deploy` cmd

### DIFF
--- a/resources/ansible/roles/node/tasks/main.yml
+++ b/resources/ansible/roles/node/tasks/main.yml
@@ -95,6 +95,31 @@
   when: make_vm_private
 
 #
+# Setup alternate storage if additional volume is attached
+#
+- name: Ensure data directory is present
+  file:
+    path: "{{ mount_dir }}/data"
+    state: directory
+    owner: safe
+    group: safe
+    mode: '0755'
+  when:
+    - additional_volume_attached
+    - not is_genesis
+
+- name: Ensure logs directory is present
+  file:
+    path: "{{ mount_dir }}/logs"
+    state: directory
+    owner: safe
+    group: safe
+    mode: '0755'
+  when:
+    - additional_volume_attached
+    - not is_genesis
+
+#
 # Add the nodes
 #
 - name: add node services
@@ -122,9 +147,12 @@
       - "{{ ('--log-format=' + log_format) if log_format is defined else omit }}"
       - "{{ ('--env=' + env_variables) if env_variables is defined else omit }}"
       - "{{ ('--version=' + version) if version is defined else ('--url=' + node_archive_url) }}"
-  when: not is_genesis and nodes_to_add | default(0) | int > 0
+      - "{{ '--data-dir-path=' + mount_dir + '/data' if additional_volume_attached else omit }}"
+      - "{{ '--log-dir-path=' + mount_dir + '/logs' if additional_volume_attached else omit }}"
+  when: 
+    - not is_genesis 
+    - nodes_to_add | default(0) | int > 0
 
-# set "interval" to override dynamic startup delay
 - name: start the node services
   become: True
   command: safenode-manager -v start --interval 200

--- a/resources/ansible/roles/node/vars/main.yml
+++ b/resources/ansible/roles/node/vars/main.yml
@@ -1,0 +1,2 @@
+hostname_lower: "{{ ansible_hostname | lower }}"
+mount_dir: "/mnt/{{ hostname_lower | regex_replace('-node-', '_node_vol_') | replace('-', '') }}"

--- a/resources/terraform/testnet/digital-ocean/variables.tf
+++ b/resources/terraform/testnet/digital-ocean/variables.tf
@@ -107,3 +107,15 @@ variable "use_custom_bin" {
   default     = false
   description = "A boolean to enable use of a custom bin"
 }
+
+variable "attach_additional_volume" {
+  description = "Use to control whether to attach an additional volume to each node"
+  type        = bool
+  default     = false
+}
+
+variable "additional_volume_size" {
+  description = "Size of the additional volume in gigabytes"
+  type        = number
+  default     = 0
+}

--- a/src/ansible/extra_vars.rs
+++ b/src/ansible/extra_vars.rs
@@ -320,7 +320,10 @@ impl ExtraVarsDocBuilder {
     }
 
     pub fn build(&self) -> String {
-        if self.variables.is_empty() && self.list_variables.is_empty() && self.bool_variables.is_empty() {
+        if self.variables.is_empty()
+            && self.list_variables.is_empty()
+            && self.bool_variables.is_empty()
+        {
             return "{}".to_string();
         }
 

--- a/src/ansible/extra_vars.rs
+++ b/src/ansible/extra_vars.rs
@@ -15,6 +15,7 @@ const SAFE_S3_BUCKET_URL: &str = "https://sn-cli.s3.eu-west-2.amazonaws.com";
 pub struct ExtraVarsDocBuilder {
     variables: Vec<(String, String)>,
     list_variables: HashMap<String, Vec<String>>,
+    bool_variables: Vec<(String, bool)>,
 }
 
 impl ExtraVarsDocBuilder {
@@ -48,6 +49,11 @@ impl ExtraVarsDocBuilder {
         let joined_env_vars = joined_env_vars.join(",");
         self.variables
             .push((name.to_string(), joined_env_vars.to_string()));
+        self
+    }
+
+    pub fn add_boolean_variable(&mut self, name: &str, value: bool) -> &mut Self {
+        self.bool_variables.push((name.to_string(), value));
         self
     }
 
@@ -314,7 +320,7 @@ impl ExtraVarsDocBuilder {
     }
 
     pub fn build(&self) -> String {
-        if self.variables.is_empty() && self.list_variables.is_empty() {
+        if self.variables.is_empty() && self.list_variables.is_empty() && self.bool_variables.is_empty() {
             return "{}".to_string();
         }
 
@@ -332,6 +338,10 @@ impl ExtraVarsDocBuilder {
             let mut temp_doc = doc.strip_suffix(", ").unwrap().to_string();
             temp_doc.push_str("], ");
             doc = temp_doc;
+        }
+
+        for (name, value) in self.bool_variables.iter() {
+            doc.push_str(&format!("\"{name}\": {value}, "));
         }
 
         let mut doc = doc.strip_suffix(", ").unwrap().to_string();

--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -76,7 +76,7 @@ pub struct ProvisionOptions {
 impl From<BootstrapOptions> for ProvisionOptions {
     fn from(bootstrap_options: BootstrapOptions) -> Self {
         ProvisionOptions {
-            additional_volume_attached: false,
+            additional_volume_attached: bootstrap_options.additional_volume_size.is_some(),
             beta_encryption_key: None,
             binary_option: bootstrap_options.binary_option,
             bootstrap_node_count: 0,

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     error::Result,
     write_environment_details, BinaryOption, DeploymentType, EnvironmentDetails, EnvironmentType,
-    LogFormat, TestnetDeployer,
+    InfraRunOptions, LogFormat, TestnetDeployer,
 };
 use colored::Colorize;
 
@@ -59,17 +59,18 @@ impl TestnetDeployer {
         )
         .await?;
 
-        self.create_or_update_infra(
-            &options.name,
-            Some(0),
-            Some(0),
-            Some(0),
-            options.node_vm_count,
-            options.private_node_vm_count,
-            Some(0),
-            build_custom_binaries,
-            &options.environment_type.get_tfvars_filename(),
-        )
+        self.create_or_update_infra(&InfraRunOptions {
+            additional_volume_size: None,
+            auditor_vm_count: Some(0),
+            bootstrap_node_vm_count: Some(0),
+            enable_build_vm: build_custom_binaries,
+            genesis_vm_count: Some(0),
+            name: options.name.clone(),
+            node_vm_count: options.node_vm_count,
+            private_node_vm_count: options.private_node_vm_count,
+            tfvars_filename: options.environment_type.get_tfvars_filename(),
+            uploader_vm_count: None,
+        })
         .await
         .map_err(|err| {
             println!("Failed to create infra {err:?}");

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -55,6 +55,7 @@ impl TestnetDeployer {
             &EnvironmentDetails {
                 environment_type: options.environment_type.clone(),
                 deployment_type: DeploymentType::Bootstrap,
+                additional_volumes_used: false,
             },
         )
         .await?;

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -19,6 +19,7 @@ use colored::Colorize;
 
 #[derive(Clone)]
 pub struct BootstrapOptions {
+    pub additional_volume_size: Option<u16>,
     pub binary_option: BinaryOption,
     pub bootstrap_peer: String,
     pub environment_type: EnvironmentType,
@@ -55,13 +56,13 @@ impl TestnetDeployer {
             &EnvironmentDetails {
                 environment_type: options.environment_type.clone(),
                 deployment_type: DeploymentType::Bootstrap,
-                additional_volumes_used: false,
+                additional_volumes_used: options.additional_volume_size.is_some(),
             },
         )
         .await?;
 
         self.create_or_update_infra(&InfraRunOptions {
-            additional_volume_size: None,
+            additional_volume_size: options.additional_volume_size,
             auditor_vm_count: Some(0),
             bootstrap_node_vm_count: Some(0),
             enable_build_vm: build_custom_binaries,

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -11,13 +11,15 @@ use crate::{
     },
     error::Result,
     get_genesis_multiaddr, write_environment_details, BinaryOption, DeploymentInventory,
-    DeploymentType, EnvironmentDetails, EnvironmentType, LogFormat, TestnetDeployer,
+    DeploymentType, EnvironmentDetails, EnvironmentType, InfraRunOptions, LogFormat,
+    TestnetDeployer,
 };
 use colored::Colorize;
 use std::{net::SocketAddr, path::PathBuf};
 
 #[derive(Clone)]
 pub struct DeployOptions {
+    pub additional_volume_size: Option<u16>,
     pub beta_encryption_key: Option<String>,
     pub binary_option: BinaryOption,
     pub bootstrap_node_count: u16,
@@ -61,17 +63,18 @@ impl TestnetDeployer {
         )
         .await?;
 
-        self.create_or_update_infra(
-            &options.name,
-            Some(1),
-            None,
-            options.bootstrap_node_vm_count,
-            options.node_vm_count,
-            options.private_node_vm_count,
-            options.uploader_vm_count,
-            build_custom_binaries,
-            &options.environment_type.get_tfvars_filename(),
-        )
+        self.create_or_update_infra(&InfraRunOptions {
+            additional_volume_size: options.additional_volume_size,
+            auditor_vm_count: Some(1),
+            bootstrap_node_vm_count: options.bootstrap_node_vm_count,
+            enable_build_vm: build_custom_binaries,
+            genesis_vm_count: Some(1),
+            name: options.name.clone(),
+            node_vm_count: options.node_vm_count,
+            private_node_vm_count: options.private_node_vm_count,
+            tfvars_filename: options.environment_type.get_tfvars_filename(),
+            uploader_vm_count: options.uploader_vm_count,
+        })
         .await
         .map_err(|err| {
             println!("Failed to create infra {err:?}");

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -59,6 +59,7 @@ impl TestnetDeployer {
             &EnvironmentDetails {
                 environment_type: options.environment_type.clone(),
                 deployment_type: DeploymentType::New,
+                additional_volumes_used: options.additional_volume_size.is_some(),
             },
         )
         .await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,13 @@ struct Opt {
 enum Commands {
     /// Bootstrap a new network from an existing deployment.
     Bootstrap {
+        /// Use this option to attach an additional volume to each node VM.
+        ///
+        /// The value is the size of the volume in gigabytes.
+        ///
+        /// The nodes will be configured to use the additional volume.
+        #[arg(long, value_parser = clap::value_parser!(u16))]
+        additional_volume_size: Option<u16>,
         /// Set to run Ansible with more verbose output.
         #[arg(long)]
         ansible_verbose: bool,
@@ -1109,6 +1116,7 @@ async fn main() -> Result<()> {
     let opt = Opt::parse();
     match opt.command {
         Commands::Bootstrap {
+            additional_volume_size,
             ansible_verbose,
             bootstrap_peer,
             branch,
@@ -1192,6 +1200,7 @@ async fn main() -> Result<()> {
 
             testnet_deployer
                 .bootstrap(&BootstrapOptions {
+                    additional_volume_size,
                     binary_option,
                     bootstrap_peer,
                     environment_type: environment_type.clone(),
@@ -2134,10 +2143,10 @@ async fn main() -> Result<()> {
             if inventory.environment_details.additional_volumes_used
                 && additional_volume_size.is_none()
             {
-                return Err(
-                    eyre!(
-                        "The original deployment used additional volumes, so the upscale must also \
-                        use them."));
+                return Err(eyre!(
+                    "The original deployment used additional volumes, so the upscale must also \
+                        use them."
+                ));
             }
 
             testnet_deployer

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,6 +204,13 @@ enum Commands {
     },
     /// Deploy a new testnet environment using the latest version of the safenode binary.
     Deploy {
+        /// Use this option to attach an additional volume to each node VM.
+        ///
+        /// The value is the size of the volume in gigabytes.
+        ///
+        /// The nodes will be configured to use the additional volume.
+        #[arg(long, value_parser = clap::value_parser!(u16))]
+        additional_volume_size: Option<u16>,
         /// Set to run Ansible with more verbose output.
         #[arg(long)]
         ansible_verbose: bool,
@@ -1217,6 +1224,7 @@ async fn main() -> Result<()> {
             Ok(())
         }
         Commands::Deploy {
+            additional_volume_size,
             ansible_verbose,
             beta_encryption_key,
             branch,
@@ -1328,6 +1336,7 @@ async fn main() -> Result<()> {
 
             testnet_deployer
                 .deploy(&DeployOptions {
+                    additional_volume_size,
                     beta_encryption_key,
                     binary_option: binary_option.clone(),
                     bootstrap_node_count: bootstrap_node_count

--- a/src/upscale.rs
+++ b/src/upscale.rs
@@ -17,6 +17,7 @@ use std::collections::HashSet;
 
 #[derive(Clone)]
 pub struct UpscaleOptions {
+    pub additional_volume_size: Option<u16>,
     pub ansible_verbose: bool,
     pub current_inventory: DeploymentInventory,
     pub desired_auditor_vm_count: Option<u16>,
@@ -158,7 +159,7 @@ impl TestnetDeployer {
         }
 
         self.create_or_update_infra(&InfraRunOptions {
-            additional_volume_size: None,
+            additional_volume_size: options.additional_volume_size,
             auditor_vm_count: Some(desired_auditor_vm_count),
             bootstrap_node_vm_count: Some(desired_bootstrap_node_vm_count),
             enable_build_vm: false,
@@ -193,7 +194,7 @@ impl TestnetDeployer {
         }
 
         let mut provision_options = ProvisionOptions {
-            additional_volume_attached: false,
+            additional_volume_attached: options.additional_volume_size.is_some(),
             beta_encryption_key: None,
             binary_option: options.current_inventory.binary_option.clone(),
             bootstrap_node_count: desired_bootstrap_node_count,


### PR DESCRIPTION
- fab09e6 **feat: provide `--additional-volume-size` arg for `deploy` cmd**

  An optional argument, that when specified, will add an additional volume to the node VMs.

  The node manager will then use that volume as data and logging storage space. On Digital Ocean, the
  disk is automatically formatted and mounted at a location that corresponds to the volume label. This
  is unlike AWS, where you need to format and mount the volume yourself.

  The extra vars document processing is also extended to add a boolean type. Boolean variables should
  not be enclosed in quotes if you want Ansible to interpret them as a boolean rather than a string.

- 6d8e547 **feat: provide `--additional-volume-size` arg for `upscale` cmd**

  An optional argument, that when specified, will add an additional volume to new node VMs when an
  existing deployment is upscaled.

  There is a caveat here: if the original deployment used an additional volume, the new nodes from the
  upscale must also use an additional volume. This is because the Terraform configuration synchronises
  the node VMs with the additional volumes on a one-to-one basis. So if you try to upscale without
  also adding volumes, Terraform will actually delete volumes for the existing VMs. The easiest thing
  is to just keep the two synchronised.

  For this reason, an additional field was added to the `EnvironmentDetails` struct to keep track of
  whether the original deploy used additional volumes. At the same time, the storage of the
  `EnvironmentDetails` struct on S3 was refactored to serialize it to JSON.

  With that new information available, the command will error if the original deploy used additional
  volumes and they were not specified for the upscale.

- 7863131 **feat: provide `--additional-volume-size` arg for `bootstrap` cmd**

  An optional argument, that when specified, will add an additional volume to the new bootstrap
  deployment.