### PR TITLE
feat: support custom branch for upscale

### DIFF
--- a/src/ansible/extra_vars.rs
+++ b/src/ansible/extra_vars.rs
@@ -78,7 +78,6 @@ impl ExtraVarsDocBuilder {
                 repo_owner,
                 branch,
                 antnode_features,
-                network_keys,
             } => {
                 self.add_variable("custom_bin", "true");
                 self.add_variable("testnet_name", deployment_name);
@@ -86,12 +85,6 @@ impl ExtraVarsDocBuilder {
                 self.add_variable("branch", branch);
                 if let Some(features) = antnode_features {
                     self.add_variable("antnode_features_list", features);
-                }
-                if let Some(network_keys) = network_keys {
-                    self.add_variable("foundation_pk", &network_keys.0);
-                    self.add_variable("genesis_pk", &network_keys.1);
-                    self.add_variable("network_royalties_pk", &network_keys.2);
-                    self.add_variable("payment_forward_pk", &network_keys.3);
                 }
             }
             BinaryOption::Versioned { .. } => {

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -90,6 +90,7 @@ impl TestnetDeployer {
             peer_cache_node_volume_size: None,
             private_node_vm_count: options.private_node_vm_count,
             private_node_volume_size: options.private_node_volume_size,
+            setup_nat_gateway: should_provision_private_nodes,
             tfvars_filename: options
                 .environment_type
                 .get_tfvars_filename(&options.name)

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -86,7 +86,10 @@ impl TestnetDeployer {
             peer_cache_node_volume_size: options.peer_cache_node_volume_size,
             private_node_vm_count: options.private_node_vm_count,
             private_node_volume_size: options.private_node_volume_size,
-            setup_nat_gateway: options.private_node_vm_count.map(|count| count > 0).unwrap_or(false),
+            setup_nat_gateway: options
+                .private_node_vm_count
+                .map(|count| count > 0)
+                .unwrap_or(false),
             tfvars_filename: options.environment_type.get_tfvars_filename(&options.name),
             uploader_vm_count: options.uploader_vm_count,
             uploader_vm_size: options.uploader_vm_size.clone(),

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -86,6 +86,7 @@ impl TestnetDeployer {
             peer_cache_node_volume_size: options.peer_cache_node_volume_size,
             private_node_vm_count: options.private_node_vm_count,
             private_node_volume_size: options.private_node_volume_size,
+            setup_nat_gateway: options.private_node_vm_count.map(|count| count > 0).unwrap_or(false),
             tfvars_filename: options.environment_type.get_tfvars_filename(&options.name),
             uploader_vm_count: options.uploader_vm_count,
             uploader_vm_size: options.uploader_vm_size.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,6 +303,37 @@ pub enum BinaryOption {
     },
 }
 
+impl BinaryOption {
+    pub fn print(&self) {
+        match self {
+            BinaryOption::BuildFromSource {
+                antnode_features,
+                branch,
+                repo_owner,
+            } => {
+                println!("Source configuration:");
+                println!("  Repository owner: {}", repo_owner);
+                println!("  Branch: {}", branch);
+                if let Some(features) = antnode_features {
+                    println!("  Antnode features: {}", features);
+                }
+            }
+            BinaryOption::Versioned {
+                ant_version,
+                antctl_version,
+                antnode_version,
+            } => {
+                println!("Versioned binaries configuration:");
+                if let Some(version) = ant_version {
+                    println!("  ant version: {}", version);
+                }
+                println!("  antctl version: {}", antctl_version);
+                println!("  antnode version: {}", antnode_version);
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum CloudProvider {
     Aws,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,7 +293,6 @@ pub enum BinaryOption {
         /// A comma-separated list that will be passed to the `--features` argument.
         antnode_features: Option<String>,
         branch: String,
-        network_keys: Option<(String, String, String, String)>,
         repo_owner: String,
     },
     /// Pre-built, versioned binaries will be fetched from S3.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -677,10 +677,11 @@ impl TestnetDeployer {
     pub fn plan(&self, options: &InfraRunOptions) -> Result<()> {
         println!("Selecting {} workspace...", options.name);
         self.terraform_runner.workspace_select(&options.name)?;
-        
+
         let args = build_terraform_args(options)?;
-        
-        self.terraform_runner.plan(Some(args), Some(options.tfvars_filename.clone()))?;
+
+        self.terraform_runner
+            .plan(Some(args), Some(options.tfvars_filename.clone()))?;
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ use alloy::primitives::Address;
 use evmlib::Network;
 use flate2::read::GzDecoder;
 use indicatif::{ProgressBar, ProgressStyle};
-use infra::InfraRunOptions;
+use infra::{build_terraform_args, InfraRunOptions};
 use log::{debug, trace};
 use semver::Version;
 use serde::{Deserialize, Serialize};
@@ -674,12 +674,13 @@ impl TestnetDeployer {
         Ok(())
     }
 
-    pub fn plan(&self, vars: Option<Vec<(String, String)>>, tfvars_filename: &str) -> Result<()> {
-        println!("Selecting {} workspace...", self.environment_name);
-        self.terraform_runner
-            .workspace_select(&self.environment_name)?;
-        self.terraform_runner
-            .plan(vars, Some(tfvars_filename.to_string()))?;
+    pub fn plan(&self, options: &InfraRunOptions) -> Result<()> {
+        println!("Selecting {} workspace...", options.name);
+        self.terraform_runner.workspace_select(&options.name)?;
+        
+        let args = build_terraform_args(options)?;
+        
+        self.terraform_runner.plan(Some(args), Some(options.tfvars_filename.clone()))?;
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -887,14 +887,6 @@ enum Commands {
         /// exclusive with the version arguments.
         #[arg(long, verbatim_doc_comment)]
         branch: Option<String>,
-        /// The desired number of auditor VMs to be running after the scale.
-        ///
-        /// If there are currently 10 VMs running, and you want there to be 20, use 20 as the
-        /// value, not 10 as a delta.
-        ///
-        /// This option is not applicable to a bootstrap deployment.
-        #[clap(long, verbatim_doc_comment)]
-        desired_auditor_vm_count: Option<u16>,
         /// The desired number of antnode services to be running on each node VM after the scale.
         ///
         /// If there are currently 10 services running on each VM, and you want there to be 25, the
@@ -954,13 +946,6 @@ enum Commands {
         /// If you want each uploader VM to run multiple uploader services, specify the total desired count.
         #[clap(long, verbatim_doc_comment)]
         desired_uploaders_count: Option<u16>,
-        /// If set to a non-zero value, the uploaders will also be accompanied by the specified
-        /// number of downloaders.
-        ///
-        /// This will be the number on each uploader VM. So if the value here is 2 and there are
-        /// 5 uploader VMs, there will be 10 downloaders across the 5 VMs.
-        #[clap(long, default_value_t = 0)]
-        downloaders_count: u16,
         /// The secret key for the wallet that will fund all the uploaders.
         ///
         /// This argument only applies when Arbitrum or Sepolia networks are used.
@@ -2781,7 +2766,6 @@ async fn main() -> Result<()> {
                     .upscale_uploaders(&UpscaleOptions {
                         ansible_verbose: false,
                         current_inventory: inventory,
-                        desired_auditor_vm_count: None,
                         desired_node_count: None,
                         desired_node_vm_count: None,
                         desired_peer_cache_node_count: None,
@@ -2790,7 +2774,6 @@ async fn main() -> Result<()> {
                         desired_private_node_vm_count: None,
                         desired_uploader_vm_count,
                         desired_uploaders_count,
-                        downloaders_count,
                         funding_wallet_secret_key,
                         gas_amount,
                         max_archived_log_files: 1,
@@ -2844,7 +2827,6 @@ async fn main() -> Result<()> {
             antctl_version,
             antnode_version,
             branch,
-            desired_auditor_vm_count,
             desired_node_count,
             desired_node_vm_count,
             desired_peer_cache_node_count,
@@ -2853,7 +2835,6 @@ async fn main() -> Result<()> {
             desired_private_node_vm_count,
             desired_uploader_vm_count,
             desired_uploaders_count,
-            downloaders_count,
             funding_wallet_secret_key,
             infra_only,
             interval,
@@ -2941,7 +2922,6 @@ async fn main() -> Result<()> {
                 .upscale(&UpscaleOptions {
                     ansible_verbose,
                     current_inventory: inventory,
-                    desired_auditor_vm_count,
                     desired_node_count,
                     desired_node_vm_count,
                     desired_peer_cache_node_count,
@@ -2950,7 +2930,6 @@ async fn main() -> Result<()> {
                     desired_private_node_vm_count,
                     desired_uploader_vm_count,
                     desired_uploaders_count,
-                    downloaders_count,
                     funding_wallet_secret_key,
                     gas_amount: None,
                     interval,

--- a/src/upscale.rs
+++ b/src/upscale.rs
@@ -20,7 +20,6 @@ pub struct UpscaleOptions {
     pub ansible_verbose: bool,
     pub ant_version: Option<String>,
     pub current_inventory: DeploymentInventory,
-    pub desired_auditor_vm_count: Option<u16>,
     pub desired_node_count: Option<u16>,
     pub desired_node_vm_count: Option<u16>,
     pub desired_peer_cache_node_count: Option<u16>,
@@ -29,7 +28,6 @@ pub struct UpscaleOptions {
     pub desired_private_node_vm_count: Option<u16>,
     pub desired_uploader_vm_count: Option<u16>,
     pub desired_uploaders_count: Option<u16>,
-    pub downloaders_count: u16,
     pub funding_wallet_secret_key: Option<String>,
     pub gas_amount: Option<U256>,
     pub interval: Duration,
@@ -52,8 +50,7 @@ impl TestnetDeployer {
         );
 
         if is_bootstrap_deploy
-            && (options.desired_auditor_vm_count.is_some()
-                || options.desired_peer_cache_node_count.is_some()
+            && (options.desired_peer_cache_node_count.is_some()
                 || options.desired_peer_cache_node_vm_count.is_some()
                 || options.desired_uploader_vm_count.is_some())
         {
@@ -182,7 +179,7 @@ impl TestnetDeployer {
         let provision_options = ProvisionOptions {
             binary_option: options.current_inventory.binary_option.clone(),
             chunk_size: None,
-            downloaders_count: options.downloaders_count,
+            downloaders_count: 0,
             env_variables: None,
             evm_network: options
                 .current_inventory
@@ -434,7 +431,7 @@ impl TestnetDeployer {
         let provision_options = ProvisionOptions {
             binary_option: options.current_inventory.binary_option.clone(),
             chunk_size: None,
-            downloaders_count: options.downloaders_count,
+            downloaders_count: 0,
             env_variables: None,
             evm_data_payments_address: options
                 .current_inventory

--- a/src/upscale.rs
+++ b/src/upscale.rs
@@ -18,6 +18,7 @@ use std::{collections::HashSet, time::Duration};
 #[derive(Clone)]
 pub struct UpscaleOptions {
     pub ansible_verbose: bool,
+    pub ant_version: Option<String>,
     pub current_inventory: DeploymentInventory,
     pub desired_auditor_vm_count: Option<u16>,
     pub desired_node_count: Option<u16>,
@@ -37,7 +38,6 @@ pub struct UpscaleOptions {
     pub max_log_files: u16,
     pub plan: bool,
     pub public_rpc: bool,
-    pub safe_version: Option<String>,
     pub provision_only: bool,
 }
 
@@ -227,7 +227,7 @@ impl TestnetDeployer {
                 .environment_details
                 .rewards_address
                 .clone(),
-            ant_version: options.safe_version.clone(),
+            ant_version: options.ant_version.clone(),
             uploaders_count: options.desired_uploaders_count,
             gas_amount: options.gas_amount,
         };
@@ -479,7 +479,7 @@ impl TestnetDeployer {
                 .environment_details
                 .rewards_address
                 .clone(),
-            ant_version: options.safe_version.clone(),
+            ant_version: options.ant_version.clone(),
             uploaders_count: options.desired_uploaders_count,
             gas_amount: options.gas_amount,
         };


### PR DESCRIPTION
- 2133a2d **chore: remove remaining traces of network keys**

  These were removed from `antnode` and are no longer required.

- ca32ee4 **chore: use different version retrieving mechanism**

  The versions for both `antnode` and `antctl` can just come from a random VM rather than the node
  registry.

- ca780ed **feat: support custom branch for upscale**

  The upscale does not build the binaries. Instead it uses the build from the original deployment. The
  binary option can be set to the same owner/branch reference as the previous deployment, and this
  means Ansible will pick up the URL where the custom binary was uploaded to.

- 07ef86b **chore: remove redundant args from `upscale` cmd**

  The `--desired-auditor-vm-count` and `--downloaders-count` arguments do not apply any more.

- 5ae4436 **refactor: use shared mechanism for apply and plan args**

  The `terraform plan` and `terraform apply` arguments should be identical to each other, such that
  the plan will be producing the same change set as the apply. There were different code paths for
  each of them, which meant they could diverge easily.

  Extract a full function for obtaining the resource value from the Terraform state. The closure was
  large, so it was making the enclosing function more difficult to read. The `vm_size` variable was
  renamed because it was misleading: the function retrieves the value of any resource, not just the
  size of a VM.

  BREAKING CHANGE: I removed the `plan` command as part of this refactor. This command on its own just
  didn't make a whole lot of sense. It makes more sense to be used with an upscale.

- 0d057a4 **feat: obtain machine sizes from previous deploy**

  It's possible to launch the original deployment with values different from those in the tfvars file.
  If you then try to upscale, Terraform will then want to apply the values from the tvfars file, which
  could be smaller or larger.

  The sizes are therefore obtained from the original deployment by inspecting the current state.
