### PR TITLE
feat: differentiate 'custom' and anvil networks

### DIFF
--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -854,8 +854,8 @@ impl AnsibleProvisioner {
         Ok(())
     }
 
-    pub fn print_ansible_run_banner(&self, n: usize, total: usize, s: &str) {
-        let ansible_run_msg = format!("Ansible Run {} of {}: ", n, total);
+    pub fn print_ansible_run_banner(&self, s: &str) {
+        let ansible_run_msg = "Ansible Run: ";
         let line = "=".repeat(s.len() + ansible_run_msg.len());
         println!("{}\n{}{}\n{}", line, ansible_run_msg, s, line);
     }

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -90,29 +90,22 @@ impl TestnetDeployer {
             err
         })?;
 
-        let mut n = 1;
-        let mut total = if build_custom_binaries { 2 } else { 1 };
-        if should_provision_private_nodes {
-            total += 2;
-        }
-
         let mut provision_options = ProvisionOptions::from(options.clone());
         if build_custom_binaries {
             self.ansible_provisioner
-                .print_ansible_run_banner(n, total, "Build Custom Binaries");
+                .print_ansible_run_banner("Build Custom Binaries");
             self.ansible_provisioner
                 .build_safe_network_binaries(&provision_options)
                 .map_err(|err| {
                     println!("Failed to build safe network binaries {err:?}");
                     err
                 })?;
-            n += 1;
         }
 
         let mut failed_to_provision = false;
 
         self.ansible_provisioner
-            .print_ansible_run_banner(n, total, "Provision Normal Nodes");
+            .print_ansible_run_banner("Provision Normal Nodes");
         match self.ansible_provisioner.provision_nodes(
             &provision_options,
             &options.bootstrap_peer,
@@ -139,7 +132,7 @@ impl TestnetDeployer {
 
             provision_options.private_node_vms = private_nodes;
             self.ansible_provisioner
-                .print_ansible_run_banner(n, total, "Provision NAT Gateway");
+                .print_ansible_run_banner("Provision NAT Gateway");
             self.ansible_provisioner
                 .provision_nat_gateway(&provision_options)
                 .map_err(|err| {
@@ -147,10 +140,8 @@ impl TestnetDeployer {
                     err
                 })?;
 
-            n += 1;
-
             self.ansible_provisioner
-                .print_ansible_run_banner(n, total, "Provision Private Nodes");
+                .print_ansible_run_banner("Provision Private Nodes");
             match self
                 .ansible_provisioner
                 .provision_private_nodes(&mut provision_options, &options.bootstrap_peer)

--- a/src/funding.rs
+++ b/src/funding.rs
@@ -320,7 +320,7 @@ impl AnsibleProvisioner {
         let _sk_count = all_secret_keys.values().map(|v| v.len()).sum::<usize>();
 
         let from_wallet = match &options.evm_network {
-            EvmNetwork::Custom => {
+            EvmNetwork::Anvil | EvmNetwork::Custom => {
                 let network = if let (
                     Some(evm_data_payments_address),
                     Some(evm_payment_token_address),


### PR DESCRIPTION
Previously we were using the 'custom' network type for doing a deployment with Anvil, but what we actually need the custom case for is when we want to use a different token contracts address. This will still use Arbitrum Sepolia, it's just that it will use a different token address. However, the payment address and the RPC URL still need to be supplied with the command. This is a closer match to how the `custom` network type is used in the node manager.

As part of this commit, the counts for the Ansible banners were removed. They are not very useful and were difficult to maintain based on all the different options.
