### PR TITLE
feat: provide `reset-to-n-nodes` command

### DIFF
--- a/resources/ansible/reset_to_n_nodes.yml
+++ b/resources/ansible/reset_to_n_nodes.yml
@@ -1,0 +1,6 @@
+---
+- name: reset to n nodes
+  hosts: all
+  become: True
+  roles:
+    - reset-to-n-nodes

--- a/resources/ansible/roles/reset-to-n-nodes/tasks/main.yml
+++ b/resources/ansible/roles/reset-to-n-nodes/tasks/main.yml
@@ -1,0 +1,15 @@
+# An assumption is being made that an environment for running nodes was already setup.
+# Nodes will be stopped slowly, then everything will be cleared using the `reset` command.
+---
+- name: copy script
+  template:
+    src: reset_to_n_nodes.sh.j2
+    dest: /usr/local/bin/reset_to_n_nodes.sh
+    mode: '0755'
+    owner: root
+    group: root
+
+- name: run script
+  ansible.builtin.shell: /usr/local/bin/reset_to_n_nodes.sh
+  args:
+    executable: /bin/bash

--- a/resources/ansible/roles/reset-to-n-nodes/templates/reset_to_n_nodes.sh.j2
+++ b/resources/ansible/roles/reset-to-n-nodes/templates/reset_to_n_nodes.sh.j2
@@ -1,0 +1,74 @@
+# An assumption is being made that an environment for running nodes was already setup.
+# Nodes will be stopped slowly, then everything will be cleared using the `reset` command.
+# The node services will then be created again, using the settings from the previous node registry.
+# After which, they will be started, using an interval between each.
+# In the production environment, it's advisable for the interval to be quite large, e.g., 5 minutes.
+
+#!/bin/bash
+
+set -euo pipefail
+
+readonly ANTCTL="/usr/local/bin/antctl"
+readonly JQ="/usr/bin/jq"
+readonly NODE_REGISTRY="/var/antctl/node_registry.json"
+
+node_count={{ node_count }}
+
+if [ "{{ evm_network_type }}" = "evm-custom" ]; then
+  rpc_url=$(cat ${NODE_REGISTRY} | ${JQ} -r '.nodes[0].evm_network.Custom.rpc_url_http')
+  payment_token_address=$(cat ${NODE_REGISTRY} | ${JQ} -r '.nodes[0].evm_network.Custom.payment_token_address')
+  data_payments_address=$(cat ${NODE_REGISTRY} | ${JQ} -r '.nodes[0].evm_network.Custom.data_payments_address')
+fi
+
+network_contacts_url=$(cat ${NODE_REGISTRY} | ${JQ} -r '.nodes[0].peers_args.network_contacts_url[0]')
+peer_multiaddr=$(cat ${NODE_REGISTRY} | ${JQ} -r '.nodes[0].peers_args.addrs[0]')
+rewards_address=$(cat ${NODE_REGISTRY} | ${JQ} -r '.nodes[0].rewards_address')
+network_id=$(cat ${NODE_REGISTRY} | ${JQ} -r '.nodes[0].network_id')
+max_archived_log_files=$(cat ${NODE_REGISTRY} | ${JQ} -r '.nodes[0].max_archived_log_files')
+max_log_files=$(cat ${NODE_REGISTRY} | ${JQ} -r '.nodes[0].max_log_files')
+
+# The delay is useful when there is only one node running.
+{% if delay is defined %}
+sleep {{ delay | default(0) }}
+{% endif %}
+antctl stop --interval {{ stop_interval }}
+
+${ANTCTL} reset --force
+
+base_rpc_port=13000
+base_metrics_port=14000
+
+for ((i=0; i<node_count; i++)); do
+  current_rpc_port=$((base_rpc_port + i))
+  current_metrics_port=$((base_metrics_port + i))
+  
+  ${ANTCTL} add \
+    --version {{ version }} \
+    --rpc-port ${current_rpc_port} \
+    --data-dir-path /mnt/antnode-storage/data \
+    --log-dir-path /mnt/antnode-storage/log \
+    --peer ${peer_multiaddr} \
+    --network-contacts-url ${network_contacts_url} \
+    --bootstrap-cache-dir /var/antctl/bootstrap_cache \
+    --network-id ${network_id} \
+    --log-format json \
+    --metrics-port ${current_metrics_port} \
+    --max-archived-log-files ${max_archived_log_files} \
+    --max-log-files ${max_log_files} \
+    --rewards-address ${rewards_address} \
+{% if environment_name is defined and not environment_name.startswith('PROD') %}
+    --testnet \
+{% endif %}
+{% if evm_network_type == 'evm-custom' %}
+    {{ evm_network_type }} \
+{% else %}
+    {{ evm_network_type }}
+{% endif %}
+{% if evm_network_type == 'evm-custom' %}
+    --rpc-url ${rpc_url} \
+    --payment-token-address ${payment_token_address} \
+    --data-payments-address ${data_payments_address}
+{% endif %}
+done
+
+${ANTCTL} start --interval {{ start_interval }}

