### PR TITLE
feat: handle missing or altered genesis node

### DIFF
--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -311,14 +311,15 @@ impl DeploymentInventoryService {
             }
         };
 
-        let (genesis_multiaddr, genesis_ip) = if environment_details.deployment_type
-            == DeploymentType::New
-        {
-            let (multiaddr, ip) = get_genesis_multiaddr(&self.ansible_runner, &self.ssh_client)?;
-            (Some(multiaddr), Some(ip))
-        } else {
-            (None, None)
-        };
+        let (genesis_multiaddr, genesis_ip) =
+            if environment_details.deployment_type == DeploymentType::New {
+                match get_genesis_multiaddr(&self.ansible_runner, &self.ssh_client) {
+                    Ok((multiaddr, ip)) => (Some(multiaddr), Some(ip)),
+                    Err(_) => (None, None),
+                }
+            } else {
+                (None, None)
+            };
         let inventory = DeploymentInventory {
             binary_option,
             environment_details,


### PR DESCRIPTION
In the case of our current production environment, I accidentally reset the node registry on the genesis VM, which meant that the inventory for the production environment could no longer be generated.

I since started 5 nodes on the genesis VM, so I'm just going to take the first node in the registry even if there are none with the `--first` flag.

It could also be possible that the original genesis VM was destroyed. So the inventory process treats it as optional.