### PR TITLE
chore: use rc branch for network dashboard

### DIFF
--- a/resources/ansible/roles/telegraf-configuration/defaults/main.yml
+++ b/resources/ansible/roles/telegraf-configuration/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-network_dashboard_branch: main
+network_dashboard_branch: rc-2024.12.1
 network_dashboard_github_url: git@github.com:maidsafe/network-dashboard.git
 network_dashboard_repo_path: /root/network-dashboard
 network_dashboard_sk_path: /root/.ssh/network-dashboard

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1078,9 +1078,9 @@ impl TestnetDeployer {
     }
 }
 
-///
-/// Shared Helpers
-///
+//
+// Shared Helpers
+//
 
 pub fn get_genesis_multiaddr(
     ansible_runner: &AnsibleRunner,


### PR DESCRIPTION
For a while the network dashboard will also use an intermediate branch.