--- a/resources/ansible/start_nodes.yml
+++ b/resources/ansible/start_nodes.yml
@@ -6,4 +6,4 @@
     interval: "{{ interval }}"
   tasks:
     - name: start
-      ansible.builtin.command: "safenode-manager start --interval {{ interval }}"
+      ansible.builtin.command: "antctl start --interval {{ interval }}"

--- a/resources/ansible/stop_nodes.yml
+++ b/resources/ansible/stop_nodes.yml
@@ -10,6 +10,6 @@
         {% if delay is defined %}
         sleep {{ delay | default(0) }}
         {% endif %}
-        safenode-manager stop --interval {{ interval }}
+        antctl stop --interval {{ interval }}
       args:
         executable: /bin/bash

--- a/src/ansible/mod.rs
+++ b/src/ansible/mod.rs
@@ -117,6 +117,10 @@ pub enum AnsiblePlaybook {
     ///
     /// Use in combination with `AnsibleInventoryType::PeerCache`.
     PeerCacheNodes,
+    /// The reset to n nodes playbook will reset the nodes to the specified number of nodes.
+    ///
+    /// See the `reset-to-n-nodes` role for more details.
+    ResetToNNodes,
     /// The rpc client playbook will setup the `safenode_rpc_client` binary on the genesis node.
     ///
     /// Use in combination with `AnsibleInventoryType::Genesis`.
@@ -197,6 +201,7 @@ impl AnsiblePlaybook {
             AnsiblePlaybook::Nodes => "nodes.yml".to_string(),
             AnsiblePlaybook::PeerCacheNodes => "peer_cache_node.yml".to_string(),
             AnsiblePlaybook::RpcClient => "safenode_rpc_client.yml".to_string(),
+            AnsiblePlaybook::ResetToNNodes => "reset_to_n_nodes.yml".to_string(),
             AnsiblePlaybook::StartFaucet => "start_faucet.yml".to_string(),
             AnsiblePlaybook::StartNodes => "start_nodes.yml".to_string(),
             AnsiblePlaybook::StartTelegraf => "start_telegraf.yml".to_string(),


### PR DESCRIPTION
- f6d8efe **chore: use `antctl` to start/stop nodes**

  Replaces the old references to `safenode-manager`.

- ba4b097 **feat: provide `reset-to-n-nodes` command**

  This command runs a playbook that uses a Bash script to clear out existing nodes then create the
  specified number of new nodes.

  It is intended to be used in the production environment to reset nodes for a particular environment,
  to avoid having to bootstrap a new one.

  In production, there will be intervals applied to the `stop` and `start` commands such that the
  existing node services will be stopped gradually, and the new services will come online slowly,
  probably with an interval of about 5 minutes between each.