### PR TITLE
refactor: split node role into two

### DIFF
--- a/resources/ansible/genesis_node.yml
+++ b/resources/ansible/genesis_node.yml
@@ -27,4 +27,4 @@
         when: provider == "aws"
       }
     - node-manager
-    - node
+    - genesis-node

--- a/resources/ansible/roles/genesis-node/defaults/main.yml
+++ b/resources/ansible/roles/genesis-node/defaults/main.yml
@@ -1,9 +1,7 @@
 ---
-is_genesis: False
 public_rpc: False
 make_vm_private: False
 node_rpc_ip: "127.0.0.1"
-node_instance_count: 20
 binary_dir: /usr/local/bin
 # If a custom branch / version is specified, this value must be overwritten.
 node_archive_url: https://sn-node.s3.eu-west-2.amazonaws.com/safenode-latest-x86_64-unknown-linux-musl.tar.gz
@@ -13,7 +11,3 @@ node_archive_filename: safenode-latest-x86_64-unknown-linux-musl.tar.gz
 # Currently it is done directly inside the code
 node_manager_archive_filename: safenode-manager-latest-x86_64-unknown-linux-musl.tar.gz
 node_manager_archive_url: https://sn-node-manager.s3.eu-west-2.amazonaws.com/{{ node_manager_archive_filename }}
-safenodemand_archive_filename: safenodemand-latest-x86_64-unknown-linux-musl.tar.gz
-safenodemand_archive_url: https://sn-node-manager.s3.eu-west-2.amazonaws.com/{{ safenodemand_archive_filename }}
-initial_metrics_start_port: 14000
-initial_rpc_start_port: 13000

--- a/resources/ansible/roles/genesis-node/defaults/main.yml
+++ b/resources/ansible/roles/genesis-node/defaults/main.yml
@@ -1,0 +1,19 @@
+---
+is_genesis: False
+public_rpc: False
+make_vm_private: False
+node_rpc_ip: "127.0.0.1"
+node_instance_count: 20
+binary_dir: /usr/local/bin
+# If a custom branch / version is specified, this value must be overwritten.
+node_archive_url: https://sn-node.s3.eu-west-2.amazonaws.com/safenode-latest-x86_64-unknown-linux-musl.tar.gz
+node_archive_filename: safenode-latest-x86_64-unknown-linux-musl.tar.gz
+# If a custom branch is specified, the URL must be changed to 
+# "https://sn-node.s3.eu-west-2.amazonaws.com/{org}/{branch}/{bin_name}-{testnet_name}-x86_64-unknown-linux-musl.tar.gz"
+# Currently it is done directly inside the code
+node_manager_archive_filename: safenode-manager-latest-x86_64-unknown-linux-musl.tar.gz
+node_manager_archive_url: https://sn-node-manager.s3.eu-west-2.amazonaws.com/{{ node_manager_archive_filename }}
+safenodemand_archive_filename: safenodemand-latest-x86_64-unknown-linux-musl.tar.gz
+safenodemand_archive_url: https://sn-node-manager.s3.eu-west-2.amazonaws.com/{{ safenodemand_archive_filename }}
+initial_metrics_start_port: 14000
+initial_rpc_start_port: 13000

--- a/resources/ansible/roles/genesis-node/tasks/main.yml
+++ b/resources/ansible/roles/genesis-node/tasks/main.yml
@@ -1,0 +1,44 @@
+---
+# This role assumes the existence of the node manager, which is setup using another role.
+- name: get the private IP for the instance
+  set_fact:
+    node_rpc_ip: "{{ instance_facts.instances[0].network_interfaces[0].private_ip_address }}"
+  when: provider == "aws" and public_rpc
+
+- name: use the public IP as the RPC address on DO
+  set_fact:
+    node_rpc_ip: "{{ ansible_host }}"
+  when: provider == "digital-ocean" and public_rpc
+
+- name: check if genesis node is already set up
+  become: True
+  ansible.builtin.command: safenode-manager status --json
+  register: genesis_status
+
+- name: parse genesis node status
+  set_fact:
+    genesis_exists: "{{ (genesis_status.stdout | from_json).nodes | selectattr('genesis', 'equalto', true) | list | length > 0 }}"
+  when: genesis_status.stdout != ""
+
+- name: add genesis node service
+  become: True
+  ansible.builtin.command:
+    # The `omit` filter is used to remove arguments that don't have values
+    argv: "{{ command_args | reject('equalto', omit) | list }}"
+  vars:
+    command_args:
+      - "{{ binary_dir }}/safenode-manager"
+      - -v
+      - add
+      - --first
+      - "--rpc-address={{ node_rpc_ip }}"
+      - "--max-archived-log-files={{ max_archived_log_files }}"
+      - "--max-log-files={{ max_log_files }}"
+      - "{{ ('--log-format=' + log_format) if log_format is defined else omit }}"
+      - "{{ ('--env=' + env_variables) if env_variables is defined else omit }}"
+      - "{{ ('--version=' + version) if version is defined else ('--url=' + node_archive_url) }}"
+  when: not genesis_exists | default(false)
+
+- name: start the genesis node service
+  become: True
+  command: safenode-manager -v start --interval 200

