### PR TITLE
fix: do not fail on errors

### DIFF
--- a/resources/ansible/nodes.yml
+++ b/resources/ansible/nodes.yml
@@ -2,7 +2,7 @@
 - name: deploy antnode to remaining nodes
   hosts: all
   become: False
-  max_fail_percentage: 10
+  any_errors_fatal: false
   ignore_unreachable: yes
   vars:
     is_genesis: False


### PR DESCRIPTION
If we have say 2 VMs, failure in 1 vm would result in 50% failure and the whole workbook would fail. 

We ignore the failures inside the rust code anyway, so I feel like we could atleast let the playbooks keep executing even if 1 vm fails.