### PR TITLE
feat: provide `--pre-upgrade-delay` arg

### DIFF
--- a/resources/ansible/upgrade_nodes.yml
+++ b/resources/ansible/upgrade_nodes.yml
@@ -2,15 +2,23 @@
 - name: upgrade node binaries using the node manager
   hosts: all
   tasks:
-    - name: upgrade
-      ansible.builtin.command:
-        # The `omit` filter removes arguments without values
-        argv: "{{ command_args | reject('equalto', omit) | list }}"
-      vars:
-        command_args:
-          - safenode-manager
-          - upgrade
-          - --interval={{ interval }}
-          - "{{ '--force' if force_safenode is defined else omit }}"
-          - "{{ ('--env=' + env_variables) if env_variables is defined else omit }}"
-          - "{{ ('--version=' + safenode_version) if safenode_version is defined else omit }}"
+    # There is an optional delay that can be applied before the upgrade starts.
+    # This is useful for when there is one node per machine.
+    - name: upgrade nodes
+      ansible.builtin.shell: |
+        {% if pre_upgrade_delay is defined %}
+        sleep {{ pre_upgrade_delay | default(0) }}
+        {% endif %}
+        cmd="safenode-manager upgrade --interval={{ interval }}"
+        {% if force_safenode is defined %}
+        cmd="$cmd --force"
+        {% endif %}
+        {% if env_variables is defined %}
+        cmd="$cmd --env={{ env_variables }}"
+        {% endif %}
+        {% if safenode_version is defined %}
+        cmd="$cmd --version={{ safenode_version }}"
+        {% endif %}
+        eval "$cmd"
+      args:
+        executable: /bin/bash

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,6 +369,7 @@ pub struct UpgradeOptions {
     pub interval: Duration,
     pub name: String,
     pub node_type: Option<NodeType>,
+    pub pre_upgrade_delay: Option<u64>,
     pub provider: CloudProvider,
     pub version: Option<String>,
 }
@@ -385,6 +386,9 @@ impl UpgradeOptions {
         }
         if let Some(version) = &self.version {
             extra_vars.add_variable("safenode_version", version);
+        }
+        if let Some(pre_upgrade_delay) = &self.pre_upgrade_delay {
+            extra_vars.add_variable("pre_upgrade_delay", &pre_upgrade_delay.to_string());
         }
         extra_vars.build()
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -725,6 +725,11 @@ enum Commands {
         /// Valid values are "bootstrap", "genesis", "generic" and "private".
         #[arg(long, conflicts_with = "custom-inventory")]
         node_type: Option<NodeType>,
+        /// Delay before an upgrade starts.
+        ///
+        /// Useful for upgrading bootstrap nodes when there is one node per machine.
+        #[clap(long)]
+        pre_upgrade_delay: Option<u64>,
         /// The cloud provider to deploy to.
         ///
         /// Valid values are "aws" or "digital-ocean".
@@ -2263,6 +2268,7 @@ async fn main() -> Result<()> {
             name,
             node_type,
             provider,
+            pre_upgrade_delay,
             version,
         } => {
             // The upgrade intentionally uses a small value for `forks`, but this is far too slow
@@ -2305,6 +2311,7 @@ async fn main() -> Result<()> {
                 name: name.clone(),
                 node_type,
                 provider,
+                pre_upgrade_delay,
                 version,
             })?;
 


### PR DESCRIPTION
The `upgrade` command can use this delay when there is only one node per machine. Bootstrap nodes can typically be deployed like this.

Without this, even using one fork, there would be no delay between servicing each machine in the inventory.