### PR TITLE
feat: provide `uploaders upscale` command

### DIFF
--- a/resources/ansible/roles/uploaders/files/upload-random-data.sh
+++ b/resources/ansible/roles/uploaders/files/upload-random-data.sh
@@ -61,7 +61,7 @@ prune_chunk_artifacts() {
 # Generate a 10MB file of random data and log its reference
 generate_random_data_file_and_upload() {
   tmpfile=$(mktemp)
-  dd if=/dev/urandom of="$tmpfile" bs=15M count=1 iflag=fullblock &> /dev/null
+  dd if=/dev/urandom of="$tmpfile" bs=150M count=1 iflag=fullblock &> /dev/null
 
   echo "Generated random data file at $tmpfile"
   file_size_kb=$(du -k "$tmpfile" | cut -f1)

--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -18,6 +18,7 @@ use crate::{
     print_duration, BinaryOption, CloudProvider, EvmCustomTestnetData, EvmNetwork, LogFormat,
     NodeType, SshClient, UpgradeOptions,
 };
+use evmlib::common::U256;
 use log::{debug, error, trace};
 use semver::Version;
 use sn_service_management::NodeRegistry;
@@ -38,6 +39,7 @@ pub struct ProvisionOptions {
     pub env_variables: Option<Vec<(String, String)>>,
     pub evm_network: EvmNetwork,
     pub funding_wallet_secret_key: Option<String>,
+    pub gas_amount: Option<U256>,
     pub log_format: Option<LogFormat>,
     pub logstash_details: Option<(String, Vec<SocketAddr>)>,
     pub name: String,
@@ -67,6 +69,7 @@ impl From<BootstrapOptions> for ProvisionOptions {
             env_variables: bootstrap_options.env_variables,
             evm_network: bootstrap_options.evm_network,
             funding_wallet_secret_key: None,
+            gas_amount: None,
             log_format: bootstrap_options.log_format,
             logstash_details: None,
             max_archived_log_files: bootstrap_options.max_archived_log_files,
@@ -95,6 +98,7 @@ impl From<DeployOptions> for ProvisionOptions {
             env_variables: deploy_options.env_variables,
             evm_network: deploy_options.evm_network,
             funding_wallet_secret_key: deploy_options.funding_wallet_secret_key,
+            gas_amount: None,
             log_format: deploy_options.log_format,
             logstash_details: deploy_options.logstash_details,
             name: deploy_options.name,
@@ -464,7 +468,7 @@ impl AnsibleProvisioner {
                 evm_network: options.evm_network.clone(),
                 funding_wallet_secret_key: options.funding_wallet_secret_key.clone(),
                 token_amount: None,
-                gas_amount: None,
+                gas_amount: options.gas_amount,
             })
             .await?;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -69,6 +69,10 @@ pub enum Error {
     GetS3ObjectError(String, String),
     #[error(transparent)]
     InquireError(#[from] inquire::InquireError),
+    #[error(
+        "The '{0}' deployment type for the environment is not supported for upscaling uploaders"
+    )]
+    InvalidUploaderUpscaleDeploymentType(String),
     #[error("The desired auditor VM count is smaller than the current count. This is invalid for an upscale operation.")]
     InvalidUpscaleDesiredAuditorVmCount,
     #[error("The desired bootstrap VM count is smaller than the current count. This is invalid for an upscale operation.")]

--- a/src/funding.rs
+++ b/src/funding.rs
@@ -19,6 +19,11 @@ use log::{debug, error, warn};
 use std::collections::HashMap;
 use std::str::FromStr;
 
+/// 1 token (1e18)
+const DEFAULT_TOKEN_AMOUNT: &str = "1_000_000_000_000_000_000";
+/// 0.1 ETH (1e17)
+const DEFAULT_GAS_AMOUNT: &str = "100_000_000_000_000_000";
+
 pub struct FundingOptions {
     pub evm_network: EvmNetwork,
     pub custom_evm_testnet_data: Option<EvmCustomTestnetData>,
@@ -354,8 +359,8 @@ impl AnsibleProvisioner {
         println!("Funding wallet gas balance: {gas_balance}");
         debug!("Funding wallet token balance: {token_balance:?} and gas balance {gas_balance}");
 
-        let default_token_amount = U256::from_str("1_000_000_000_000_000_000").unwrap();
-        let default_gas_amount = U256::from_str("100_000_000_000_000_000").unwrap();
+        let default_token_amount = U256::from_str(DEFAULT_TOKEN_AMOUNT).unwrap();
+        let default_gas_amount = U256::from_str(DEFAULT_GAS_AMOUNT).unwrap();
 
         let tokens_for_each_uploader = options.token_amount.unwrap_or(default_token_amount);
         let gas_for_each_uploader = options.gas_amount.unwrap_or(default_gas_amount);


### PR DESCRIPTION
This upscales the uploaders on their own, as opposed to upscaling all the components of the network.

We also change the size of uploaded files from 15 to 150MB.