### PR TITLE
feat: use `network-contacts` for prod environment

### DIFF
--- a/resources/ansible/roles/uploaders/files/upload-random-data.sh
+++ b/resources/ansible/roles/uploaders/files/upload-random-data.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-# Target rate of 1.5mb/s
-
 CONTACT_PEER="${1:-}"
 
 CONTACT_PEER_ARG=""
@@ -18,8 +16,6 @@ if [ -z "$CONTACT_PEER" ]; then
   echo "No contact peer provided. Please provide the bootstrap peer."
   exit 1
 fi
-
-total_files=10000
 
 write_metrics_on_success() {
   local time=$1
@@ -44,21 +40,6 @@ metrics_header() {
   fi
 }
 
-prune_chunk_artifacts() {
-  echo "Pruning chunk artifacts more than 60 minutes old..."
-  rm -f old_chunk_artifacts.txt
-
-  start_time=$(date +%s)
-  find ~/.local/share/safe/client/chunk_artifacts -type d -mmin +60 > old_chunk_artifacts.txt
-  artifact_count=$(wc -l < old_chunk_artifacts.txt)
-  xargs -a old_chunk_artifacts.txt rm -rf
-  end_time=$(date +%s)
-
-  elapsed_time=$((end_time - start_time))
-  echo "Removed $artifact_count old chunk artifacts in $elapsed_time seconds"
-}
-
-# Generate a 10MB file of random data and log its reference
 generate_random_data_file_and_upload() {
   tmpfile=$(mktemp)
   dd if=/dev/urandom of="$tmpfile" bs=15M count=1 iflag=fullblock &> /dev/null
@@ -91,11 +72,10 @@ generate_random_data_file_and_upload() {
   rm "$tmpfile"
 }
 
-for i in $(seq 1 $total_files); do
+while true; do
   echo "$(date +"%A, %B %d, %Y %H:%M:%S")"
-  echo "Generating and uploading file $i of $total_files..."
+  echo "Generating and uploading file..."
   generate_random_data_file_and_upload
-  # prune_chunk_artifacts
   # TODO: re-enable when the new CLI has a `wallet balance` command
   # echo "$(autonomi $CONTACT_PEER_ARG wallet balance)"
 done

--- a/resources/ansible/roles/uploaders/tasks/main.yml
+++ b/resources/ansible/roles/uploaders/tasks/main.yml
@@ -26,8 +26,8 @@
   loop: "{{ range(1, autonomi_uploader_instances | int + 1) | list }}"
 
 - name: copy upload-random-data.sh to remote for each safe user
-  ansible.builtin.copy:
-    src: upload-random-data.sh
+  ansible.builtin.template:
+    src: upload-random-data.sh.j2
     dest: "/home/safe{{ item }}/upload-random-data.sh"
     owner: "safe{{ item }}"
     group: "safe{{ item }}"

--- a/resources/ansible/roles/uploaders/templates/autonomi_uploader.service.j2
+++ b/resources/ansible/roles/uploaders/templates/autonomi_uploader.service.j2
@@ -14,7 +14,11 @@ Environment="EVM_NETWORK=arbitrum-sepolia"
 Environment="EVM_NETWORK=arbitrum-one"
 {% endif %}
 User=safe{{ count }}
+{% if testnet_name.startswith('PROD-') %}
+ExecStart=/home/safe{{ count }}/upload-random-data.sh
+{% else %}
 ExecStart=/home/safe{{ count }}/upload-random-data.sh {{ genesis_multiaddr }}
+{% endif %}
 Restart=always
 WorkingDirectory=/home/safe{{ count }}
 

--- a/resources/ansible/roles/uploaders/templates/upload-random-data.sh.j2
+++ b/resources/ansible/roles/uploaders/templates/upload-random-data.sh.j2
@@ -2,18 +2,22 @@
 
 CONTACT_PEER="${1:-}"
 
+{% if not testnet_name.startswith('PROD-') %}
 CONTACT_PEER_ARG=""
 if [ -n "$CONTACT_PEER" ]; then
   CONTACT_PEER_ARG="--peer $CONTACT_PEER"
 fi
 
-if ! command -v autonomi &> /dev/null; then
-  echo "Error: 'autonomi' not found in PATH."
-  exit 1
-fi
-
 if [ -z "$CONTACT_PEER" ]; then
   echo "No contact peer provided. Please provide the bootstrap peer."
+  exit 1
+fi
+{% else %}
+CONTACT_PEER_ARG=""
+{% endif %}
+
+if ! command -v autonomi &> /dev/null; then
+  echo "Error: 'autonomi' not found in PATH."
   exit 1
 fi
 
@@ -54,7 +58,7 @@ generate_random_data_file_and_upload() {
   if [ $? -eq 0 ]; then
     echo "Successfully uploaded $tmpfile using SAFE CLI"
 
-    file_ref=$(echo "$stdout" | grep -oP 'Uploaded ".*" to address \K\S+')
+    file_ref=$(echo "$stdout" | grep -oP 'At address: \K\S+')
     if [ -z "$file_ref" ]; then
       echo "Error: Unable to extract file reference."
     else

--- a/resources/ansible/upgrade_uploaders.yml
+++ b/resources/ansible/upgrade_uploaders.yml
@@ -40,6 +40,16 @@
         dest: /usr/local/bin
         remote_src: True
 
+    - name: copy upload-random-data.sh to remote for each safe user
+      ansible.builtin.template:
+        src: roles/uploaders/templates/upload-random-data.sh.j2
+        dest: "/home/safe{{ item | regex_replace('safe([0-9]+)', '\\1') }}/upload-random-data.sh"
+        owner: "safe{{ item | regex_replace('safe([0-9]+)', '\\1') }}"
+        group: "safe{{ item | regex_replace('safe([0-9]+)', '\\1') }}"
+        mode: '0744'
+      become_user: "safe{{ item | regex_replace('safe([0-9]+)', '\\1') }}"
+      loop: "{{ safe_users.stdout_lines }}"
+
     - name: start all uploader services
       systemd:
         name: "autonomi_uploader_{{ item | regex_replace('safe([0-9]+)', '\\1') }}"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2540,6 +2540,7 @@ async fn main() -> Result<()> {
 
                 let ansible_runner = testnet_deploy.ansible_provisioner.ansible_runner;
                 let mut extra_vars = ExtraVarsDocBuilder::default();
+                extra_vars.add_variable("testnet_name", &name);
                 extra_vars.add_variable("autonomi_version", &version.to_string());
                 ansible_runner.run_playbook(
                     AnsiblePlaybook::UpgradeUploaders,


### PR DESCRIPTION
- 34a2f9c **feat: use inifinite loop in uploader script**

  There is no reason to upload some finite number of files; we just want the uploader to run forever.

  Also removes the chunk artifact pruning; this is not something we need with the new `autonomi`
  client.

- acae912 **feat: use `network-contacts` for prod environment**

  If we are using a production network, the autonomi client should not provide an explicit peer and
  instead use the network contacts. In production it's possible for the single peer to become
  unavailable and this would then break the uploader.

  We need to use a template to do this, so the file was moved to a jinja template.

- 55d66cf **feat: copy upload script on uploader upgrade**

  If the script has been updated, the new version will be copied as part of the upgrade.