### PR TITLE
fix: apply network id to uploader service

### DIFF
--- a/resources/ansible/roles/uploaders/templates/ant_uploader.service.j2
+++ b/resources/ansible/roles/uploaders/templates/ant_uploader.service.j2
@@ -18,6 +18,7 @@ User=ant{{ count }}
 ExecStart=/home/ant{{ count }}/upload-random-data.sh
 {% else %}
 ExecStart=/home/ant{{ count }}/upload-random-data.sh {{ genesis_multiaddr }} {{network_contacts_url}}{% if network_id is defined %} {{network_id}}{% endif %}
+
 {% endif %}
 Restart=always
 WorkingDirectory=/home/ant{{ count }}


### PR DESCRIPTION
Without the newline in the template, the service definition was not written correctly.