### PR TITLE
chore: apply `telegraf-configuration` role before `node` role

### DIFF
--- a/resources/ansible/nodes.yml
+++ b/resources/ansible/nodes.yml
@@ -25,9 +25,9 @@
         become: True,
         when: make_vm_private
       }
-    - node
     - role: telegraf-configuration
       become: True
+    - node
 
   tasks:
     # Something is wrong with the journal service on Ubuntu that causes no


### PR DESCRIPTION
It is sometimes possible that the application of the `node` role will result in an error, such as some nodes failing to start. In this case, Ansible will stop applying remaining roles on hosts where the failure occurred. For this reason, we want to configure and start Telegraf before we attempt to start the nodes, so that we will still collect monitoring data even if one or two nodes fail to start.