### PR TITLE
feat: provide `configure-swapfile` command

### DIFF
--- a/resources/ansible/configure_swapfile.yml
+++ b/resources/ansible/configure_swapfile.yml
@@ -1,0 +1,44 @@
+---
+- name: configure swapfile
+  hosts: all
+  become: yes
+  vars:
+    swapfile_size: "{{ swapfile_size | default('120G') }}"
+    swapfile_path: /swapfile
+  tasks:
+    - name: check existing swapfile
+      stat:
+        path: "{{ swapfile_path }}"
+      register: swapfile_stats
+
+    - name: create swapfile
+      command: fallocate -l {{ swapfile_size }} {{ swapfile_path }}
+      when: not swapfile_stats.stat.exists
+
+    - name: set correct permissions on swapfile
+      file:
+        path: "{{ swapfile_path }}"
+        mode: '0600'
+
+    - name: format swapfile
+      command: mkswap {{ swapfile_path }}
+      when: not swapfile_stats.stat.exists
+
+    - name: enable swapfile
+      command: swapon {{ swapfile_path }}
+      when: ansible_swaptotal_mb == 0
+
+    - name: add swapfile entry to /etc/fstab
+      lineinfile:
+        path: /etc/fstab
+        line: '{{ swapfile_path }} none swap sw 0 0'
+        state: present
+
+    - name: show swap status
+      command: free -h
+      register: swap_status
+      changed_when: false
+
+    - name: display swap status
+      debug:
+        var: swap_status.stdout_lines

--- a/src/ansible/mod.rs
+++ b/src/ansible/mod.rs
@@ -64,6 +64,10 @@ pub enum AnsiblePlaybook {
     ///
     /// Use in combination with the node machines.
     CleanupLogs,
+    /// The configure swapfile playbook will configure the swapfile on the machines it is run against.
+    ///
+    /// Use in combination with `AnsibleInventoryType::Nodes` or `AnsibleInventoryType::Bootstrap`.
+    ConfigureSwapfile,
     /// The logs playbook will retrieve node logs from any machines it is run against.
     ///
     /// Use in combination with `AnsibleInventoryType::Genesis` or `AnsibleInventoryType::Nodes`.
@@ -164,6 +168,7 @@ impl AnsiblePlaybook {
             AnsiblePlaybook::Auditor => "auditor.yml".to_string(),
             AnsiblePlaybook::Build => "build.yml".to_string(),
             AnsiblePlaybook::CleanupLogs => "cleanup_logs.yml".to_string(),
+            AnsiblePlaybook::ConfigureSwapfile => "configure_swapfile.yml".to_string(),
             AnsiblePlaybook::CopyLogs => "copy_logs.yml".to_string(),
             AnsiblePlaybook::Genesis => "genesis_node.yml".to_string(),
             AnsiblePlaybook::Faucet => "faucet.yml".to_string(),


### PR DESCRIPTION
We now have a requirement to setup a swapfile on all the node machines.

There is also an option to run against the bootstrap nodes.