### PR TITLE
fix: ensure telegraf is running on uploaders

### DIFF
--- a/resources/ansible/uploaders.yml
+++ b/resources/ansible/uploaders.yml
@@ -23,15 +23,9 @@
         state: restarted
         enabled: yes
     # # The Telegraf service seems to need to be rebooted for metrics to start transmitting.
-    # - name: restart telegraf
-    #   become: True
-    #   ansible.builtin.systemd:
-    #     name: telegraf
-    #     state: restarted
-    #     enabled: yes
-    - name: stop telegraf
+    - name: restart telegraf
       become: True
       ansible.builtin.systemd:
         name: telegraf
-        state: stopped
-        enabled: no
+        state: restarted
+        enabled: yes


### PR DESCRIPTION
The service should now be started automatically rather than be in a stopped state, which was requested for development work.