### PR TITLE
feat: provide `provision-only` argument

### DIFF
--- a/resources/terraform/testnet/digital-ocean/production.tfvars
+++ b/resources/terraform/testnet/digital-ocean/production.tfvars
@@ -1,12 +1,12 @@
 bootstrap_droplet_size = "c-16"
-bootstrap_node_vm_count = 50
+bootstrap_node_vm_count = 79
 bootstrap_droplet_image_id = 157362431
 evm_node_vm_count = 0
 evm_node_droplet_size = "s-4vcpu-8gb"
 evm_node_droplet_image_id = 167317579
 nat_gateway_droplet_image_id = 166664184
 node_droplet_size = "c-16"
-node_vm_count = 79
+node_vm_count = 100
 node_droplet_image_id = 157362431
 private_node_vm_count = 1
 setup_nat_gateway = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -1122,6 +1122,10 @@ enum UploadersCommands {
         /// This argument only applies when Arbitrum or Sepolia networks are used.
         #[clap(long)]
         funding_wallet_secret_key: Option<String>,
+        /// The amount of gas tokens to transfer to each uploader.
+        /// Must be a decimal value between 0 and 1, e.g. "0.1"
+        #[clap(long)]
+        gas_amount: Option<String>,
         /// Set to only use Terraform to upscale the VMs and not run Ansible.
         #[clap(long, default_value_t = false)]
         infra_only: bool,
@@ -1136,13 +1140,12 @@ enum UploadersCommands {
         /// The plan will run and then the command will exit without doing anything else.
         #[clap(long, default_value_t = false)]
         plan: bool,
+        /// Set to skip the Terraform infrastructure run and only run the Ansible provisioning.
+        #[clap(long, default_value_t = false)]
+        provision_only: bool,
         /// The cloud provider for the environment.
         #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
         provider: CloudProvider,
-        /// The amount of gas tokens to transfer to each uploader.
-        /// Must be a decimal value between 0 and 1, e.g. "0.1"
-        #[clap(long)]
-        gas_amount: Option<String>,
     },
 }
 
@@ -2365,6 +2368,7 @@ async fn main() -> Result<()> {
                 infra_only,
                 name,
                 plan,
+                provision_only,
                 provider,
             } => {
                 let gas_amount = if let Some(amount) = gas_amount {
@@ -2413,6 +2417,7 @@ async fn main() -> Result<()> {
                         max_log_files: 1,
                         infra_only,
                         plan,
+                        provision_only,
                         public_rpc: false,
                         safe_version: Some(autonomi_version),
                     })
@@ -2511,6 +2516,7 @@ async fn main() -> Result<()> {
                     max_log_files,
                     infra_only,
                     plan,
+                    provision_only: false,
                     public_rpc,
                     safe_version,
                 })

--- a/src/upscale.rs
+++ b/src/upscale.rs
@@ -38,6 +38,7 @@ pub struct UpscaleOptions {
     pub plan: bool,
     pub public_rpc: bool,
     pub safe_version: Option<String>,
+    pub provision_only: bool,
 }
 
 impl TestnetDeployer {
@@ -420,30 +421,32 @@ impl TestnetDeployer {
             return Ok(());
         }
 
-        self.create_or_update_infra(&InfraRunOptions {
-            bootstrap_node_vm_count: None,
-            bootstrap_node_vm_size: None,
-            enable_build_vm: false,
-            evm_node_count: None,
-            evm_node_vm_size: None,
-            genesis_vm_count: None,
-            name: options.current_inventory.name.clone(),
-            node_vm_count: None,
-            node_vm_size: None,
-            private_node_vm_count: None,
-            tfvars_filename: options
-                .current_inventory
-                .environment_details
-                .environment_type
-                .get_tfvars_filename()
-                .to_string(),
-            uploader_vm_count: Some(desired_uploader_vm_count),
-            uploader_vm_size: None,
-        })
-        .map_err(|err| {
-            println!("Failed to create infra {err:?}");
-            err
-        })?;
+        if !options.provision_only {
+            self.create_or_update_infra(&InfraRunOptions {
+                bootstrap_node_vm_count: None,
+                bootstrap_node_vm_size: None,
+                enable_build_vm: false,
+                evm_node_count: None,
+                evm_node_vm_size: None,
+                genesis_vm_count: None,
+                name: options.current_inventory.name.clone(),
+                node_vm_count: None,
+                node_vm_size: None,
+                private_node_vm_count: None,
+                tfvars_filename: options
+                    .current_inventory
+                    .environment_details
+                    .environment_type
+                    .get_tfvars_filename()
+                    .to_string(),
+                uploader_vm_count: Some(desired_uploader_vm_count),
+                uploader_vm_size: None,
+            })
+            .map_err(|err| {
+                println!("Failed to create infra {err:?}");
+                err
+            })?;
+        }
 
         if options.infra_only {
             return Ok(());


### PR DESCRIPTION
- 3c68ff4 **chore: align current production counts**

  These new values bring the production defaults in line with how much they have been upscaled to.

- a72adc9 **feat: provide `provision-only` argument**

  This offers the ability to only run the Ansible provision and not the Terraform run.