--- a/resources/ansible/roles/node/defaults/main.yml
+++ b/resources/ansible/roles/node/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-is_genesis: False
 public_rpc: False
 make_vm_private: False
 node_rpc_ip: "127.0.0.1"
@@ -7,13 +6,10 @@ node_instance_count: 20
 binary_dir: /usr/local/bin
 # If a custom branch / version is specified, this value must be overwritten.
 node_archive_url: https://sn-node.s3.eu-west-2.amazonaws.com/safenode-latest-x86_64-unknown-linux-musl.tar.gz
-node_archive_filename: safenode-latest-x86_64-unknown-linux-musl.tar.gz
 # If a custom branch is specified, the URL must be changed to 
 # "https://sn-node.s3.eu-west-2.amazonaws.com/{org}/{branch}/{bin_name}-{testnet_name}-x86_64-unknown-linux-musl.tar.gz"
 # Currently it is done directly inside the code
 node_manager_archive_filename: safenode-manager-latest-x86_64-unknown-linux-musl.tar.gz
 node_manager_archive_url: https://sn-node-manager.s3.eu-west-2.amazonaws.com/{{ node_manager_archive_filename }}
-safenodemand_archive_filename: safenodemand-latest-x86_64-unknown-linux-musl.tar.gz
-safenodemand_archive_url: https://sn-node-manager.s3.eu-west-2.amazonaws.com/{{ safenodemand_archive_filename }}
 initial_metrics_start_port: 14000
 initial_rpc_start_port: 13000

--- a/resources/ansible/roles/node/tasks/main.yml
+++ b/resources/ansible/roles/node/tasks/main.yml
@@ -9,38 +9,6 @@
   set_fact:
     node_rpc_ip: "{{ ansible_host }}"
   when: provider == "digital-ocean" and public_rpc
-#
-# Setup genesis node on genesis run
-#
-- name: check if genesis node is already set up
-  become: True
-  ansible.builtin.command: safenode-manager status --json
-  register: genesis_status
-  when: is_genesis
-
-- name: parse genesis node status
-  set_fact:
-    genesis_exists: "{{ (genesis_status.stdout | from_json).nodes | selectattr('genesis', 'equalto', true) | list | length > 0 }}"
-  when: is_genesis and genesis_status.stdout != ""
-
-- name: add genesis node service
-  become: True
-  ansible.builtin.command:
-    # The `omit` filter is used to remove arguments that don't have values
-    argv: "{{ command_args | reject('equalto', omit) | list }}"
-  vars:
-    command_args:
-      - "{{ binary_dir }}/safenode-manager"
-      - -v
-      - add
-      - --first
-      - "--rpc-address={{ node_rpc_ip }}"
-      - "--max-archived-log-files={{ max_archived_log_files }}"
-      - "--max-log-files={{ max_log_files }}"
-      - "{{ ('--log-format=' + log_format) if log_format is defined else omit }}"
-      - "{{ ('--env=' + env_variables) if env_variables is defined else omit }}"
-      - "{{ ('--version=' + version) if version is defined else ('--url=' + node_archive_url) }}"
-  when: is_genesis and not genesis_exists | default(false)
 
 #
 # Calculate the number of nodes to add
@@ -122,9 +90,8 @@
       - "{{ ('--log-format=' + log_format) if log_format is defined else omit }}"
       - "{{ ('--env=' + env_variables) if env_variables is defined else omit }}"
       - "{{ ('--version=' + version) if version is defined else ('--url=' + node_archive_url) }}"
