### PR TITLE
chore: replace old `sn-cli` bucket ref

### DIFF
--- a/resources/ansible/roles/uploaders/defaults/main.yml
+++ b/resources/ansible/roles/uploaders/defaults/main.yml
@@ -1,3 +1,1 @@
 binary_dir: /usr/local/bin
-autonomi_archive_filename: autonomi-latest-x86_64-unknown-linux-musl.tar.gz
-autonomi_archive_url: https://sn-cli.s3.eu-west-2.amazonaws.com/{{ autonomi_archive_filename }}

--- a/src/ansible/extra_vars.rs
+++ b/src/ansible/extra_vars.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 const NODE_S3_BUCKET_URL: &str = "https://sn-node.s3.eu-west-2.amazonaws.com";
 const NODE_MANAGER_S3_BUCKET_URL: &str = "https://sn-node-manager.s3.eu-west-2.amazonaws.com";
 const RPC_CLIENT_BUCKET_URL: &str = "https://sn-node-rpc-client.s3.eu-west-2.amazonaws.com";
-const SAFE_S3_BUCKET_URL: &str = "https://sn-cli.s3.eu-west-2.amazonaws.com";
+const SAFE_S3_BUCKET_URL: &str = "https://autonomi-cli.s3.eu-west-2.amazonaws.com";
 
 #[derive(Default)]
 pub struct ExtraVarsDocBuilder {


### PR DESCRIPTION
The new binary does not get uploaded here. This was only noticed now because it's the first time I've tried to deploy a versioned `autonomi`.

The default URL was also removed. There isn't a 'latest' version of this binary available anyway. The URL always needs to be passed.