### PR TITLE
feat: obtain listener addresses with quic protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4164,9 +4164,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "sn-releases"
-version = "0.2.6"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9160dd891b488e9a41b8e8a481a3f39648d58a94a19b177af863d93c7fc52a54"
+checksum = "7786e530f6940356aa4fbb110b6e9238d764653bc14df4a522f96096c26ac7d7"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ semver = { version = "1.0.20", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sn_service_management = "~0.2.8"
-sn-releases = "~0.2.3"
+sn-releases = "0.3.1"
 thiserror = "1.0.23"
 tar = "0.4"
 tempfile = "3.8.0"

--- a/resources/ansible/upgrade_uploaders.yml
+++ b/resources/ansible/upgrade_uploaders.yml
@@ -4,7 +4,7 @@
   become: True
   vars:
     safe_version: "{{ safe_version }}"
-    safe_archive_url: "https://sn-cli.s3.eu-west-2.amazonaws.com/safe-{{ safe_version }}-x86_64-unknown-linux-musl.tar.gz"
+    safe_archive_url: "https://autonomi-cli.s3.eu-west-2.amazonaws.com/safe-{{ safe_version }}-x86_64-unknown-linux-musl.tar.gz"
   tasks:
     - name: stop the uploader service
       systemd:

--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -428,50 +428,6 @@ impl AnsibleProvisioner {
         Ok(())
     }
 
-    /// Provision the faucet service on the genesis node and start it.
-    pub fn provision_and_start_faucet(
-        &self,
-        options: &ProvisionOptions,
-        genesis_multiaddr: &str,
-    ) -> Result<()> {
-        let start = Instant::now();
-        println!("Running ansible against genesis node to deploy and start faucet...");
-        self.ansible_runner.run_playbook(
-            AnsiblePlaybook::Faucet,
-            AnsibleInventoryType::Genesis,
-            Some(extra_vars::build_faucet_extra_vars_doc(
-                &self.cloud_provider.to_string(),
-                options,
-                genesis_multiaddr,
-                false,
-            )?),
-        )?;
-        print_duration(start.elapsed());
-        Ok(())
-    }
-
-    /// Stop the faucet service on the genesis node. If the faucet is not provisioned, this will also provision it.
-    pub fn provision_and_stop_faucet(
-        &self,
-        options: &ProvisionOptions,
-        genesis_multiaddr: &str,
-    ) -> Result<()> {
-        let start = Instant::now();
-        println!("Running ansible against genesis node stop the faucet...");
-        self.ansible_runner.run_playbook(
-            AnsiblePlaybook::Faucet,
-            AnsibleInventoryType::Genesis,
-            Some(extra_vars::build_faucet_extra_vars_doc(
-                &self.cloud_provider.to_string(),
-                options,
-                genesis_multiaddr,
-                true,
-            )?),
-        )?;
-        print_duration(start.elapsed());
-        Ok(())
-    }
-
     pub fn provision_safenode_rpc_client(
         &self,
         options: &ProvisionOptions,

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -432,10 +432,16 @@ impl NodeVirtualMachine {
                     .iter()
                     .map(|node| {
                         if let Some(listen_addresses) = &node.listen_addr {
-                            // It seems to be the case that the listening address with the public IP is
-                            // always in the second position. If this ever changes, we could do some
-                            // filtering to find the address that does not start with "127." or "10.".
-                            listen_addresses[1].to_string()
+                            // Find the public address with quic-v1 protocol
+                            listen_addresses.iter()
+                                .find(|&addr| {
+                                    let addr_str = addr.to_string();
+                                    addr_str.contains("/quic-v1") && 
+                                    !addr_str.starts_with("/ip4/127.0.0.1") && 
+                                    !addr_str.starts_with("/ip4/10.")
+                                })
+                                .map(|addr| addr.to_string())
+                                .unwrap_or_else(|| UNAVAILABLE_NODE.to_string())
                         } else {
                             UNAVAILABLE_NODE.to_string()
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,6 @@ pub enum BinaryOption {
     },
     /// Pre-built, versioned binaries will be fetched from S3.
     Versioned {
-        faucet_version: Option<Version>,
         safe_version: Option<Version>,
         safenode_version: Version,
         safenode_manager_version: Version,
@@ -1082,19 +1081,12 @@ pub async fn notify_slack(inventory: DeploymentInventory) -> Result<()> {
             message.push_str(&format!("Branch: {}\n", branch));
         }
         BinaryOption::Versioned {
-            ref faucet_version,
             ref safe_version,
             ref safenode_version,
             ref safenode_manager_version,
             ..
         } => {
             message.push_str("*Version Details*\n");
-            message.push_str(&format!(
-                "faucet version: {}\n",
-                faucet_version
-                    .as_ref()
-                    .map_or("None".to_string(), |v| v.to_string())
-            ));
             message.push_str(&format!(
                 "safe version: {}\n",
                 safe_version
@@ -1244,4 +1236,3 @@ pub async fn write_environment_details(
         .await?;
     Ok(())
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -828,8 +828,8 @@ pub fn get_genesis_multiaddr(
         .run_command(
             &genesis_ip,
             "root",
-            // fetch the first multiaddr if genesis is true and which does not contain the localhost addr.
-            "jq -r '.nodes[] | select(.genesis == true) | .listen_addr[] | select(contains(\"127.0.0.1\") | not)' /var/safenode-manager/node_registry.json | head -n 1",
+            // fetch the first public multiaddr with quic-v1 protocol for the genesis node
+            "jq -r '.nodes[] | select(.genesis == true) | .listen_addr[] | select(contains(\"127.0.0.1\") | not) | select(contains(\"quic-v1\"))' /var/safenode-manager/node_registry.json | head -n 1",
             false,
         )?.first()
         .cloned()
@@ -1244,3 +1244,4 @@ pub async fn write_environment_details(
         .await?;
     Ok(())
 }
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -2054,7 +2054,7 @@ async fn main() -> Result<()> {
                 provider,
                 safe_version,
             } => {
-                let version = get_version_from_option(safe_version, &ReleaseType::Safe).await?;
+                let version = get_version_from_option(safe_version, &ReleaseType::Autonomi).await?;
 
                 let testnet_deploy = TestnetDeployBuilder::default()
                     .environment_name(&name)
@@ -2239,15 +2239,13 @@ async fn get_binary_option(
     let binary_option = if use_versions {
         print_with_banner("Binaries will be supplied from pre-built versions");
 
-        let faucet_version = get_version_from_option(faucet_version, &ReleaseType::Faucet).await?;
-        let safe_version = get_version_from_option(safe_version, &ReleaseType::Safe).await?;
+        let safe_version = get_version_from_option(safe_version, &ReleaseType::Autonomi).await?;
         let safenode_version =
             get_version_from_option(safenode_version, &ReleaseType::Safenode).await?;
         let safenode_manager_version =
             get_version_from_option(safenode_manager_version, &ReleaseType::SafenodeManager)
                 .await?;
         BinaryOption::Versioned {
-            faucet_version: Some(faucet_version),
             safe_version: Some(safe_version),
             safenode_version,
             safenode_manager_version,

--- a/src/upscale.rs
+++ b/src/upscale.rs
@@ -243,7 +243,7 @@ impl TestnetDeployer {
 
         let should_provision_private_nodes = desired_private_node_vm_count > 0;
         let mut n = 1;
-        let mut total = if is_bootstrap_deploy { 3 } else { 6 };
+        let mut total = if is_bootstrap_deploy { 3 } else { 4 };
         if should_provision_private_nodes {
             total += 2;
         }
@@ -345,17 +345,6 @@ impl TestnetDeployer {
         }
 
         if !is_bootstrap_deploy {
-            // make sure faucet is running
-            self.ansible_provisioner
-                .print_ansible_run_banner(n, total, "Start Faucet");
-            self.ansible_provisioner
-                .provision_and_start_faucet(&provision_options, &initial_multiaddr)
-                .map_err(|err| {
-                    println!("Failed to stop faucet {err:?}");
-                    err
-                })?;
-            n += 1;
-
             self.wait_for_ssh_availability_on_new_machines(
                 AnsibleInventoryType::Uploaders,
                 &options.current_inventory,
@@ -366,16 +355,6 @@ impl TestnetDeployer {
                 .provision_uploaders(&provision_options, &initial_multiaddr, None)
                 .map_err(|err| {
                     println!("Failed to provision uploaders {err:?}");
-                    err
-                })?;
-            n += 1;
-
-            self.ansible_provisioner
-                .print_ansible_run_banner(n, total, "Stop Faucet");
-            self.ansible_provisioner
-                .provision_and_stop_faucet(&provision_options, &initial_multiaddr)
-                .map_err(|err| {
-                    println!("Failed to stop faucet {err:?}");
                     err
                 })?;
         }


### PR DESCRIPTION
- 70bc28c **feat: obtain listener addresses with quic protocol**

  We have now added the `websockets` feature to `safenode`, and this means it exposes `ws` listener
  addresses. We are only interested in the `quic-v1` addresses.

- 28438fa **feat: replace safe bin with autonomi**

  The `sn_releases` reference is updated to the latest version, which replaces the `ReleaseType::Safe`
  variant with `ReleaseType::Autonomi`, which will ensure the correct version of the client is
  obtained.

  The commit also removes other traces of the faucet that are no longer necessary. The
  `ReleaseType::Faucet` variant was removed from the latest version of `sn_releases`.