### PR TITLE
feat: introduce cmd to stop all running nodes

### DIFF
--- a/resources/ansible/stop_nodes.yml
+++ b/resources/ansible/stop_nodes.yml
@@ -1,0 +1,9 @@
+---
+- name: ensure all nodes are stopped using the node manager
+  hosts: all
+  become: True
+  vars:
+    interval: "{{ interval }}"
+  tasks:
+    - name: stop all nodes
+      ansible.builtin.command: safenode-manager stop --interval {{ interval }}

--- a/src/ansible/extra_vars.rs
+++ b/src/ansible/extra_vars.rs
@@ -18,7 +18,7 @@ const NODE_MANAGER_S3_BUCKET_URL: &str = "https://sn-node-manager.s3.eu-west-2.a
 const RPC_CLIENT_BUCKET_URL: &str = "https://sn-node-rpc-client.s3.eu-west-2.amazonaws.com";
 const AUTONOMI_S3_BUCKET_URL: &str = "https://autonomi-cli.s3.eu-west-2.amazonaws.com";
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ExtraVarsDocBuilder {
     map: serde_json::Map<String, Value>,
 }

--- a/src/ansible/mod.rs
+++ b/src/ansible/mod.rs
@@ -135,6 +135,11 @@ pub enum AnsiblePlaybook {
     StartUploaders,
     /// This playbook will stop the faucet for the environment.
     StopFaucet,
+    /// The stop nodes playbook will use the node manager to stop any node services on any
+    /// machines it runs against.
+    ///
+    /// Use in combination with `AnsibleInventoryType::Genesis` or `AnsibleInventoryType::Nodes`.
+    StopNodes,
     /// This playbook will stop the Telegraf service running on each machine.
     ///
     /// It can be necessary for running upgrades, since Telegraf will run `safenode-manager
@@ -185,6 +190,7 @@ impl AnsiblePlaybook {
             AnsiblePlaybook::StartUploaders => "start_uploaders.yml".to_string(),
             AnsiblePlaybook::Status => "node_status.yml".to_string(),
             AnsiblePlaybook::StopFaucet => "stop_faucet.yml".to_string(),
+            AnsiblePlaybook::StopNodes => "stop_nodes.yml".to_string(),
             AnsiblePlaybook::StopTelegraf => "stop_telegraf.yml".to_string(),
             AnsiblePlaybook::StopUploaders => "stop_uploaders.yml".to_string(),
             AnsiblePlaybook::UpgradeNodeManager => "upgrade_node_manager.yml".to_string(),

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -111,7 +111,7 @@ impl TestnetDeployer {
         match self.ansible_provisioner.provision_nodes(
             &provision_options,
             &options.bootstrap_peer,
-            NodeType::Normal,
+            NodeType::Generic,
             options.evm_custom_testnet_data.clone(),
         ) {
             Ok(()) => {

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -214,7 +214,7 @@ impl TestnetDeployer {
         match self.ansible_provisioner.provision_nodes(
             &provision_options,
             &genesis_multiaddr,
-            NodeType::Normal,
+            NodeType::Generic,
             evm_testnet_data.clone(),
         ) {
             Ok(()) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@
 // This SAFE Network Software is licensed under the BSD-3-Clause license.
 // Please see the LICENSE file for more details.
 
-use crate::ansible::inventory::AnsibleInventoryType;
+use crate::{ansible::inventory::AnsibleInventoryType, NodeType};
 use evmlib::contract::network_token;
 use thiserror::Error;
 use tokio::task::JoinError;
@@ -69,6 +69,8 @@ pub enum Error {
     GetS3ObjectError(String, String),
     #[error(transparent)]
     InquireError(#[from] inquire::InquireError),
+    #[error("The node type '{0:?}' is not supported")]
+    InvalidNodeType(NodeType),
     #[error(
         "The '{0}' deployment type for the environment is not supported for upscaling uploaders"
     )]

--- a/src/error.rs
+++ b/src/error.rs
@@ -125,6 +125,8 @@ pub enum Error {
     NoFaucetError,
     #[error("This deployment does not have any uploaders. It may be a bootstrap deployment.")]
     NoUploadersError,
+    #[error("The node count for the provided custom vms are not equal")]
+    NodeCountMismatch,
     #[error("Could not obtain a multiaddr from the node inventory")]
     NodeAddressNotFound,
     #[error("Failed to upload {0} to S3 bucket {1}")]

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -533,6 +533,12 @@ pub struct NodeVirtualMachine {
     pub safenodemand_endpoint: Option<SocketAddr>,
 }
 
+impl NodeVirtualMachine {
+    pub fn node_count(&self) -> usize {
+        self.node_multiaddr.len()
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 pub struct VirtualMachine {
     pub id: u64,
@@ -669,20 +675,12 @@ impl DeploymentInventory {
         list
     }
 
-    pub fn node_vm_list(&self) -> Vec<VirtualMachine> {
+    pub fn node_vm_list(&self) -> Vec<NodeVirtualMachine> {
         let mut list = Vec::new();
-        list.extend(
-            self.bootstrap_node_vms
-                .iter()
-                .map(|node_vm| node_vm.vm.clone()),
-        );
-        list.extend(self.genesis_vm.iter().map(|node_vm| node_vm.vm.clone()));
-        list.extend(self.node_vms.iter().map(|node_vm| node_vm.vm.clone()));
-        list.extend(
-            self.private_node_vms
-                .iter()
-                .map(|node_vm| node_vm.vm.clone()),
-        );
+        list.extend(self.bootstrap_node_vms.iter().cloned());
+        list.extend(self.genesis_vm.iter().cloned());
+        list.extend(self.node_vms.iter().cloned());
+        list.extend(self.private_node_vms.iter().cloned());
 
         list
     }
@@ -737,7 +735,7 @@ impl DeploymentInventory {
 
     pub fn bootstrap_node_count(&self) -> usize {
         if let Some(first_vm) = self.bootstrap_node_vms.first() {
-            first_vm.node_multiaddr.len()
+            first_vm.node_count()
         } else {
             0
         }
@@ -745,7 +743,7 @@ impl DeploymentInventory {
 
     pub fn genesis_node_count(&self) -> usize {
         if let Some(genesis_vm) = &self.genesis_vm {
-            genesis_vm.node_multiaddr.len()
+            genesis_vm.node_count()
         } else {
             0
         }
@@ -753,7 +751,7 @@ impl DeploymentInventory {
 
     pub fn node_count(&self) -> usize {
         if let Some(first_vm) = self.node_vms.first() {
-            first_vm.node_multiaddr.len()
+            first_vm.node_count()
         } else {
             0
         }
@@ -761,7 +759,7 @@ impl DeploymentInventory {
 
     pub fn private_node_count(&self) -> usize {
         if let Some(first_vm) = self.private_node_vms.first() {
-            first_vm.node_multiaddr.len()
+            first_vm.node_count()
         } else {
             0
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -683,6 +683,16 @@ impl TestnetDeployer {
         Ok(())
     }
 
+    pub fn stop(
+        &self,
+        interval: Duration,
+        custom_inventory: Option<Vec<VirtualMachine>>,
+    ) -> Result<()> {
+        self.ansible_provisioner
+            .stop_nodes(&self.environment_name, interval, custom_inventory)?;
+        Ok(())
+    }
+
     pub fn stop_telegraf(&self, custom_inventory: Option<Vec<VirtualMachine>>) -> Result<()> {
         self.ansible_provisioner
             .stop_telegraf(&self.environment_name, custom_inventory)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -713,6 +713,12 @@ enum Commands {
         /// The name of the environment
         #[arg(short = 'n', long)]
         name: String,
+        /// Specify the type of node VM to upgrade the safenode services on. If not provided, the safenode services on
+        /// all the node VMs will be upgraded. This is mutually exclusive with the '--custom-inventory' argument.
+        ///
+        /// Valid values are "bootstrap", "genesis", "generic" and "private".
+        #[arg(long, conflicts_with = "custom-inventory")]
+        node_type: Option<NodeType>,
         /// The cloud provider to deploy to.
         ///
         /// Valid values are "aws" or "digital-ocean".
@@ -740,6 +746,13 @@ enum Commands {
         /// The name of the environment
         #[arg(short = 'n', long)]
         name: String,
+        /// Specify the type of node VM to upgrade the safenode-manager services on. If not provided, the
+        /// safenode-manager on all the node VMs will be upgraded.
+        /// This is mutually exclusive with the '--custom-inventory' argument.
+        ///
+        /// Valid values are "bootstrap", "genesis", "generic" and "private".
+        #[arg(long, conflicts_with = "custom-inventory")]
+        node_type: Option<NodeType>,
         #[arg(long)]
         /// The cloud provider of the environment.
         ///
@@ -2235,6 +2248,7 @@ async fn main() -> Result<()> {
             forks,
             interval,
             name,
+            node_type,
             provider,
             version,
         } => {
@@ -2276,6 +2290,7 @@ async fn main() -> Result<()> {
                 forks,
                 interval,
                 name: name.clone(),
+                node_type,
                 provider,
                 version,
             })?;
@@ -2293,6 +2308,7 @@ async fn main() -> Result<()> {
         Commands::UpgradeNodeManager {
             custom_inventory,
             name,
+            node_type,
             provider,
             version,
         } => {
@@ -2316,7 +2332,7 @@ async fn main() -> Result<()> {
                 None
             };
 
-            testnet_deployer.upgrade_node_manager(version.parse()?, custom_inventory)?;
+            testnet_deployer.upgrade_node_manager(version.parse()?, node_type, custom_inventory)?;
             Ok(())
         }
         Commands::UpgradeNodeTelegrafConfig {

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use sn_testnet_deploy::{
     setup::setup_dotenv_file,
     upscale::UpscaleOptions,
     BinaryOption, CloudProvider, EnvironmentType, EvmCustomTestnetData, EvmNetwork, LogFormat,
-    TestnetDeployBuilder, UpgradeOptions,
+    NodeType, TestnetDeployBuilder, UpgradeOptions,
 };
 use std::{env, net::IpAddr};
 use std::{str::FromStr, time::Duration};
@@ -574,6 +574,12 @@ enum Commands {
         /// The name of the environment.
         #[arg(short = 'n', long)]
         name: String,
+        /// Specify the type of node VM to start the safenode services on. If not provided, the safenode services on
+        /// all the node VMs will be started. This is mutually exclusive with the '--custom-inventory' argument.
+        ///
+        /// Valid values are "bootstrap", "genesis", "generic" and "private".
+        #[arg(long, conflicts_with = "custom-inventory")]
+        node_type: Option<NodeType>,
         /// The cloud provider for the environment.
         #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
         provider: CloudProvider,
@@ -607,6 +613,12 @@ enum Commands {
         /// The name of the environment.
         #[arg(short = 'n', long)]
         name: String,
+        /// Specify the type of node VM to start the telegraf services on. If not provided, the telegraf services on
+        /// all the node VMs will be started. This is mutually exclusive with the '--custom-inventory' argument.
+        ///
+        /// Valid values are "bootstrap", "genesis", "generic" and "private".
+        #[arg(long, conflicts_with = "custom-inventory")]
+        node_type: Option<NodeType>,
         /// The cloud provider for the environment.
         #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
         provider: CloudProvider,
@@ -628,6 +640,12 @@ enum Commands {
         /// The name of the environment.
         #[arg(short = 'n', long)]
         name: String,
+        /// Specify the type of node VM to stop the safenode services on. If not provided, the safenode services on
+        /// all the node VMs will be stopped. This is mutually exclusive with the '--custom-inventory' argument.
+        ///
+        /// Valid values are "bootstrap", "genesis", "generic" and "private".
+        #[arg(long, conflicts_with = "custom-inventory")]
+        node_type: Option<NodeType>,
         /// The cloud provider for the environment.
         #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
         provider: CloudProvider,
@@ -648,6 +666,12 @@ enum Commands {
         /// The name of the environment.
         #[arg(short = 'n', long)]
         name: String,
+        /// Specify the type of node VM to stop the telegraf services on. If not provided, the telegraf services on
+        /// all the node VMs will be stopped. This is mutually exclusive with the '--custom-inventory' argument.
+        ///
+        /// Valid values are "bootstrap", "genesis", "generic" and "private".
+        #[arg(long, conflicts_with = "custom-inventory")]
+        node_type: Option<NodeType>,
         /// The cloud provider for the environment.
         #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
         provider: CloudProvider,
@@ -2008,6 +2032,7 @@ async fn main() -> Result<()> {
             forks,
             interval,
             name,
+            node_type,
             provider,
         } => {
             let testnet_deployer = TestnetDeployBuilder::default()
@@ -2034,7 +2059,7 @@ async fn main() -> Result<()> {
                 None
             };
 
-            testnet_deployer.start(interval, custom_inventory)?;
+            testnet_deployer.start(interval, node_type, custom_inventory)?;
 
             Ok(())
         }
@@ -2042,6 +2067,7 @@ async fn main() -> Result<()> {
             custom_inventory,
             forks,
             name,
+            node_type,
             provider,
         } => {
             let testnet_deployer = TestnetDeployBuilder::default()
@@ -2068,7 +2094,7 @@ async fn main() -> Result<()> {
                 None
             };
 
-            testnet_deployer.start_telegraf(custom_inventory)?;
+            testnet_deployer.start_telegraf(node_type, custom_inventory)?;
 
             Ok(())
         }
@@ -2102,6 +2128,7 @@ async fn main() -> Result<()> {
             forks,
             interval,
             name,
+            node_type,
             provider,
         } => {
             let testnet_deployer = TestnetDeployBuilder::default()
@@ -2125,7 +2152,7 @@ async fn main() -> Result<()> {
                 None
             };
 
-            testnet_deployer.stop(interval, custom_inventory)?;
+            testnet_deployer.stop(interval, node_type, custom_inventory)?;
 
             Ok(())
         }
@@ -2133,6 +2160,7 @@ async fn main() -> Result<()> {
             custom_inventory,
             forks,
             name,
+            node_type,
             provider,
         } => {
             let testnet_deployer = TestnetDeployBuilder::default()
@@ -2159,7 +2187,7 @@ async fn main() -> Result<()> {
                 None
             };
 
-            testnet_deployer.stop_telegraf(custom_inventory)?;
+            testnet_deployer.stop_telegraf(node_type, custom_inventory)?;
 
             Ok(())
         }

--- a/src/upscale.rs
+++ b/src/upscale.rs
@@ -294,7 +294,7 @@ impl TestnetDeployer {
         match self.ansible_provisioner.provision_nodes(
             &provision_options,
             &initial_multiaddr,
-            NodeType::Normal,
+            NodeType::Generic,
             evm_testnet_data.clone(),
         ) {
             Ok(()) => {


### PR DESCRIPTION
- stop all running nodes with `--interval` option. Depends on the safenode-manager upgraded to use this commit https://github.com/maidsafe/safe_network/pull/2385
- stop/start nodes or telegraph on specific node types.
- upgrade safenode/safenode-manager on speicifc node types