### PR TITLE
feat: provide `update-peer` command

### DIFF
--- a/resources/ansible/update_peer.yml
+++ b/resources/ansible/update_peer.yml
@@ -1,0 +1,13 @@
+---
+- name: Update peer in node registry
+  hosts: all
+  become: true
+  vars:
+    peer: "{{ peer }}"
+
+  tasks:
+    - name: Update bootstrap peer in node registry
+      ansible.builtin.replace:
+        path: /var/safenode-manager/node_registry.json
+        regexp: '("bootstrap_peers":\s*\[")[^"]+(")'
+        replace: '\1{{ peer }}\2'

--- a/src/ansible/inventory.rs
+++ b/src/ansible/inventory.rs
@@ -282,11 +282,13 @@ pub fn generate_custom_environment_inventory(
 ) -> Result<()> {
     let dest_path = output_inventory_dir_path
         .join(AnsibleInventoryType::Custom.get_inventory_path(environment_name, "digital_ocean"));
+    debug!("Creating custom inventory file at {dest_path:#?}");
     let file = File::create(&dest_path)?;
     let mut writer = BufWriter::new(file);
 
     writeln!(writer, "[custom]")?;
     for vm in vm_list.iter() {
+        debug!("Adding VM to custom inventory: {}", vm.public_ip_addr);
         writeln!(writer, "{}", vm.public_ip_addr)?;
     }
 

--- a/src/ansible/mod.rs
+++ b/src/ansible/mod.rs
@@ -165,6 +165,8 @@ pub enum AnsiblePlaybook {
     ///
     /// Use in combination with `AnsibleInventoryType::Uploaders`.
     Uploaders,
+    /// The update peer playbook will update the peer multiaddr in all node service definitions.
+    UpdatePeer,
 }
 
 impl AnsiblePlaybook {
@@ -203,6 +205,7 @@ impl AnsiblePlaybook {
                 "upgrade_uploader_telegraf_config.yml".to_string()
             }
             AnsiblePlaybook::Uploaders => "uploaders.yml".to_string(),
+            AnsiblePlaybook::UpdatePeer => "update_peer.yml".to_string(),
         }
     }
 }


### PR DESCRIPTION
This command can be useful as a quick way to update the peer reference in the node registry. This in turn will cause the service definitions to be updated when they are upgraded.