### PR TITLE
chore: prevent nodes not starting killing entire playbook

### DIFF
--- a/resources/ansible/roles/genesis-node/tasks/main.yml
+++ b/resources/ansible/roles/genesis-node/tasks/main.yml
@@ -48,4 +48,13 @@
 
 - name: start the genesis node service
   become: True
-  command: antctl -v start --interval {{ interval }}
+  command: antctl -v start --interval {{ interval}}
+  register: start_services_result
+  failed_when: false
+
+- name: log node services start failures
+  ansible.builtin.debug:
+    msg: "Warning: starting node services failed on {{ inventory_hostname }} with return code {{ start_services_result.rc }}"
+  when: 
+    - start_services_result.rc is defined
+    - start_services_result.rc != 0

--- a/resources/ansible/roles/genesis-node/tasks/main.yml
+++ b/resources/ansible/roles/genesis-node/tasks/main.yml
@@ -36,7 +36,7 @@
       - "--rewards-address={{ rewards_address }}"
       - "--max-archived-log-files={{ max_archived_log_files }}"
       - "--max-log-files={{ max_log_files }}"
-      - "{{ ('--network-id=' + network_id) if network_id else omit }}"
+      - "{{ ('--network-id=' + network_id) if network_id is defined and network_id else omit }}"
       - "{{ ('--log-format=' + log_format) if log_format is defined else omit }}"
       - "{{ ('--env=' + env_variables) if env_variables is defined else omit }}"
       - "{{ ('--version=' + version) if version is defined else ('--url=' + node_archive_url) }}"

--- a/resources/ansible/roles/node/tasks/main.yml
+++ b/resources/ansible/roles/node/tasks/main.yml
@@ -103,3 +103,12 @@
 - name: start the node services
   become: True
   command: antctl -v start --interval {{ interval}}
+  register: start_services_result
+  failed_when: false
+
+- name: log node services start failures
+  ansible.builtin.debug:
+    msg: "Warning: starting node services failed on {{ inventory_hostname }} with return code {{ start_services_result.rc }}"
+  when: 
+    - start_services_result.rc is defined
+    - start_services_result.rc != 0

--- a/resources/ansible/roles/node/tasks/main.yml
+++ b/resources/ansible/roles/node/tasks/main.yml
@@ -68,7 +68,6 @@
 - name: add node services
   become: True
   ansible.builtin.command:
-    # The `omit` filter is used to remove arguments that don't have values
     argv: "{{ command_args | reject('equalto', omit) | list }}"
   vars:
     command_args:
@@ -80,7 +79,7 @@
       - "--count={{ nodes_to_add }}"
       - "{{ ('--peer=' + genesis_multiaddr) if genesis_multiaddr else omit }}"
       - "{{ ('--network-contacts-url=' + network_contacts_url) if network_contacts_url else omit }}"
-      - "{{ ('--network-id=' + network_id) if network_id else omit }}"
+      - "{{ ('--network-id=' + network_id) if network_id is defined and network_id else omit }}"
       - --testnet
       - "--rpc-address={{ node_rpc_ip }}"
       - "--rewards-address={{ rewards_address }}"

--- a/resources/ansible/roles/uploaders/templates/ant_uploader.service.j2
+++ b/resources/ansible/roles/uploaders/templates/ant_uploader.service.j2
@@ -17,7 +17,7 @@ User=ant{{ count }}
 {% if testnet_name.startswith('PROD-') %}
 ExecStart=/home/ant{{ count }}/upload-random-data.sh
 {% else %}
-ExecStart=/home/ant{{ count }}/upload-random-data.sh {{ genesis_multiaddr }} {{network_contacts_url}} {{network_id}}
+ExecStart=/home/ant{{ count }}/upload-random-data.sh {{ genesis_multiaddr }} {{network_contacts_url}}{% if network_id is defined %} {{network_id}}{% endif %}
 {% endif %}
 Restart=always
 WorkingDirectory=/home/ant{{ count }}


### PR DESCRIPTION
- defc507 **fix: make network id optional**

  The variable was not being correctly referenced in these tasks.

- ed4b838 **chore: prevent nodes not starting killing entire playbook**

  In the case of the peer cache setup, if the nodes did not start correctly, the nginx playbook was
  not being applied.