### PR TITLE
chore: align prod specs with environment

### DIFF
--- a/resources/terraform/testnet/digital-ocean/production.tfvars
+++ b/resources/terraform/testnet/digital-ocean/production.tfvars
@@ -1,11 +1,11 @@
-bootstrap_droplet_size = "c2-32vcpu-64gb-intel"
+bootstrap_droplet_size = "c-16"
 bootstrap_node_vm_count = 50
 bootstrap_droplet_image_id = 157362431
 evm_node_vm_count = 0
 evm_node_droplet_size = "s-4vcpu-8gb"
 evm_node_droplet_image_id = 167317579
 nat_gateway_droplet_image_id = 166664184
-node_droplet_size = "c2-48vcpu-96gb-intel"
+node_droplet_size = "c-16"
 node_vm_count = 79
 node_droplet_image_id = 157362431
 private_node_vm_count = 1


### PR DESCRIPTION
We used custom node sizes in the deployment, so this brings them in line.