-  when: not is_genesis and nodes_to_add | default(0) | int > 0
+  when: nodes_to_add | default(0) | int > 0
 
-# set "interval" to override dynamic startup delay
 - name: start the node services
   become: True
   command: safenode-manager -v start --interval 200

--- a/src/ansible/extra_vars.rs
+++ b/src/ansible/extra_vars.rs
@@ -3,9 +3,10 @@
 //
 // This SAFE Network Software is licensed under the BSD-3-Clause license.
 // Please see the LICENSE file for more details.
+use crate::ansible::provisioning::{ProvisionOptions, DEFAULT_BETA_ENCRYPTION_KEY};
+use crate::NodeType;
 use crate::{BinaryOption, Error, Result};
 use std::collections::HashMap;
-use crate::ansible::provisioning::{DEFAULT_BETA_ENCRYPTION_KEY, ProvisionOptions, NodeType};
 use std::net::IpAddr;
 
 const NODE_S3_BUCKET_URL: &str = "https://sn-node.s3.eu-west-2.amazonaws.com";

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -7,13 +7,10 @@
 use std::path::PathBuf;
 
 use crate::{
-    ansible::{
-        inventory::AnsibleInventoryType,
-        provisioning::{NodeType, ProvisionOptions},
-    },
+    ansible::{inventory::AnsibleInventoryType, provisioning::ProvisionOptions},
     error::Result,
     write_environment_details, BinaryOption, DeploymentType, EnvironmentDetails, EnvironmentType,
-    LogFormat, TestnetDeployer,
+    LogFormat, NodeType, TestnetDeployer,
 };
 use colored::Colorize;
 

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -5,13 +5,10 @@
 // Please see the LICENSE file for more details.
 
 use crate::{
-    ansible::{
-        inventory::AnsibleInventoryType,
-        provisioning::{NodeType, ProvisionOptions},
-    },
+    ansible::{inventory::AnsibleInventoryType, provisioning::ProvisionOptions},
     error::Result,
     get_genesis_multiaddr, write_environment_details, BinaryOption, DeploymentInventory,
-    DeploymentType, EnvironmentDetails, EnvironmentType, LogFormat, TestnetDeployer,
+    DeploymentType, EnvironmentDetails, EnvironmentType, LogFormat, NodeType, TestnetDeployer,
 };
 use colored::Colorize;
 use std::{net::SocketAddr, path::PathBuf};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,9 +86,21 @@ impl std::str::FromStr for DeploymentType {
     }
 }
 
+#[derive(Debug)]
 pub enum NodeType {
     Bootstrap,
     Normal,
+    Private,
+}
+
+impl NodeType {
+    pub fn telegraph_role(&self) -> &'static str {
+        match self {
+            NodeType::Bootstrap => "BOOTSTRAP_NODE",
+            NodeType::Normal => "GENERIC_NODE",
+            NodeType::Private => "NAT_RANDOMIZED_NODE",
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]

--- a/src/upscale.rs
+++ b/src/upscale.rs
@@ -6,9 +6,10 @@
 
 use crate::{
     ansible::inventory::AnsibleInventoryType,
-    ansible::provisioning::{NodeType, ProvisionOptions},
+    ansible::provisioning::ProvisionOptions,
     error::{Error, Result},
-    get_genesis_multiaddr, get_multiaddr, DeploymentInventory, DeploymentType, TestnetDeployer,
+    get_genesis_multiaddr, get_multiaddr, DeploymentInventory, DeploymentType, NodeType,
+    TestnetDeployer,
 };
 use colored::Colorize;
 use log::debug;


### PR DESCRIPTION
- 3102499 **refactor: split node role into two**

  A `genesis-node` role is extracted from the `node` role. This avoids the need for having genesis
  conditionals on the other tasks in the `node` role, making things easier to understand. This will be
  important for the EVM-based network, where even more arguments for `safenode-manager` will be
  introduced.

- 9955fde **refactor: move extra vars functions to module**

  These functions were cluttering the `provisioning` module. They can be grouped along with
  other extra vars functions in the `extra_vars` module.

- 4027883 **refactor: remove duplicate `NodeType` struct**

  This struct had been duplicated, so one of them was deleted and the other was moved to sit alongside
  the other enums in the main `lib` module.
  
- a835236 **chore: remove redundant variables from node roles**