### PR TITLE
feat: extend `deploy` command to use arbitrum sepolia

### DIFF
--- a/resources/ansible/build.yml
+++ b/resources/ansible/build.yml
@@ -6,7 +6,7 @@
   roles:
     - {
         role: build_safe_network_binary,
-        bin_name: "autonomi_cli",
+        bin_name: "autonomi",
         when: custom_bin == "true"
       }
     - {

--- a/resources/ansible/roles/uploaders/defaults/main.yml
+++ b/resources/ansible/roles/uploaders/defaults/main.yml
@@ -1,3 +1,3 @@
 binary_dir: /usr/local/bin
-autonomi_archive_filename: autonomi_cli-latest-x86_64-unknown-linux-musl.tar.gz
+autonomi_archive_filename: autonomi-latest-x86_64-unknown-linux-musl.tar.gz
 autonomi_archive_url: https://sn-cli.s3.eu-west-2.amazonaws.com/{{ autonomi_archive_filename }}

--- a/resources/ansible/roles/uploaders/files/upload-random-data.sh
+++ b/resources/ansible/roles/uploaders/files/upload-random-data.sh
@@ -9,8 +9,8 @@ if [ -n "$CONTACT_PEER" ]; then
   CONTACT_PEER_ARG="--peer $CONTACT_PEER"
 fi
 
-if ! command -v autonomi_cli &> /dev/null; then
-  echo "Error: 'autonomi_cli' not found in PATH."
+if ! command -v autonomi &> /dev/null; then
+  echo "Error: 'autonomi' not found in PATH."
   exit 1
 fi
 
@@ -67,7 +67,7 @@ generate_random_data_file_and_upload() {
   file_size_kb=$(du -k "$tmpfile" | cut -f1)
 
   now=$(date +"%s")
-  stdout=$(autonomi_cli $CONTACT_PEER_ARG file upload "$tmpfile" 2>&1)
+  stdout=$(autonomi $CONTACT_PEER_ARG file upload "$tmpfile" 2>&1)
   echo "$stdout"
 
   if [ $? -eq 0 ]; then
@@ -97,5 +97,5 @@ for i in $(seq 1 $total_files); do
   generate_random_data_file_and_upload
   # prune_chunk_artifacts
   # TODO: re-enable when the new CLI has a `wallet balance` command
-  # echo "$(autonomi_cli $CONTACT_PEER_ARG wallet balance)"
+  # echo "$(autonomi $CONTACT_PEER_ARG wallet balance)"
 done

--- a/resources/ansible/roles/uploaders/tasks/main.yml
+++ b/resources/ansible/roles/uploaders/tasks/main.yml
@@ -1,22 +1,22 @@
 ---
-- name: check if autonomi_cli binary exists
+- name: check if autonomi binary exists
   ansible.builtin.stat:
-    path: "{{ binary_dir }}/autonomi_cli"
-  register: autonomi_cli_binary
+    path: "{{ binary_dir }}/autonomi"
+  register: autonomi_binary
 
-- name: download the autonomi_cli binary
+- name: download the autonomi binary
   ansible.builtin.get_url:
     url: "{{ autonomi_archive_url }}"
     dest: "/tmp/{{ autonomi_archive_filename }}"
-  when: not autonomi_cli_binary.stat.exists
+  when: not autonomi_binary.stat.exists
 
-- name: extract the autonomi_cli binary to /usr/local/bin
+- name: extract the autonomi binary to /usr/local/bin
   ansible.builtin.unarchive:
     src: "/tmp/{{ autonomi_archive_filename }}"
     dest: "{{ binary_dir }}"
     remote_src: true
   become: true
-  when: not autonomi_cli_binary.stat.exists
+  when: not autonomi_binary.stat.exists
 
 - name: create safe users
   ansible.builtin.user:
@@ -44,7 +44,7 @@
     group: root
     mode: '0644'
   become: yes
-  when: not autonomi_cli_binary.stat.exists
+  when: not autonomi_binary.stat.exists
 
 - name: start and enable autonomi_uploader service for each uploader
   ansible.builtin.systemd:

--- a/resources/ansible/roles/uploaders/templates/autonomi_uploader.service.j2
+++ b/resources/ansible/roles/uploaders/templates/autonomi_uploader.service.j2
@@ -4,9 +4,15 @@ After=network.target
 
 [Service]
 Environment="SECRET_KEY={{ autonomi_secret_key }}"
+{% if evm_network_type == "evm-custom" %}
 Environment="RPC_URL={{ evm_rpc_url }}"
 Environment="PAYMENT_TOKEN_ADDRESS={{ evm_payment_token_address }}"
 Environment="DATA_PAYMENTS_ADDRESS={{ evm_data_payments_address }}"
+{% elif evm_network_type == "evm-arbitrum-sepolia" %}
+Environment="EVM_NETWORK=arbitrum-sepolia"
+{% elif evm_network_type == "evm-arbitrum-one" %}
+Environment="EVM_NETWORK=arbitrum-one"
+{% endif %}
 User=safe%i
 ExecStart=/home/safe%i/upload-random-data.sh {{ genesis_multiaddr }}
 Restart=always

--- a/src/ansible/extra_vars.rs
+++ b/src/ansible/extra_vars.rs
@@ -244,7 +244,7 @@ impl ExtraVarsDocBuilder {
             self.variables.push((
                 "autonomi_archive_url".to_string(),
                 format!(
-                    "{}/autonomi_cli-{}-x86_64-unknown-linux-musl.tar.gz",
+                    "{}/autonomi-{}-x86_64-unknown-linux-musl.tar.gz",
                     SAFE_S3_BUCKET_URL, version
                 ),
             ));
@@ -258,7 +258,7 @@ impl ExtraVarsDocBuilder {
                 self.add_branch_url_variable(
                     "autonomi_archive_url",
                     &format!(
-                        "{}/{}/{}/autonomi_cli-{}-x86_64-unknown-linux-musl.tar.gz",
+                        "{}/{}/{}/autonomi-{}-x86_64-unknown-linux-musl.tar.gz",
                         NODE_S3_BUCKET_URL, repo_owner, branch, deployment_name
                     ),
                     branch,
@@ -271,7 +271,7 @@ impl ExtraVarsDocBuilder {
                     self.variables.push((
                         "autonomi_archive_url".to_string(),
                         format!(
-                            "{}/autonomi_cli-{}-x86_64-unknown-linux-musl.tar.gz",
+                            "{}/autonomi-{}-x86_64-unknown-linux-musl.tar.gz",
                             SAFE_S3_BUCKET_URL, version
                         ),
                     ));

--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -14,8 +14,8 @@ use crate::{
     deploy::DeployOptions,
     error::{Error, Result},
     inventory::{DeploymentNodeRegistries, VirtualMachine},
-    print_duration, BinaryOption, CloudProvider, EvmCustomTestnetData, LogFormat, NodeType,
-    SshClient, UpgradeOptions,
+    print_duration, BinaryOption, CloudProvider, EvmCustomTestnetData, EvmNetwork, LogFormat,
+    NodeType, SshClient, UpgradeOptions,
 };
 use log::{debug, error, trace};
 use semver::Version;
@@ -35,6 +35,7 @@ pub struct ProvisionOptions {
     pub chunk_size: Option<u64>,
     pub downloaders_count: u16,
     pub env_variables: Option<Vec<(String, String)>>,
+    pub evm_network: EvmNetwork,
     pub log_format: Option<LogFormat>,
     pub logstash_details: Option<(String, Vec<SocketAddr>)>,
     pub name: String,
@@ -52,6 +53,7 @@ pub struct ProvisionOptions {
     pub safe_version: Option<String>,
     pub uploaders_count: Option<u16>,
     pub rewards_address: String,
+    pub wallet_secret_key: Option<String>,
 }
 
 impl From<BootstrapOptions> for ProvisionOptions {
@@ -62,6 +64,7 @@ impl From<BootstrapOptions> for ProvisionOptions {
             chunk_size: None,
             downloaders_count: 0,
             env_variables: bootstrap_options.env_variables,
+            evm_network: bootstrap_options.evm_network,
             log_format: bootstrap_options.log_format,
             logstash_details: None,
             name: bootstrap_options.name,
@@ -76,6 +79,7 @@ impl From<BootstrapOptions> for ProvisionOptions {
             safe_version: None,
             uploaders_count: None,
             rewards_address: String::new(),
+            wallet_secret_key: None,
         }
     }
 }
@@ -88,6 +92,7 @@ impl From<DeployOptions> for ProvisionOptions {
             chunk_size: deploy_options.chunk_size,
             downloaders_count: deploy_options.downloaders_count,
             env_variables: deploy_options.env_variables,
+            evm_network: deploy_options.evm_network,
             log_format: deploy_options.log_format,
             logstash_details: deploy_options.logstash_details,
             name: deploy_options.name,
@@ -102,6 +107,7 @@ impl From<DeployOptions> for ProvisionOptions {
             safe_version: None,
             uploaders_count: Some(deploy_options.uploaders_count),
             rewards_address: deploy_options.rewards_address,
+            wallet_secret_key: deploy_options.wallet_secret_key,
         }
     }
 }
@@ -288,6 +294,7 @@ impl AnsibleProvisioner {
                 NodeType::Bootstrap,
                 None,
                 1,
+                options.evm_network.clone(),
                 evm_testnet_data,
             )?),
         )?;
@@ -382,6 +389,7 @@ impl AnsibleProvisioner {
                 node_type,
                 Some(initial_contact_peer.to_string()),
                 node_count,
+                options.evm_network.clone(),
                 evm_testnet_data,
             )?),
         )?;

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -39,6 +39,7 @@ pub struct DeployOptions {
     pub rewards_address: String,
     pub uploaders_count: u16,
     pub uploader_vm_count: Option<u16>,
+    pub wallet_secret_key: Option<String>,
 }
 
 impl TestnetDeployer {
@@ -56,6 +57,7 @@ impl TestnetDeployer {
             evm_node_count: match options.evm_network {
                 EvmNetwork::ArbitrumOne => Some(0),
                 EvmNetwork::Custom => Some(1),
+                EvmNetwork::ArbitrumSepolia => Some(0),
             },
             genesis_vm_count: Some(1),
             name: options.name.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,14 +129,16 @@ impl NodeType {
 pub enum EvmNetwork {
     #[default]
     ArbitrumOne,
+    ArbitrumSepolia,
     Custom,
 }
 
 impl std::fmt::Display for EvmNetwork {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            EvmNetwork::ArbitrumOne => write!(f, "arbitrum-one"),
-            EvmNetwork::Custom => write!(f, "custom"),
+            EvmNetwork::ArbitrumOne => write!(f, "evm-arbitrum-one"),
+            EvmNetwork::Custom => write!(f, "evm-custom"),
+            EvmNetwork::ArbitrumSepolia => write!(f, "evm-arbitrum-sepolia"),
         }
     }
 }
@@ -148,6 +150,7 @@ impl std::str::FromStr for EvmNetwork {
         match s.to_lowercase().as_str() {
             "arbitrum-one" => Ok(EvmNetwork::ArbitrumOne),
             "custom" => Ok(EvmNetwork::Custom),
+            "arbitrum-sepolia" => Ok(EvmNetwork::ArbitrumSepolia),
             _ => Err(format!("Invalid EVM network type: {}", s)),
         }
     }

--- a/src/upscale.rs
+++ b/src/upscale.rs
@@ -35,6 +35,7 @@ pub struct UpscaleOptions {
     pub plan: bool,
     pub public_rpc: bool,
     pub safe_version: Option<String>,
+    pub wallet_secret_key: Option<String>,
 }
 
 impl TestnetDeployer {
@@ -152,6 +153,7 @@ impl TestnetDeployer {
                 match options.current_inventory.environment_details.evm_network {
                     EvmNetwork::Custom => 1,
                     EvmNetwork::ArbitrumOne => 0,
+                    EvmNetwork::ArbitrumSepolia => 0,
                 },
             ),
             genesis_vm_count: Some(
@@ -191,6 +193,11 @@ impl TestnetDeployer {
             chunk_size: None,
             downloaders_count: options.downloaders_count,
             env_variables: None,
+            evm_network: options
+                .current_inventory
+                .environment_details
+                .evm_network
+                .clone(),
             log_format: None,
             logstash_details: None,
             name: options.current_inventory.name.clone(),
@@ -212,6 +219,7 @@ impl TestnetDeployer {
                 .clone(),
             safe_version: options.safe_version.clone(),
             uploaders_count: options.desired_uploaders_count,
+            wallet_secret_key: options.wallet_secret_key.clone(),
         };
         let mut node_provision_failed = false;
 


### PR DESCRIPTION
- 97ada2d **fix: replace autonomi cli references**

  The binary was renamed to `autonomi` rather than `autonomi_cli`.

- 70e58db **feat: extend `deploy` command to use arbitrum sepolia**

  In this setup, there may be some issues with using one wallet for multiple uploaders, but this
  should get us started.
