### PR TITLE
feat: specify gas and token amounts on `deploy`

### DIFF
--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -48,30 +48,31 @@ pub struct ProvisionOptions {
     pub evm_network: EvmNetwork,
     pub evm_payment_token_address: Option<String>,
     pub evm_rpc_url: Option<String>,
-    /// Used to fund the uploaders.
     pub funding_wallet_secret_key: Option<String>,
     pub gas_amount: Option<U256>,
     pub interval: Duration,
     pub log_format: Option<LogFormat>,
     pub logstash_details: Option<(String, Vec<SocketAddr>)>,
+    pub max_archived_log_files: u16,
+    pub max_log_files: u16,
     pub name: String,
     pub nat_gateway: Option<VirtualMachine>,
     pub network_id: Option<u8>,
     pub node_count: u16,
-    pub max_archived_log_files: u16,
-    pub max_log_files: u16,
     pub output_inventory_dir_path: PathBuf,
     pub peer_cache_node_count: u16,
     pub private_node_count: u16,
     pub private_node_vms: Vec<VirtualMachine>,
     pub public_rpc: bool,
-    pub uploaders_count: Option<u16>,
     pub rewards_address: String,
+    pub token_amount: Option<U256>,
+    pub uploaders_count: Option<u16>,
 }
 
 impl From<BootstrapOptions> for ProvisionOptions {
     fn from(bootstrap_options: BootstrapOptions) -> Self {
         ProvisionOptions {
+            ant_version: None,
             binary_option: bootstrap_options.binary_option,
             chunk_size: bootstrap_options.chunk_size,
             downloaders_count: 0,
@@ -97,7 +98,7 @@ impl From<BootstrapOptions> for ProvisionOptions {
             private_node_vms: Vec::new(),
             public_rpc: false,
             rewards_address: bootstrap_options.rewards_address,
-            ant_version: None,
+            token_amount: None,
             uploaders_count: None,
         }
     }
@@ -106,6 +107,7 @@ impl From<BootstrapOptions> for ProvisionOptions {
 impl From<DeployOptions> for ProvisionOptions {
     fn from(deploy_options: DeployOptions) -> Self {
         ProvisionOptions {
+            ant_version: None,
             binary_option: deploy_options.binary_option,
             chunk_size: deploy_options.chunk_size,
             downloaders_count: deploy_options.downloaders_count,
@@ -115,24 +117,24 @@ impl From<DeployOptions> for ProvisionOptions {
             evm_payment_token_address: deploy_options.evm_payment_token_address,
             evm_rpc_url: deploy_options.evm_rpc_url,
             funding_wallet_secret_key: deploy_options.funding_wallet_secret_key,
-            gas_amount: None,
+            gas_amount: deploy_options.initial_gas,
             interval: deploy_options.interval,
             log_format: deploy_options.log_format,
             logstash_details: deploy_options.logstash_details,
+            max_archived_log_files: deploy_options.max_archived_log_files,
+            max_log_files: deploy_options.max_log_files,
             name: deploy_options.name,
             nat_gateway: None,
             network_id: deploy_options.network_id,
             node_count: deploy_options.node_count,
-            max_archived_log_files: deploy_options.max_archived_log_files,
-            max_log_files: deploy_options.max_log_files,
             output_inventory_dir_path: deploy_options.output_inventory_dir_path,
             peer_cache_node_count: deploy_options.peer_cache_node_count,
-            public_rpc: deploy_options.public_rpc,
             private_node_count: deploy_options.private_node_count,
             private_node_vms: Vec::new(),
-            ant_version: None,
-            uploaders_count: Some(deploy_options.uploaders_count),
+            public_rpc: deploy_options.public_rpc,
             rewards_address: deploy_options.rewards_address,
+            token_amount: deploy_options.initial_tokens,
+            uploaders_count: Some(deploy_options.uploaders_count),
         }
     }
 }
@@ -517,13 +519,13 @@ impl AnsibleProvisioner {
         let sk_map = self
             .deposit_funds_to_uploaders(&FundingOptions {
                 evm_data_payments_address: options.evm_data_payments_address.clone(),
+                evm_network: options.evm_network.clone(),
                 evm_payment_token_address: options.evm_payment_token_address.clone(),
                 evm_rpc_url: options.evm_rpc_url.clone(),
-                uploaders_count: options.uploaders_count,
-                evm_network: options.evm_network.clone(),
                 funding_wallet_secret_key: options.funding_wallet_secret_key.clone(),
-                token_amount: None,
                 gas_amount: options.gas_amount,
+                token_amount: options.token_amount,
+                uploaders_count: options.uploaders_count,
             })
             .await?;
 

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -12,7 +12,7 @@ use crate::{
     BinaryOption, DeploymentInventory, DeploymentType, EnvironmentDetails, EnvironmentType,
     EvmNetwork, InfraRunOptions, LogFormat, NodeType, TestnetDeployer,
 };
-use alloy::hex::ToHexExt;
+use alloy::{hex::ToHexExt, primitives::U256};
 use colored::Colorize;
 use std::{net::SocketAddr, path::PathBuf, time::Duration};
 
@@ -31,6 +31,8 @@ pub struct DeployOptions {
     pub evm_rpc_url: Option<String>,
     pub funding_wallet_secret_key: Option<String>,
     pub genesis_node_volume_size: Option<u16>,
+    pub initial_gas: Option<U256>,
+    pub initial_tokens: Option<U256>,
     pub interval: Duration,
     pub log_format: Option<LogFormat>,
     pub logstash_details: Option<(String, Vec<SocketAddr>)>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -398,6 +398,16 @@ enum Commands {
         /// argument.
         #[clap(long)]
         genesis_node_volume_size: Option<u16>,
+        /// The amount of gas to initially transfer to each uploader, in U256
+        ///
+        /// 1 ETH = 1_000_000_000_000_000_000. Defaults to 0.1 ETH
+        #[arg(long)]
+        initial_gas: Option<U256>,
+        /// The amount of tokens to initially transfer to each uploader, in U256
+        ///
+        /// 1 Token = 1_000_000_000_000_000_000. Defaults to 100 token.
+        #[arg(long)]
+        initial_tokens: Option<U256>,
         /// The interval between starting each node in milliseconds.
         #[clap(long, value_parser = |t: &str| -> Result<Duration> { Ok(t.parse().map(Duration::from_millis)?)}, default_value = "2000")]
         interval: Duration,
@@ -1601,6 +1611,8 @@ async fn main() -> Result<()> {
             forks,
             funding_wallet_secret_key,
             genesis_node_volume_size,
+            initial_gas,
+            initial_tokens,
             interval,
             log_format,
             logstash_stack_name,
@@ -1734,6 +1746,8 @@ async fn main() -> Result<()> {
                     funding_wallet_secret_key,
                     genesis_node_volume_size: genesis_node_volume_size
                         .or_else(|| Some(calculate_size_per_attached_volume(1))),
+                    initial_gas,
+                    initial_tokens,
                     interval,
                     log_format,
                     logstash_details,
@@ -2749,6 +2763,7 @@ async fn main() -> Result<()> {
                         provision_only,
                         public_rpc: false,
                         ant_version: Some(autonomi_version),
+                        token_amount: None,
                     })
                     .await?;
 
@@ -2896,6 +2911,7 @@ async fn main() -> Result<()> {
             testnet_deployer
                 .upscale(&UpscaleOptions {
                     ansible_verbose,
+                    ant_version,
                     current_inventory: inventory,
                     desired_node_count,
                     desired_node_vm_count,
@@ -2907,14 +2923,14 @@ async fn main() -> Result<()> {
                     desired_uploaders_count,
                     funding_wallet_secret_key,
                     gas_amount: None,
+                    infra_only,
                     interval,
                     max_archived_log_files,
                     max_log_files,
-                    infra_only,
                     plan,
                     provision_only: false,
                     public_rpc,
-                    ant_version,
+                    token_amount: None,
                 })
                 .await?;
 

--- a/src/upscale.rs
+++ b/src/upscale.rs
@@ -37,6 +37,7 @@ pub struct UpscaleOptions {
     pub plan: bool,
     pub public_rpc: bool,
     pub provision_only: bool,
+    pub token_amount: Option<U256>,
 }
 
 impl TestnetDeployer {
@@ -193,6 +194,7 @@ impl TestnetDeployer {
             ant_version: options.ant_version.clone(),
             uploaders_count: options.desired_uploaders_count,
             gas_amount: options.gas_amount,
+            token_amount: None,
         };
         let mut node_provision_failed = false;
 
@@ -447,6 +449,7 @@ impl TestnetDeployer {
             ant_version: options.ant_version.clone(),
             uploaders_count: options.desired_uploaders_count,
             gas_amount: options.gas_amount,
+            token_amount: options.token_amount,
         };
 
         self.wait_for_ssh_availability_on_new_machines(


### PR DESCRIPTION
It could be useful to do this as part of the deployment rather than also having an additional funding run later.

Plus, it could be set to 0 on the initial deploy if need be.