### PR TITLE
chore: restore uploader control commands

### DIFF
--- a/resources/ansible/start_uploaders.yml
+++ b/resources/ansible/start_uploaders.yml
@@ -1,9 +1,9 @@
 ---
-- name: ensure the ant uploader service is started
+- name: ensure ant uploader services are started
   hosts: all
   become: True
   tasks:
-    - name: stop all autonomi uploader service
+    - name: start all uploader services
       ansible.builtin.systemd:
         name: "ant_uploader_{{ item }}"
         state: started

--- a/resources/ansible/stop_uploaders.yml
+++ b/resources/ansible/stop_uploaders.yml
@@ -1,13 +1,12 @@
 ---
-- name: ensure the safe uploader service is stopped
+- name: ensure the uploader service is stopped
   hosts: all
   become: True
   tasks:
-    - name: stop all autonomi uploader service
+    - name: stop all uploader services
       ansible.builtin.systemd:
         name: "ant_uploader_{{ item }}"
         state: stopped
         enabled: yes
       become: true
       loop: "{{ range(1, ant_uploader_instances | int + 1) | list }}"
-      ignore_errors: "{{ skip_err | default(false) }}"

--- a/src/ansible/extra_vars.rs
+++ b/src/ansible/extra_vars.rs
@@ -424,17 +424,13 @@ pub fn build_uploaders_extra_vars_doc(
 
 pub fn build_start_or_stop_uploader_extra_vars_doc(
     cloud_provider: &str,
-    options: &ProvisionOptions,
-    skip_err: bool,
+    environment_name: &str,
+    uploader_instances: u16,
 ) -> String {
     let mut extra_vars = ExtraVarsDocBuilder::default();
     extra_vars.add_variable("provider", cloud_provider);
-    extra_vars.add_variable("testnet_name", &options.name);
-    extra_vars.add_variable(
-        "ant_uploader_instances",
-        &options.uploaders_count.unwrap_or(1).to_string(),
-    );
-    extra_vars.add_variable("skip_err", &skip_err.to_string());
+    extra_vars.add_variable("testnet_name", environment_name);
+    extra_vars.add_variable("ant_uploader_instances", &uploader_instances.to_string());
     extra_vars.build()
 }
 


### PR DESCRIPTION
The `start` and `stop` uploader commands had stopped working after the uploaders were configured for multiple services running on one machine.

Unfortunately because we don't keep track of the node counts as part of the inventory, the service instance count has to be passed.