### PR TITLE
feat: provide `delay` for `start` command

### DIFF
--- a/resources/ansible/stop_nodes.yml
+++ b/resources/ansible/stop_nodes.yml
@@ -1,9 +1,15 @@
 ---
-- name: ensure all nodes are stopped using the node manager
+- name: stop nodes using the node manager
   hosts: all
   become: True
   vars:
     interval: "{{ interval }}"
   tasks:
-    - name: stop all nodes
-      ansible.builtin.command: safenode-manager stop --interval {{ interval }}
+    - name: stop nodes
+      ansible.builtin.shell: |
+        {% if delay is defined %}
+        sleep {{ delay | default(0) }}
+        {% endif %}
+        safenode-manager stop --interval {{ interval }}
+      args:
+        executable: /bin/bash

--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -602,16 +602,21 @@ impl AnsibleProvisioner {
         interval: Duration,
         node_type: Option<NodeType>,
         custom_inventory: Option<Vec<VirtualMachine>>,
+        delay: Option<u64>,
     ) -> Result<()> {
         let mut extra_vars = ExtraVarsDocBuilder::default();
         extra_vars.add_variable("interval", &interval.as_millis().to_string());
+        if let Some(delay) = delay {
+            extra_vars.add_variable("delay", &delay.to_string());
+        }
+        let extra_vars = extra_vars.build();
 
         if let Some(node_type) = node_type {
             println!("Running the stop nodes playbook for {node_type:?} nodes");
             self.ansible_runner.run_playbook(
                 AnsiblePlaybook::StopNodes,
                 node_type.to_ansible_inventory_type(),
-                Some(extra_vars.build()),
+                Some(extra_vars),
             )?;
             return Ok(());
         }
@@ -626,7 +631,7 @@ impl AnsibleProvisioner {
             self.ansible_runner.run_playbook(
                 AnsiblePlaybook::StopNodes,
                 AnsibleInventoryType::Custom,
-                Some(extra_vars.build()),
+                Some(extra_vars),
             )?;
             return Ok(());
         }
@@ -636,7 +641,7 @@ impl AnsibleProvisioner {
             self.ansible_runner.run_playbook(
                 AnsiblePlaybook::StopNodes,
                 node_inv_type,
-                Some(extra_vars.build()),
+                Some(extra_vars.clone()),
             )?;
         }
 

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 use alloy::hex::ToHexExt;
 use color_eyre::{eyre::eyre, Result};
+use log::debug;
 use rand::seq::{IteratorRandom, SliceRandom};
 use semver::Version;
 use serde::{Deserialize, Serialize};
@@ -998,9 +999,9 @@ impl DeploymentInventory {
     }
 
     pub fn print_bootstrap_listeners(&self) {
-        println!("=======================");
+        println!("========================");
         println!("Bootstrap Node Listeners");
-        println!("=======================");
+        println!("========================");
 
         let mut quic_listeners = Vec::new();
         let mut ws_listeners = Vec::new();
@@ -1010,27 +1011,32 @@ impl DeploymentInventory {
                 for addr in addresses {
                     if !addr.starts_with("/ip4/127.0.0.1") && !addr.starts_with("/ip4/10.") {
                         if addr.contains("/quic") {
-                            quic_listeners.push(addr.clone());
+                            quic_listeners.push((node_vm.vm.name.clone(), addr.clone()));
                         } else if addr.contains("/ws") {
-                            ws_listeners.push(addr.clone());
+                            ws_listeners.push((node_vm.vm.name.clone(), addr.clone()));
                         }
                     }
                 }
             }
         }
 
+        quic_listeners.sort_by(|a, b| a.0.cmp(&b.0));
+        ws_listeners.sort_by(|a, b| a.0.cmp(&b.0));
+
         if !quic_listeners.is_empty() {
             println!("QUIC:");
-            for addr in quic_listeners {
+            for (vm_name, addr) in &quic_listeners {
                 println!("  {addr}");
+                debug!("  {vm_name}: {addr}");
             }
             println!();
         }
 
         if !ws_listeners.is_empty() {
             println!("Websocket:");
-            for addr in ws_listeners {
+            for (vm_name, addr) in &ws_listeners {
                 println!("  {addr}");
+                debug!("  {vm_name}: {addr}");
             }
             println!();
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -731,12 +731,14 @@ impl TestnetDeployer {
         interval: Duration,
         node_type: Option<NodeType>,
         custom_inventory: Option<Vec<VirtualMachine>>,
+        delay: Option<u64>,
     ) -> Result<()> {
         self.ansible_provisioner.stop_nodes(
             &self.environment_name,
             interval,
             node_type,
             custom_inventory,
+            delay,
         )?;
         Ok(())
     }


### PR DESCRIPTION
- 55bd63e **chore: order bootstrap peers by vm name**


- f450d3b **feat: provide `delay` for `start` command**

  Similar to the `upgrade` command, this can be used when we want to stop nodes when there is only one
  running on each machine.