### PR TITLE
chore: provision uploaders on upscale when specified

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2825,7 +2825,17 @@ async fn main() -> Result<()> {
             }
 
             if desired_uploader_vm_count.is_some() && ant_version.is_none() {
-                return Err(eyre!("The --ant-version argument is required when --desired-uploader-vm-count is used"));
+                return Err(eyre!(
+                    "The ant version is required to upscale the uploaders"
+                ));
+            }
+
+            if (desired_uploader_vm_count.is_some() || desired_uploaders_count.is_some())
+                && funding_wallet_secret_key.is_none()
+            {
+                return Err(eyre!(
+                    "The funding wallet secret key is required to upscale the uploaders"
+                ));
             }
 
             println!("Upscaling deployment...");

--- a/src/upscale.rs
+++ b/src/upscale.rs
@@ -213,8 +213,6 @@ impl TestnetDeployer {
         let initial_network_contacts_url = get_bootstrap_cache_url(&initial_ip_addr);
         debug!("Retrieved initial peer {initial_multiaddr} and initial network contacts {initial_network_contacts_url}");
 
-        let should_provision_private_nodes = desired_private_node_vm_count > 0;
-
         if !is_bootstrap_deploy {
             self.wait_for_ssh_availability_on_new_machines(
                 AnsibleInventoryType::PeerCacheNodes,
@@ -258,6 +256,7 @@ impl TestnetDeployer {
             }
         }
 
+        let should_provision_private_nodes = desired_private_node_vm_count > 0;
         if should_provision_private_nodes {
             println!("Private node provisioning will be skipped during upscale");
             // TODO: Reenable this after examining and fixing the problems.
@@ -305,7 +304,9 @@ impl TestnetDeployer {
             }
         }
 
-        if !is_bootstrap_deploy {
+        let should_provision_uploaders = options.desired_uploaders_count.is_some()
+            || options.desired_uploader_vm_count.is_some();
+        if should_provision_uploaders {
             self.wait_for_ssh_availability_on_new_machines(
                 AnsibleInventoryType::Uploaders,
                 &options.current_inventory,


### PR DESCRIPTION
The uploader provisioning should only run when either of the uploader counts have been supplied.

This prevents the need to supply the secret key for the funding wallet on other types of upscales where it is not relevant.