### PR TITLE
feat: capture all listener addresses in inventory

### DIFF
--- a/resources/ansible/start_telegraf.yml
+++ b/resources/ansible/start_telegraf.yml
@@ -3,7 +3,7 @@
   hosts: all
   become: True
   tasks:
-    - name: stop telegraf service
+    - name: start telegraf service
       systemd:
         name: telegraf
         enabled: yes

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -996,6 +996,45 @@ impl DeploymentInventory {
             .find(|vm| vm.name.contains("genesis"))
             .map(|vm| vm.public_ip_addr)
     }
+
+    pub fn print_bootstrap_listeners(&self) {
+        println!("=======================");
+        println!("Bootstrap Node Listeners");
+        println!("=======================");
+
+        let mut quic_listeners = Vec::new();
+        let mut ws_listeners = Vec::new();
+
+        for node_vm in &self.bootstrap_node_vms {
+            for addresses in &node_vm.node_listen_addresses {
+                for addr in addresses {
+                    if !addr.starts_with("/ip4/127.0.0.1") && !addr.starts_with("/ip4/10.") {
+                        if addr.contains("/quic") {
+                            quic_listeners.push(addr.clone());
+                        } else if addr.contains("/ws") {
+                            ws_listeners.push(addr.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        if !quic_listeners.is_empty() {
+            println!("QUIC:");
+            for addr in quic_listeners {
+                println!("  {addr}");
+            }
+            println!();
+        }
+
+        if !ws_listeners.is_empty() {
+            println!("Websocket:");
+            for addr in ws_listeners {
+                println!("  {addr}");
+            }
+            println!();
+        }
+    }
 }
 
 pub fn get_data_directory() -> Result<PathBuf> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -525,6 +525,9 @@ enum Commands {
         /// This is useful if the testnet was created on another machine.
         #[clap(long, default_value_t = false)]
         force_regeneration: bool,
+        /// If set to true, all non-local listener addresses will be printed for each peer.
+        #[clap(long, default_value_t = false)]
+        full: bool,
         /// The name of the environment
         #[arg(short = 'n', long)]
         name: String,
@@ -1472,7 +1475,7 @@ async fn main() -> Result<()> {
             let new_inventory = inventory_service
                 .generate_or_retrieve_inventory(&name, true, None)
                 .await?;
-            new_inventory.print_report()?;
+            new_inventory.print_report(false)?;
             new_inventory.save()?;
             Ok(())
         }
@@ -1672,7 +1675,7 @@ async fn main() -> Result<()> {
                 }
             };
 
-            inventory.print_report()?;
+            inventory.print_report(false)?;
             inventory.save()?;
 
             inventory_service
@@ -1849,6 +1852,7 @@ async fn main() -> Result<()> {
         },
         Commands::Inventory {
             force_regeneration,
+            full,
             name,
             network_contacts_file_name,
             provider,
@@ -1862,7 +1866,7 @@ async fn main() -> Result<()> {
             let inventory = inventory_service
                 .generate_or_retrieve_inventory(&name, force_regeneration, None)
                 .await?;
-            inventory.print_report()?;
+            inventory.print_report(full)?;
             inventory.save()?;
 
             inventory_service
@@ -2583,7 +2587,7 @@ async fn main() -> Result<()> {
                     }
                 };
 
-                inventory.print_report()?;
+                inventory.print_report(false)?;
                 inventory.save()?;
 
                 Ok(())
@@ -2718,7 +2722,7 @@ async fn main() -> Result<()> {
                 }
             };
 
-            inventory.print_report()?;
+            inventory.print_report(false)?;
             inventory.save()?;
 
             Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -520,6 +520,9 @@ enum Commands {
     #[clap(name = "funds", subcommand)]
     Funds(FundsCommand),
     Inventory {
+        /// If set to true, only print the bootstrap listeners.
+        #[clap(long, default_value_t = false)]
+        bootstrap: bool,
         /// If set to true, the inventory will be regenerated.
         ///
         /// This is useful if the testnet was created on another machine.
@@ -1851,6 +1854,7 @@ async fn main() -> Result<()> {
             }
         },
         Commands::Inventory {
+            bootstrap,
             force_regeneration,
             full,
             name,
@@ -1866,7 +1870,13 @@ async fn main() -> Result<()> {
             let inventory = inventory_service
                 .generate_or_retrieve_inventory(&name, force_regeneration, None)
                 .await?;
-            inventory.print_report(full)?;
+
+            if bootstrap {
+                inventory.print_bootstrap_listeners();
+            } else {
+                inventory.print_report(full)?;
+            }
+
             inventory.save()?;
 
             inventory_service


### PR DESCRIPTION
Now that we have websockets enabled, there is an interest in finding listener addresses that are not using QUIC.

We now store all the listener addresses, and we can filter them when reporting. The `inventory` command adds an optional `full` flag that will print the whole list, grouped by QUIC and websockets.

For some reason there was a filter applied to the printing of peers with respect to a bootstrap deployment. That was removed. I can't think why I added it in the first place; it would be useful to print the peers even if the deployment is a bootstrap type.