### PR TITLE
chore: revert upload file size to 15mb

### DIFF
--- a/resources/ansible/roles/uploaders/files/upload-random-data.sh
+++ b/resources/ansible/roles/uploaders/files/upload-random-data.sh
@@ -61,7 +61,7 @@ prune_chunk_artifacts() {
 # Generate a 10MB file of random data and log its reference
 generate_random_data_file_and_upload() {
   tmpfile=$(mktemp)
-  dd if=/dev/urandom of="$tmpfile" bs=150M count=1 iflag=fullblock &> /dev/null
+  dd if=/dev/urandom of="$tmpfile" bs=15M count=1 iflag=fullblock &> /dev/null
 
   echo "Generated random data file at $tmpfile"
   file_size_kb=$(du -k "$tmpfile" | cut -f1)


### PR DESCRIPTION
Yesterday we increased this to 150mb to get some more data flowing through the production network, but it contributed to a development comparison filling up its disk space quite quickly.

For now we will revert back to 15, but shortly we can make it a configurable value.