### PR TITLE
chore: define spec for `prod-02` environment

### DIFF
--- a/resources/terraform/testnet/digital-ocean/PROD-02.tfvars
+++ b/resources/terraform/testnet/digital-ocean/PROD-02.tfvars
@@ -1,0 +1,15 @@
+evm_node_droplet_size = "s-4vcpu-8gb"
+evm_node_droplet_image_id = 172723723
+evm_node_vm_count = 1
+nat_gateway_droplet_image_id = 172724206
+node_droplet_size = "s-8vcpu-16gb"
+node_droplet_image_id = 173265007
+node_vm_count = 39
+peer_cache_droplet_size = "s-8vcpu-16gb"
+peer_cache_droplet_image_id = 173264988
+peer_cache_node_vm_count = 0
+private_node_vm_count = 1
+setup_nat_gateway = true
+uploader_droplet_size = "s-4vcpu-8gb"
+uploader_droplet_image_id = 172724146
+uploader_vm_count = 0


### PR DESCRIPTION
This is going to be bootstrapped from the `PROD-01` environment. It will have the same size machines.

Since it's bootstrapped, the peer cache and uploaders don't apply, so those counts are set to 0.