### PR TITLE
refactor: split command management into modules

### DIFF
--- a/src/cmd/deployments.rs
+++ b/src/cmd/deployments.rs
@@ -1,0 +1,599 @@
+// Copyright (c) 2023, MaidSafe.
+// All rights reserved.
+//
+// This SAFE Network Software is licensed under the BSD-3-Clause license.
+// Please see the LICENSE file for more details.
+
+use super::get_binary_option;
+
+use alloy::primitives::U256;
+use color_eyre::{eyre::eyre, Help, Result};
+use sn_testnet_deploy::{
+    bootstrap::BootstrapOptions, calculate_size_per_attached_volume, deploy::DeployOptions,
+    error::Error, inventory::DeploymentInventoryService, logstash::LogstashDeployBuilder,
+    upscale::UpscaleOptions, BinaryOption, CloudProvider, EnvironmentType, EvmNetwork, LogFormat,
+    TestnetDeployBuilder,
+};
+use std::time::Duration;
+
+#[allow(clippy::too_many_arguments)]
+pub async fn handle_bootstrap(
+    ansible_verbose: bool,
+    antctl_version: Option<String>,
+    antnode_features: Option<Vec<String>>,
+    antnode_version: Option<String>,
+    bootstrap_network_contacts_url: Option<String>,
+    bootstrap_peer: Option<String>,
+    branch: Option<String>,
+    chunk_size: Option<u64>,
+    environment_type: EnvironmentType,
+    env_variables: Option<Vec<(String, String)>>,
+    evm_data_payments_address: Option<String>,
+    evm_network_type: EvmNetwork,
+    evm_payment_token_address: Option<String>,
+    evm_rpc_url: Option<String>,
+    full_cone_private_node_count: Option<u16>,
+    full_cone_private_node_vm_count: Option<u16>,
+    full_cone_private_node_volume_size: Option<u16>,
+    forks: Option<usize>,
+    interval: Duration,
+    log_format: Option<LogFormat>,
+    name: String,
+    network_id: Option<u8>,
+    node_count: Option<u16>,
+    node_vm_count: Option<u16>,
+    node_volume_size: Option<u16>,
+    node_vm_size: Option<String>,
+    max_archived_log_files: u16,
+    max_log_files: u16,
+    symmetric_private_node_count: Option<u16>,
+    symmetric_private_node_vm_count: Option<u16>,
+    symmetric_private_node_volume_size: Option<u16>,
+    provider: CloudProvider,
+    repo_owner: Option<String>,
+    rewards_address: String,
+) -> Result<()> {
+    if bootstrap_network_contacts_url.is_none() && bootstrap_peer.is_none() {
+        return Err(eyre!(
+            "Either bootstrap-peer or bootstrap-network-contacts-url must be provided"
+        ));
+    }
+
+    if evm_network_type == EvmNetwork::Anvil {
+        return Err(eyre!(
+            "The anvil network type cannot be used for bootstrapping. 
+            Use the custom network type, supplying the Anvil contract addresses and RPC URL
+            from the previous network. They can be found in the network's inventory."
+        ));
+    }
+
+    if evm_network_type == EvmNetwork::Custom
+        && (evm_data_payments_address.is_none()
+            || evm_payment_token_address.is_none()
+            || evm_rpc_url.is_none())
+    {
+        return Err(eyre!(
+            "When using a custom EVM network, you must supply evm-data-payments-address, evm-payment-token-address, and evm-rpc-url"
+        ));
+    }
+
+    if evm_network_type != EvmNetwork::Custom && evm_rpc_url.is_some() {
+        return Err(eyre!(
+            "EVM RPC URL can only be set for a custom EVM network"
+        ));
+    }
+
+    let binary_option = get_binary_option(
+        branch,
+        repo_owner,
+        None,
+        antnode_version,
+        antctl_version,
+        antnode_features,
+    )
+    .await?;
+
+    let mut builder = TestnetDeployBuilder::default();
+    builder
+        .ansible_verbose_mode(ansible_verbose)
+        .deployment_type(environment_type.clone())
+        .environment_name(&name)
+        .provider(provider);
+    if let Some(forks) = forks {
+        builder.ansible_forks(forks);
+    }
+    let testnet_deployer = builder.build()?;
+
+    let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
+    inventory_service
+        .generate_or_retrieve_inventory(&name, true, Some(binary_option.clone()))
+        .await?;
+
+    match testnet_deployer.init().await {
+        Ok(_) => {}
+        Err(e @ Error::LogsForPreviousTestnetExist(_)) => {
+            return Err(eyre!(e)
+                .wrap_err(format!(
+                    "Logs already exist for a previous testnet with the \
+                            name '{name}'"
+                ))
+                .suggestion(
+                    "If you wish to keep them, retrieve the logs with the 'logs get' \
+                        command, then remove them with 'logs rm'. If you don't need them, \
+                        simply run 'logs rm'. Then you can proceed with deploying your \
+                        new testnet.",
+                ));
+        }
+        Err(e) => {
+            return Err(eyre!(e));
+        }
+    }
+
+    let node_count = node_count.unwrap_or(environment_type.get_default_node_count());
+    let symmetric_private_node_count = symmetric_private_node_count
+        .unwrap_or(environment_type.get_default_symmetric_private_node_count());
+    let full_cone_private_node_count = full_cone_private_node_count
+        .unwrap_or(environment_type.get_default_full_cone_private_node_count());
+
+    testnet_deployer
+        .bootstrap(&BootstrapOptions {
+            binary_option,
+            bootstrap_network_contacts_url,
+            bootstrap_peer,
+            environment_type: environment_type.clone(),
+            env_variables,
+            evm_data_payments_address,
+            evm_network: evm_network_type,
+            evm_payment_token_address,
+            evm_rpc_url,
+            full_cone_private_node_count,
+            full_cone_private_node_vm_count,
+            full_cone_private_node_volume_size: full_cone_private_node_volume_size.or_else(|| {
+                Some(calculate_size_per_attached_volume(
+                    full_cone_private_node_count,
+                ))
+            }),
+            interval,
+            log_format,
+            name: name.clone(),
+            network_id,
+            node_count,
+            node_vm_count,
+            node_vm_size,
+            node_volume_size: node_volume_size
+                .or_else(|| Some(calculate_size_per_attached_volume(node_count))),
+            max_archived_log_files,
+            max_log_files,
+            output_inventory_dir_path: inventory_service
+                .working_directory_path
+                .join("ansible")
+                .join("inventory"),
+            symmetric_private_node_vm_count,
+            symmetric_private_node_count,
+            symmetric_private_node_volume_size: symmetric_private_node_volume_size.or_else(|| {
+                Some(calculate_size_per_attached_volume(
+                    symmetric_private_node_count,
+                ))
+            }),
+            rewards_address,
+            chunk_size,
+        })
+        .await?;
+
+    let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
+    let new_inventory = inventory_service
+        .generate_or_retrieve_inventory(&name, true, None)
+        .await?;
+    new_inventory.print_report(false)?;
+    new_inventory.save()?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn handle_deploy(
+    ansible_verbose: bool,
+    ant_version: Option<String>,
+    antctl_version: Option<String>,
+    antnode_features: Option<Vec<String>>,
+    antnode_version: Option<String>,
+    branch: Option<String>,
+    chunk_size: Option<u64>,
+    downloaders_count: u16,
+    env_variables: Option<Vec<(String, String)>>,
+    environment_type: crate::EnvironmentType,
+    evm_data_payments_address: Option<String>,
+    evm_network_type: EvmNetwork,
+    evm_node_vm_size: Option<String>,
+    evm_payment_token_address: Option<String>,
+    evm_rpc_url: Option<String>,
+    full_cone_nat_gateway_vm_size: Option<String>,
+    full_cone_private_node_count: Option<u16>,
+    full_cone_private_node_vm_count: Option<u16>,
+    full_cone_private_node_volume_size: Option<u16>,
+    forks: Option<usize>,
+    funding_wallet_secret_key: Option<String>,
+    genesis_node_volume_size: Option<u16>,
+    initial_gas: Option<U256>,
+    initial_tokens: Option<U256>,
+    interval: std::time::Duration,
+    log_format: Option<LogFormat>,
+    logstash_stack_name: String,
+    max_archived_log_files: u16,
+    max_log_files: u16,
+    name: String,
+    network_id: Option<u8>,
+    network_contacts_file_name: Option<String>,
+    node_count: Option<u16>,
+    node_vm_count: Option<u16>,
+    node_vm_size: Option<String>,
+    node_volume_size: Option<u16>,
+    peer_cache_node_count: Option<u16>,
+    peer_cache_node_vm_count: Option<u16>,
+    peer_cache_node_vm_size: Option<String>,
+    peer_cache_node_volume_size: Option<u16>,
+    symmetric_nat_gateway_vm_size: Option<String>,
+    symmetric_private_node_count: Option<u16>,
+    symmetric_private_node_vm_count: Option<u16>,
+    symmetric_private_node_volume_size: Option<u16>,
+    provider: crate::CloudProvider,
+    public_rpc: bool,
+    repo_owner: Option<String>,
+    rewards_address: String,
+    uploader_vm_count: Option<u16>,
+    uploader_vm_size: Option<String>,
+    uploaders_count: u16,
+) -> Result<()> {
+    if evm_network_type == EvmNetwork::Custom {
+        if evm_data_payments_address.is_none() {
+            return Err(eyre!(
+                "Data payments address must be provided for custom EVM network"
+            ));
+        }
+        if evm_payment_token_address.is_none() {
+            return Err(eyre!(
+                "Payment token address must be provided for custom EVM network"
+            ));
+        }
+        if evm_rpc_url.is_none() {
+            return Err(eyre!("RPC URL must be provided for custom EVM network"));
+        }
+    }
+
+    if funding_wallet_secret_key.is_none() && evm_network_type != EvmNetwork::Anvil {
+        return Err(eyre!(
+            "Wallet secret key is required for Arbitrum or Sepolia networks"
+        ));
+    }
+
+    let binary_option = get_binary_option(
+        branch,
+        repo_owner,
+        ant_version,
+        antnode_version,
+        antctl_version,
+        antnode_features,
+    )
+    .await?;
+
+    let mut builder = TestnetDeployBuilder::default();
+    builder
+        .ansible_verbose_mode(ansible_verbose)
+        .deployment_type(environment_type.clone())
+        .environment_name(&name)
+        .provider(provider);
+    if let Some(forks) = forks {
+        builder.ansible_forks(forks);
+    }
+    let testnet_deployer = builder.build()?;
+
+    let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
+    let inventory = inventory_service
+        .generate_or_retrieve_inventory(&name, true, Some(binary_option.clone()))
+        .await?;
+
+    match testnet_deployer.init().await {
+        Ok(_) => {}
+        Err(e @ sn_testnet_deploy::error::Error::LogsForPreviousTestnetExist(_)) => {
+            return Err(eyre!(e)
+                .wrap_err(format!(
+                    "Logs already exist for a previous testnet with the \
+                            name '{name}'"
+                ))
+                .suggestion(
+                    "If you wish to keep them, retrieve the logs with the 'logs get' \
+                        command, then remove them with 'logs rm'. If you don't need them, \
+                        simply run 'logs rm'. Then you can proceed with deploying your \
+                        new testnet.",
+                ));
+        }
+        Err(e) => {
+            return Err(eyre!(e));
+        }
+    }
+
+    let logstash_details = {
+        let logstash_deploy = LogstashDeployBuilder::default()
+            .environment_name(&name)
+            .provider(provider)
+            .build()?;
+        let stack_hosts = logstash_deploy
+            .get_stack_hosts(&logstash_stack_name)
+            .await?;
+        if stack_hosts.is_empty() {
+            None
+        } else {
+            Some((logstash_stack_name, stack_hosts))
+        }
+    };
+
+    let peer_cache_node_count =
+        peer_cache_node_count.unwrap_or(environment_type.get_default_peer_cache_node_count());
+    let node_count = node_count.unwrap_or(environment_type.get_default_node_count());
+    let symmetric_private_node_count = symmetric_private_node_count
+        .unwrap_or(environment_type.get_default_symmetric_private_node_count());
+    let full_cone_private_node_count = full_cone_private_node_count
+        .unwrap_or(environment_type.get_default_full_cone_private_node_count());
+
+    testnet_deployer
+        .deploy(&DeployOptions {
+            binary_option: binary_option.clone(),
+            chunk_size,
+            current_inventory: inventory,
+            downloaders_count,
+            env_variables,
+            environment_type: environment_type.clone(),
+            evm_data_payments_address,
+            evm_network: evm_network_type,
+            evm_node_vm_size,
+            evm_payment_token_address,
+            evm_rpc_url,
+            funding_wallet_secret_key,
+            full_cone_nat_gateway_vm_size,
+            full_cone_private_node_count,
+            full_cone_private_node_vm_count,
+            full_cone_private_node_volume_size: full_cone_private_node_volume_size.or_else(|| {
+                Some(calculate_size_per_attached_volume(
+                    full_cone_private_node_count,
+                ))
+            }),
+            genesis_node_volume_size: genesis_node_volume_size
+                .or_else(|| Some(calculate_size_per_attached_volume(1))),
+            initial_gas,
+            initial_tokens,
+            interval,
+            log_format,
+            logstash_details,
+            max_archived_log_files,
+            max_log_files,
+            name: name.clone(),
+            network_id,
+            node_count,
+            node_vm_count,
+            node_vm_size,
+            node_volume_size: node_volume_size
+                .or_else(|| Some(calculate_size_per_attached_volume(node_count))),
+            output_inventory_dir_path: inventory_service
+                .working_directory_path
+                .join("ansible")
+                .join("inventory"),
+            peer_cache_node_count,
+            peer_cache_node_vm_count,
+            peer_cache_node_vm_size,
+            peer_cache_node_volume_size: peer_cache_node_volume_size
+                .or_else(|| Some(calculate_size_per_attached_volume(peer_cache_node_count))),
+            symmetric_nat_gateway_vm_size,
+            symmetric_private_node_count,
+            symmetric_private_node_vm_count,
+            symmetric_private_node_volume_size: symmetric_private_node_volume_size.or_else(|| {
+                Some(calculate_size_per_attached_volume(
+                    symmetric_private_node_count,
+                ))
+            }),
+            public_rpc,
+            rewards_address,
+            uploader_vm_count,
+            uploader_vm_size,
+            uploaders_count,
+        })
+        .await?;
+
+    let max_retries = 3;
+    let mut retries = 0;
+    let inventory = loop {
+        match inventory_service
+            .generate_or_retrieve_inventory(&name, true, Some(binary_option.clone()))
+            .await
+        {
+            Ok(inv) => break inv,
+            Err(e) if retries < max_retries => {
+                retries += 1;
+                eprintln!("Failed to generate inventory on attempt {retries}: {:?}", e);
+                eprintln!("Will retry up to {max_retries} times...");
+            }
+            Err(_) => {
+                eprintln!("Failed to generate inventory after {max_retries} attempts");
+                eprintln!("Please try running the `inventory` command or workflow separately");
+                return Ok(());
+            }
+        }
+    };
+
+    inventory.print_report(false)?;
+    inventory.save()?;
+
+    inventory_service
+        .upload_network_contacts(&inventory, network_contacts_file_name)
+        .await?;
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn handle_upscale(
+    ansible_verbose: bool,
+    ant_version: Option<String>,
+    antctl_version: Option<String>,
+    antnode_version: Option<String>,
+    branch: Option<String>,
+    desired_node_count: Option<u16>,
+    desired_full_cone_private_node_count: Option<u16>,
+    desired_full_cone_private_node_vm_count: Option<u16>,
+    desired_node_vm_count: Option<u16>,
+    desired_peer_cache_node_count: Option<u16>,
+    desired_peer_cache_node_vm_count: Option<u16>,
+    desired_symmetric_private_node_count: Option<u16>,
+    desired_symmetric_private_node_vm_count: Option<u16>,
+    desired_uploader_vm_count: Option<u16>,
+    desired_uploaders_count: Option<u16>,
+    funding_wallet_secret_key: Option<String>,
+    infra_only: bool,
+    interval: Duration,
+    max_archived_log_files: u16,
+    max_log_files: u16,
+    name: String,
+    plan: bool,
+    provider: CloudProvider,
+    public_rpc: bool,
+    repo_owner: Option<String>,
+) -> Result<()> {
+    if branch.is_some() && repo_owner.is_none() {
+        return Err(eyre!(
+            "The --repo-owner argument is required when --branch is used"
+        ));
+    }
+
+    if branch.is_some()
+        && (antnode_version.is_some() || antctl_version.is_some() || ant_version.is_some())
+    {
+        return Err(eyre!(
+            "The version arguments cannot be used when --branch is specified"
+        ));
+    }
+
+    if desired_uploader_vm_count.is_some() && ant_version.is_none() {
+        return Err(eyre!(
+            "The ant version is required to upscale the uploaders"
+        ));
+    }
+
+    if (desired_uploader_vm_count.is_some() || desired_uploaders_count.is_some())
+        && funding_wallet_secret_key.is_none()
+    {
+        return Err(eyre!(
+            "The funding wallet secret key is required to upscale the uploaders"
+        ));
+    }
+
+    println!("Upscaling deployment...");
+    let testnet_deployer = TestnetDeployBuilder::default()
+        .ansible_verbose_mode(ansible_verbose)
+        .environment_name(&name)
+        .provider(provider)
+        .build()?;
+    testnet_deployer.init().await?;
+
+    let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
+    let mut inventory = inventory_service
+        .generate_or_retrieve_inventory(&name, true, None)
+        .await?;
+
+    if branch.is_some() {
+        println!("The upscale will use the binaries built in the original deployment");
+        inventory.binary_option = BinaryOption::BuildFromSource {
+            antnode_features: None,
+            branch: branch.unwrap(),
+            repo_owner: repo_owner.unwrap(),
+        };
+    } else if antnode_version.is_some() || antctl_version.is_some() {
+        match &inventory.binary_option {
+            BinaryOption::Versioned {
+                ant_version: _,
+                antnode_version: existing_antnode_version,
+                antctl_version: existing_antctl_version,
+            } => {
+                let new_antnode_version = antnode_version
+                    .map(|v| v.parse().expect("Invalid antnode version"))
+                    .unwrap_or(existing_antnode_version.clone());
+                let new_antctl_version = antctl_version
+                    .map(|v| v.parse().expect("Invalid antctl version"))
+                    .unwrap_or(existing_antctl_version.clone());
+
+                println!("The upscale will use the following override binary versions:");
+                println!("antnode: {}", new_antnode_version);
+                println!("antctl: {}", new_antctl_version);
+
+                inventory.binary_option = BinaryOption::Versioned {
+                    ant_version: None,
+                    antnode_version: new_antnode_version,
+                    antctl_version: new_antctl_version,
+                };
+            }
+            BinaryOption::BuildFromSource { .. } => {
+                return Err(eyre!(
+                    "Cannot override versions when the deployment uses BuildFromSource"
+                ));
+            }
+        }
+    }
+
+    inventory.binary_option.print();
+
+    testnet_deployer
+        .upscale(&UpscaleOptions {
+            ansible_verbose,
+            ant_version,
+            current_inventory: inventory,
+            desired_node_count,
+            desired_full_cone_private_node_count,
+            desired_full_cone_private_node_vm_count,
+            desired_node_vm_count,
+            desired_peer_cache_node_count,
+            desired_peer_cache_node_vm_count,
+            desired_symmetric_private_node_count,
+            desired_symmetric_private_node_vm_count,
+            desired_uploader_vm_count,
+            desired_uploaders_count,
+            funding_wallet_secret_key,
+            gas_amount: None,
+            infra_only,
+            interval,
+            max_archived_log_files,
+            max_log_files,
+            plan,
+            provision_only: false,
+            public_rpc,
+            token_amount: None,
+        })
+        .await?;
+
+    if plan {
+        return Ok(());
+    }
+
+    println!("Generating new inventory after upscale...");
+    let max_retries = 3;
+    let mut retries = 0;
+    let inventory = loop {
+        match inventory_service
+            .generate_or_retrieve_inventory(&name, true, None)
+            .await
+        {
+            Ok(inv) => break inv,
+            Err(e) if retries < max_retries => {
+                retries += 1;
+                eprintln!("Failed to generate inventory on attempt {retries}: {:?}", e);
+                eprintln!("Will retry up to {max_retries} times...");
+            }
+            Err(_) => {
+                eprintln!("Failed to generate inventory after {max_retries} attempts");
+                eprintln!("Please try running the `inventory` command or workflow separately");
+                return Ok(());
+            }
+        }
+    };
+
+    inventory.print_report(false)?;
+    inventory.save()?;
+
+    Ok(())
+}

--- a/src/cmd/funds.rs
+++ b/src/cmd/funds.rs
@@ -1,0 +1,166 @@
+// Copyright (c) 2023, MaidSafe.
+// All rights reserved.
+//
+// This SAFE Network Software is licensed under the BSD-3-Clause license.
+// Please see the LICENSE file for more details.
+
+use super::*;
+
+use alloy::primitives::{Address, U256};
+use clap::Subcommand;
+use color_eyre::{eyre::eyre, Result};
+use evmlib::Network;
+use sn_testnet_deploy::{
+    funding::FundingOptions, get_environment_details, inventory::DeploymentInventoryService,
+    CloudProvider, EvmNetwork, TestnetDeployBuilder,
+};
+use std::str::FromStr;
+
+#[derive(Subcommand, Debug)]
+pub enum FundsCommand {
+    /// Deposit tokens and gas from the provided funding wallet secret key to all the uploaders
+    Deposit {
+        /// The secret key for the wallet that will fund all the uploaders.
+        ///
+        /// This argument only applies when Arbitrum or Sepolia networks are used.
+        #[clap(long)]
+        funding_wallet_secret_key: Option<String>,
+        /// The number of gas to transfer, in U256
+        ///
+        /// 1 ETH = 1_000_000_000_000_000_000. Defaults to 0.1 ETH
+        #[arg(long)]
+        gas_to_transfer: Option<U256>,
+        /// The name of the environment.
+        #[arg(short = 'n', long)]
+        name: String,
+        /// The cloud provider for the environment.
+        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
+        provider: CloudProvider,
+        /// The number of tokens to transfer, in U256
+        ///
+        /// 1 Token = 1_000_000_000_000_000_000. Defaults to 100 token.
+        #[arg(long)]
+        tokens_to_transfer: Option<U256>,
+    },
+    /// Drain all the tokens and gas from the uploaders to the funding wallet.
+    Drain {
+        /// The name of the environment.
+        #[arg(short = 'n', long)]
+        name: String,
+        /// The cloud provider for the environment.
+        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
+        provider: CloudProvider,
+        /// The address of the wallet that will receive all the tokens and gas.
+        ///
+        /// This argument is optional, the funding wallet address from the S3 environment file will be used by default.
+        #[clap(long)]
+        to_address: Option<String>,
+    },
+}
+
+pub async fn handle_funds_command(cmd: FundsCommand) -> Result<()> {
+    match cmd {
+        FundsCommand::Deposit {
+            funding_wallet_secret_key,
+            gas_to_transfer,
+            name,
+            provider,
+            tokens_to_transfer,
+        } => {
+            let testnet_deployer = TestnetDeployBuilder::default()
+                .environment_name(&name)
+                .provider(provider)
+                .build()?;
+            let inventory_services = DeploymentInventoryService::from(&testnet_deployer);
+            inventory_services
+                .generate_or_retrieve_inventory(&name, true, None)
+                .await?;
+
+            let environment_details =
+                get_environment_details(&name, &inventory_services.s3_repository).await?;
+
+            let options = FundingOptions {
+                evm_data_payments_address: environment_details.evm_data_payments_address,
+                evm_payment_token_address: environment_details.evm_payment_token_address,
+                evm_rpc_url: environment_details.evm_rpc_url,
+                evm_network: environment_details.evm_network,
+                funding_wallet_secret_key,
+                uploaders_count: None,
+                token_amount: tokens_to_transfer,
+                gas_amount: gas_to_transfer,
+            };
+            testnet_deployer
+                .ansible_provisioner
+                .deposit_funds_to_uploaders(&options)
+                .await?;
+
+            Ok(())
+        }
+        FundsCommand::Drain {
+            name,
+            provider,
+            to_address,
+        } => {
+            let testnet_deployer = TestnetDeployBuilder::default()
+                .environment_name(&name)
+                .provider(provider)
+                .build()?;
+
+            let inventory_services = DeploymentInventoryService::from(&testnet_deployer);
+            inventory_services
+                .generate_or_retrieve_inventory(&name, true, None)
+                .await?;
+
+            let environment_details =
+                get_environment_details(&name, &inventory_services.s3_repository).await?;
+
+            let to_address = if let Some(to_address) = to_address {
+                Address::from_str(&to_address)?
+            } else if let Some(to_address) = environment_details.funding_wallet_address {
+                Address::from_str(&to_address)?
+            } else {
+                return Err(eyre!(
+                    "No to-address was provided and no funding wallet address was found in the environment details"
+                ));
+            };
+
+            let network = match environment_details.evm_network {
+                EvmNetwork::Anvil => {
+                    return Err(eyre!(
+                        "Draining funds from uploaders is not supported for an Anvil network"
+                    ));
+                }
+                EvmNetwork::ArbitrumOne => Network::ArbitrumOne,
+                EvmNetwork::ArbitrumSepolia => Network::ArbitrumSepolia,
+                EvmNetwork::Custom => {
+                    if let (
+                        Some(emv_data_payments_address),
+                        Some(evm_payment_token_address),
+                        Some(evm_rpc_url),
+                    ) = (
+                        environment_details.evm_data_payments_address,
+                        environment_details.evm_payment_token_address,
+                        environment_details.evm_rpc_url,
+                    ) {
+                        Network::new_custom(
+                            &evm_rpc_url,
+                            &evm_payment_token_address,
+                            &emv_data_payments_address,
+                        )
+                    } else {
+                        return Err(eyre!(
+                            "Custom EVM details not found in the environment details"
+                        ));
+                    }
+                }
+            };
+
+            testnet_deployer
+                .ansible_provisioner
+                .drain_funds_from_uploaders(to_address, network)
+                .await?;
+
+            Ok(())
+        }
+    }
+}

--- a/src/cmd/logs.rs
+++ b/src/cmd/logs.rs
@@ -1,0 +1,183 @@
+// Copyright (c) 2023, MaidSafe.
+// All rights reserved.
+//
+// This SAFE Network Software is licensed under the BSD-3-Clause license.
+// Please see the LICENSE file for more details.
+
+use super::*;
+
+use clap::Subcommand;
+use color_eyre::Result;
+use sn_testnet_deploy::{
+    inventory::DeploymentInventoryService, CloudProvider, TestnetDeployBuilder,
+};
+
+#[derive(Subcommand, Debug)]
+pub enum LogCommands {
+    /// Removes all the rotated log files from the the node VMs.
+    Cleanup {
+        /// The name of the environment
+        #[arg(short = 'n', long)]
+        name: String,
+        /// The cloud provider that was used.
+        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
+        provider: CloudProvider,
+        /// Setup a cron job to perform the cleanup periodically.
+        #[clap(long)]
+        setup_cron: bool,
+    },
+    /// Retrieve the logs for a given environment by copying them from all the VMs.
+    ///
+    /// This will write the logs to 'logs/<name>', relative to the current directory.
+    Copy {
+        /// The name of the environment
+        #[arg(short = 'n', long)]
+        name: String,
+        /// The cloud provider that was used.
+        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
+        provider: CloudProvider,
+        /// Should we copy the resource-usage.logs only
+        #[arg(short = 'r', long)]
+        resources_only: bool,
+    },
+    /// Retrieve the logs for a given environment from S3.
+    ///
+    /// This will write the logs to 'logs/<name>', relative to the current directory.
+    Get {
+        /// The name of the environment
+        #[arg(short = 'n', long)]
+        name: String,
+    },
+    /// Reassemble retrieved logs from their parts.
+    ///
+    /// The logs must have already been retrieved using the 'get' command and be present at
+    /// 'logs/<name>'.
+    ///
+    /// This will write the logs to 'logs/<name>-reassembled', relative to the current directory.
+    ///
+    /// The original logs are left intact so you can sync again if need be.
+    Reassemble {
+        /// The name of the environment for which logs have already been retrieved
+        #[arg(short = 'n', long)]
+        name: String,
+    },
+    /// Run a ripgrep query through all the logs from all the VMs and copy the results.
+    ///
+    /// The results will be written to `logs/<name>/<vm>/rg-timestamp.log`
+    Rg {
+        /// The ripgrep arguments that are directly passed to ripgrep. The text to search for should be put inside
+        /// single quotes. The dir to search for is set automatically, so do not provide one.
+        ///
+        /// Example command: `cargo run --release -- logs rg --name <name> --args "'ValidSpendRecordPutFromNetwork' -z -a"`
+        #[arg(short = 'a', long, allow_hyphen_values(true))]
+        args: String,
+        /// The name of the environment
+        #[arg(short = 'n', long)]
+        name: String,
+        /// The cloud provider that was used.
+        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
+        provider: CloudProvider,
+    },
+    /// Remove the logs from a given environment from the bucket on S3.
+    Rm {
+        /// The name of the environment for which logs have already been retrieved
+        #[arg(short = 'n', long)]
+        name: String,
+    },
+    /// Rsync the logs from all the VMs for a given environment.
+    /// Rerunning the same command will sync only the changed log files without copying everything from the beginning.
+    ///
+    /// This will write the logs to 'logs/<name>', relative to the current directory.
+    Rsync {
+        /// The name of the environment
+        #[arg(short = 'n', long)]
+        name: String,
+        /// The cloud provider that was used.
+        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
+        provider: CloudProvider,
+        /// Optionally only sync the logs for the VMs that contain the following string.
+        #[arg(long)]
+        vm_filter: Option<String>,
+    },
+}
+
+pub async fn handle_logs_command(log_cmd: LogCommands) -> Result<()> {
+    match log_cmd {
+        LogCommands::Cleanup {
+            name,
+            provider,
+            setup_cron,
+        } => {
+            let testnet_deployer = TestnetDeployBuilder::default()
+                .environment_name(&name)
+                .provider(provider)
+                .build()?;
+            testnet_deployer.init().await?;
+            let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
+            inventory_service.setup_environment_inventory(&name)?;
+
+            testnet_deployer.cleanup_node_logs(setup_cron)?;
+            Ok(())
+        }
+        LogCommands::Copy {
+            name,
+            provider,
+            resources_only,
+        } => {
+            let testnet_deployer = TestnetDeployBuilder::default()
+                .environment_name(&name)
+                .provider(provider)
+                .build()?;
+            testnet_deployer.init().await?;
+            let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
+            inventory_service.setup_environment_inventory(&name)?;
+
+            testnet_deployer.copy_logs(&name, resources_only)?;
+            Ok(())
+        }
+        LogCommands::Get { name } => {
+            sn_testnet_deploy::logs::get_logs(&name).await?;
+            Ok(())
+        }
+        LogCommands::Reassemble { name } => {
+            sn_testnet_deploy::logs::reassemble_logs(&name)?;
+            Ok(())
+        }
+        LogCommands::Rg {
+            args,
+            name,
+            provider,
+        } => {
+            let testnet_deployer = TestnetDeployBuilder::default()
+                .environment_name(&name)
+                .provider(provider)
+                .build()?;
+            testnet_deployer.init().await?;
+            let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
+            inventory_service.setup_environment_inventory(&name)?;
+
+            testnet_deployer.ripgrep_logs(&name, &args)?;
+            Ok(())
+        }
+        LogCommands::Rm { name } => {
+            sn_testnet_deploy::logs::rm_logs(&name).await?;
+            Ok(())
+        }
+        LogCommands::Rsync {
+            name,
+            provider,
+            vm_filter,
+        } => {
+            let testnet_deployer = TestnetDeployBuilder::default()
+                .environment_name(&name)
+                .provider(provider)
+                .build()?;
+            testnet_deployer.init().await?;
+            let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
+            inventory_service.setup_environment_inventory(&name)?;
+
+            testnet_deployer.rsync_logs(&name, vm_filter)?;
+            Ok(())
+        }
+    }
+}

--- a/src/cmd/misc.rs
+++ b/src/cmd/misc.rs
@@ -1,0 +1,185 @@
+// Copyright (c) 2023, MaidSafe.
+// All rights reserved.
+//
+// This SAFE Network Software is licensed under the BSD-3-Clause license.
+// Please see the LICENSE file for more details.
+
+use color_eyre::{
+    eyre::{eyre, Result},
+    Help,
+};
+use sn_testnet_deploy::{
+    ansible::{extra_vars::ExtraVarsDocBuilder, inventory::AnsibleInventoryType, AnsiblePlaybook},
+    get_environment_details,
+    infra::InfraRunOptions,
+    inventory::{get_data_directory, DeploymentInventory, DeploymentInventoryService},
+    notify_slack, TestnetDeployBuilder,
+};
+
+#[allow(clippy::too_many_arguments)]
+pub async fn handle_extend_volume_size(
+    ansible_verbose: bool,
+    genesis_node_volume_size: Option<u16>,
+    full_cone_private_node_volume_size: Option<u16>,
+    node_volume_size: Option<u16>,
+    name: String,
+    peer_cache_node_volume_size: Option<u16>,
+    provider: sn_testnet_deploy::CloudProvider,
+    symmetric_private_node_volume_size: Option<u16>,
+) -> Result<()> {
+    if peer_cache_node_volume_size.is_none()
+        && genesis_node_volume_size.is_none()
+        && node_volume_size.is_none()
+        && symmetric_private_node_volume_size.is_none()
+        && full_cone_private_node_volume_size.is_none()
+    {
+        return Err(eyre!("At least one volume size must be provided"));
+    }
+
+    println!("Extending attached volume size...");
+    let testnet_deployer = TestnetDeployBuilder::default()
+        .ansible_verbose_mode(ansible_verbose)
+        .environment_name(&name)
+        .provider(provider)
+        .build()?;
+    testnet_deployer.init().await?;
+
+    let environemt_details =
+        get_environment_details(&name, &testnet_deployer.s3_repository).await?;
+
+    let mut infra_run_options = InfraRunOptions::generate_existing(
+        &name,
+        &testnet_deployer.terraform_runner,
+        &environemt_details,
+    )
+    .await?;
+    println!("Obtained infra run options from previous deployment {infra_run_options:?}");
+    let mut node_types = Vec::new();
+
+    if peer_cache_node_volume_size.is_some() {
+        infra_run_options.peer_cache_node_volume_size = peer_cache_node_volume_size;
+        node_types.push(AnsibleInventoryType::PeerCacheNodes);
+    }
+    if genesis_node_volume_size.is_some() {
+        infra_run_options.genesis_node_volume_size = genesis_node_volume_size;
+        node_types.push(AnsibleInventoryType::Genesis);
+    }
+    if node_volume_size.is_some() {
+        infra_run_options.node_volume_size = node_volume_size;
+        node_types.push(AnsibleInventoryType::Nodes);
+    }
+    if symmetric_private_node_volume_size.is_some() {
+        infra_run_options.symmetric_private_node_volume_size = symmetric_private_node_volume_size;
+        node_types.push(AnsibleInventoryType::SymmetricPrivateNodes);
+    }
+    if full_cone_private_node_volume_size.is_some() {
+        infra_run_options.full_cone_private_node_volume_size = full_cone_private_node_volume_size;
+        node_types.push(AnsibleInventoryType::FullConePrivateNodes);
+    }
+
+    println!("Running infra update with new volume sizes: {infra_run_options:?}");
+    testnet_deployer
+        .create_or_update_infra(&infra_run_options)
+        .map_err(|err| {
+            println!("Failed to create infra {err:?}");
+            err
+        })?;
+
+    for node_type in node_types {
+        println!("Extending volume size for {node_type} nodes...");
+        testnet_deployer
+            .ansible_provisioner
+            .ansible_runner
+            .run_playbook(AnsiblePlaybook::ExtendVolumeSize, node_type, None)?;
+    }
+
+    Ok(())
+}
+
+pub async fn handle_inventory(
+    force_regeneration: bool,
+    full: bool,
+    name: String,
+    network_contacts_file_name: Option<String>,
+    peer_cache: bool,
+    provider: sn_testnet_deploy::CloudProvider,
+) -> Result<()> {
+    let testnet_deployer = TestnetDeployBuilder::default()
+        .environment_name(&name)
+        .provider(provider)
+        .build()?;
+
+    let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
+    let inventory = inventory_service
+        .generate_or_retrieve_inventory(&name, force_regeneration, None)
+        .await?;
+
+    if peer_cache {
+        inventory.print_peer_cache_webserver();
+    } else {
+        inventory.print_report(full)?;
+    }
+
+    inventory.save()?;
+
+    inventory_service
+        .upload_network_contacts(&inventory, network_contacts_file_name)
+        .await?;
+
+    Ok(())
+}
+
+pub async fn handle_notify(name: String) -> Result<()> {
+    let inventory_path = get_data_directory()?.join(format!("{name}-inventory.json"));
+    if !inventory_path.exists() {
+        return Err(eyre!("There is no inventory for the {name} testnet")
+            .suggestion("Please run the inventory command to generate it"));
+    }
+
+    let inventory = DeploymentInventory::read(&inventory_path)?;
+    notify_slack(inventory).await?;
+    Ok(())
+}
+
+pub async fn handle_configure_swapfile(
+    name: String,
+    provider: sn_testnet_deploy::CloudProvider,
+    peer_cache: bool,
+    size: u16,
+) -> Result<()> {
+    let testnet_deployer = TestnetDeployBuilder::default()
+        .environment_name(&name)
+        .provider(provider)
+        .build()?;
+
+    let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
+    let inventory = inventory_service
+        .generate_or_retrieve_inventory(&name, true, None)
+        .await?;
+    if inventory.is_empty() {
+        return Err(eyre!("The {name} environment does not exist"));
+    }
+
+    let ansible_runner = testnet_deployer.ansible_provisioner.ansible_runner;
+    ansible_runner.run_playbook(
+        AnsiblePlaybook::ConfigureSwapfile,
+        AnsibleInventoryType::Nodes,
+        Some(build_swapfile_extra_vars_doc(size)?),
+    )?;
+
+    if peer_cache {
+        ansible_runner.run_playbook(
+            AnsiblePlaybook::ConfigureSwapfile,
+            AnsibleInventoryType::PeerCacheNodes,
+            Some(build_swapfile_extra_vars_doc(size)?),
+        )?;
+    }
+
+    Ok(())
+}
+
+fn build_swapfile_extra_vars_doc(size: u16) -> Result<String> {
+    let mut extra_vars = ExtraVarsDocBuilder::default();
+    extra_vars.add_variable("swapfile_size", &format!("{size}G"));
+    Ok(extra_vars.build())
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,0 +1,1299 @@
+// Copyright (c) 2023, MaidSafe.
+// All rights reserved.
+//
+// This SAFE Network Software is licensed under the BSD-3-Clause license.
+// Please see the LICENSE file for more details.
+
+pub mod deployments;
+pub mod funds;
+pub mod logs;
+pub mod misc;
+pub mod network;
+pub mod nodes;
+pub mod telegraf;
+pub mod upgrade;
+pub mod uploaders;
+
+use crate::cmd::{
+    funds::FundsCommand, logs::LogCommands, network::NetworkCommands, uploaders::UploadersCommands,
+};
+use alloy::primitives::U256;
+use ant_releases::{AntReleaseRepoActions, ReleaseType};
+use clap::Subcommand;
+use color_eyre::{
+    eyre::{bail, eyre, OptionExt},
+    Help, Result,
+};
+use log::debug;
+use semver::Version;
+use sn_testnet_deploy::{
+    inventory::{DeploymentInventory, VirtualMachine},
+    BinaryOption, CloudProvider, EnvironmentType, EvmNetwork, LogFormat, NodeType,
+};
+use std::time::Duration;
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Bootstrap a new network from an existing deployment.
+    Bootstrap {
+        /// Supply a version number for the antctl binary.
+        ///
+        /// There should be no 'v' prefix.
+        ///
+        /// The version arguments are mutually exclusive with the --branch and --repo-owner
+        /// arguments. You can only supply version numbers or a custom branch, not both.
+        #[arg(long, verbatim_doc_comment)]
+        antctl_version: Option<String>,
+        /// The features to enable on the antnode binary.
+        ///
+        /// If not provided, the default feature set specified for the antnode binary are used.
+        ///
+        /// The features argument is mutually exclusive with the --antnode-version argument.
+        #[clap(long, verbatim_doc_comment)]
+        antnode_features: Option<Vec<String>>,
+        /// Supply a version number for the antnode binary.
+        ///
+        /// There should be no 'v' prefix.
+        ///
+        /// The version arguments are mutually exclusive with the --branch and --repo-owner
+        /// arguments. You can only supply version numbers or a custom branch, not both.
+        #[arg(long, verbatim_doc_comment)]
+        antnode_version: Option<String>,
+        /// Set to run Ansible with more verbose output.
+        #[arg(long)]
+        ansible_verbose: bool,
+        /// The branch of the Github repository to build from.
+        ///
+        /// If used, all binaries will be built from this branch. It is typically used for testing
+        /// changes on a fork.
+        ///
+        /// This argument must be used in conjunction with the --repo-owner argument.
+        ///
+        /// The --branch and --repo-owner arguments are mutually exclusive with the binary version
+        /// arguments. You can only supply version numbers or a custom branch, not both.
+        #[arg(long, verbatim_doc_comment)]
+        branch: Option<String>,
+        /// The network contacts URL to bootstrap from.
+        ///
+        /// Either this or the `bootstrap-peer` argument must be provided.
+        bootstrap_network_contacts_url: Option<String>,
+        /// The peer from an existing network that we can bootstrap from.
+        ///
+        /// Either this or the `bootstrap-network-contacts-url` argument must be provided.
+        #[arg(long)]
+        bootstrap_peer: Option<String>,
+        /// Specify the chunk size for the custom binaries using a 64-bit integer.
+        ///
+        /// This option only applies if the --branch and --repo-owner arguments are used.
+        #[clap(long, value_parser = parse_chunk_size)]
+        chunk_size: Option<u64>,
+        /// The type of deployment.
+        ///
+        /// Possible values are 'development', 'production' or 'staging'. The value used will
+        /// determine the sizes of VMs, the number of VMs, and the number of nodes deployed on
+        /// them. The specification will increase in size from development, to staging, to
+        /// production.
+        ///
+        /// The default is 'development'.
+        #[clap(long, default_value_t = EnvironmentType::Development, value_parser = parse_deployment_type, verbatim_doc_comment)]
+        environment_type: EnvironmentType,
+        /// Provide environment variables for the antnode service.
+        ///
+        /// This is useful to set the antnode's log levels. Each variable should be comma
+        /// separated without any space.
+        ///
+        /// Example: --env SN_LOG=all,RUST_LOG=libp2p=debug
+        #[clap(name = "env", long, use_value_delimiter = true, value_parser = parse_environment_variables, verbatim_doc_comment)]
+        env_variables: Option<Vec<(String, String)>>,
+        /// The address of the data payments contract.
+        ///
+        /// This argument must match the same contract address used in the existing network.
+        #[arg(long)]
+        evm_data_payments_address: Option<String>,
+        /// The EVM network to use.
+        ///
+        /// Valid values are "arbitrum-one", "arbitrum-sepolia", or "custom".
+        #[clap(long, default_value_t = EvmNetwork::ArbitrumOne, value_parser = parse_evm_network)]
+        evm_network_type: EvmNetwork,
+        /// The address of the payment token contract.
+        ///
+        /// This argument must match the same contract address used in the existing network.
+        #[arg(long)]
+        evm_payment_token_address: Option<String>,
+        /// The RPC URL for the EVM network.
+        ///
+        /// This argument only applies if the EVM network type is 'custom'.
+        #[arg(long)]
+        evm_rpc_url: Option<String>,
+        /// Override the maximum number of forks Ansible will use to execute tasks on target hosts.
+        ///
+        /// The default value from ansible.cfg is 50.
+        #[clap(long)]
+        forks: Option<usize>,
+        /// The number of antnode services to be run behind a Full Cone NAT Gateway on each private node VM.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        /// argument.
+        #[clap(long, verbatim_doc_comment)]
+        full_cone_private_node_count: Option<u16>,
+        /// The number of private node VMs to create. The private nodes will be behind a Full Cone NAT Gateway.
+        ///
+        /// Each VM will run many antnode services.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        #[clap(long, verbatim_doc_comment)]
+        full_cone_private_node_vm_count: Option<u16>,
+        /// The size of the volumes to attach to each private node VM. This argument will set the size of all the
+        /// 7 attached volumes.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        /// argument.
+        #[clap(long)]
+        full_cone_private_node_volume_size: Option<u16>,
+        /// The interval between starting each node in milliseconds.
+        #[clap(long, value_parser = |t: &str| -> Result<Duration> { Ok(t.parse().map(Duration::from_millis)?)}, default_value = "2000")]
+        interval: Duration,
+        /// Specify the logging format for the nodes.
+        ///
+        /// Valid values are "default" or "json".
+        ///
+        /// If the argument is not used, the default format will be applied.
+        #[clap(long, value_parser = LogFormat::parse_from_str, verbatim_doc_comment)]
+        log_format: Option<LogFormat>,
+        /// The maximum of archived log files to keep. After reaching this limit, the older files are deleted.
+        #[clap(long, default_value = "5")]
+        max_archived_log_files: u16,
+        /// The maximum number of log files to keep. After reaching this limit, the older files are archived.
+        #[clap(long, default_value = "10")]
+        max_log_files: u16,
+        /// The name of the environment
+        #[arg(short = 'n', long)]
+        name: String,
+        /// Specify the network ID to use for the node services. This is used to partition the network and will not allow
+        /// nodes with different network IDs to join.
+        ///
+        /// By default, the network ID is set to 1, which represents the mainnet.
+        #[clap(long, verbatim_doc_comment)]
+        network_id: Option<u8>,
+        /// The number of antnode services to run on each VM.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        /// argument.
+        #[clap(long)]
+        node_count: Option<u16>,
+        /// The number of node VMs to create.
+        ///
+        /// Each VM will run many antnode services.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        /// argument.
+        #[clap(long)]
+        node_vm_count: Option<u16>,
+        /// Override the size of the node VMs.
+        #[clap(long)]
+        node_vm_size: Option<String>,
+        /// The size of the volumes to attach to each node VM. This argument will set the size of all the 7 attached
+        /// volumes.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        /// argument.
+        #[clap(long)]
+        node_volume_size: Option<u16>,
+        /// The cloud provider to deploy to.
+        ///
+        /// Valid values are "aws" or "digital-ocean".
+        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
+        provider: CloudProvider,
+        /// The owner/org of the Github repository to build from.
+        ///
+        /// If used, all binaries will be built from this repository. It is typically used for
+        /// testing changes on a fork.
+        ///
+        /// This argument must be used in conjunction with the --repo-owner argument.
+        ///
+        /// The --branch and --repo-owner arguments are mutually exclusive with the binary version
+        /// arguments. You can only supply version numbers or a custom branch, not both.
+        #[arg(long, verbatim_doc_comment)]
+        repo_owner: Option<String>,
+        /// The rewards address for each of the antnode services.
+        #[arg(long, required = true)]
+        rewards_address: String,
+        /// The number of antnode services to be run behind a Symmetric NAT Gateway on each private node VM.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        /// argument.
+        #[clap(long, verbatim_doc_comment)]
+        symmetric_private_node_count: Option<u16>,
+        /// The number of private node VMs to create. The private nodes will be behind a Symmetric NAT Gateway.
+        ///
+        /// Each VM will run many antnode services.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        #[clap(long, verbatim_doc_comment)]
+        symmetric_private_node_vm_count: Option<u16>,
+        /// The size of the volumes to attach to each private node VM. This argument will set the size of all the
+        /// 7 attached volumes.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        /// argument.
+        #[clap(long)]
+        symmetric_private_node_volume_size: Option<u16>,
+    },
+    /// Clean a deployed testnet environment.
+    Clean {
+        /// The name of the environment.
+        #[arg(short = 'n', long)]
+        name: String,
+        /// The cloud provider for the environment.
+        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
+        provider: CloudProvider,
+    },
+    /// Configure a swapfile on all nodes in the environment.
+    ConfigureSwapfile {
+        /// The name of the environment.
+        #[arg(short = 'n', long)]
+        name: String,
+        /// The size of the swapfile in GB.
+        #[arg(short = 's', long)]
+        size: u16,
+        /// Set to also configure swapfile on the PeerCache nodes.
+        #[arg(long)]
+        peer_cache: bool,
+        /// The cloud provider for the environment.
+        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
+        provider: CloudProvider,
+    },
+    /// Deploy a new testnet environment using the latest version of the antnode binary.
+    Deploy {
+        /// Set to run Ansible with more verbose output.
+        #[arg(long)]
+        ansible_verbose: bool,
+        /// Supply a version number for the ant binary.
+        ///
+        /// There should be no 'v' prefix.
+        ///
+        /// The version arguments are mutually exclusive with the --branch and --repo-owner
+        /// arguments. You can only supply version numbers or a custom branch, not both.
+        #[arg(long, verbatim_doc_comment)]
+        ant_version: Option<String>,
+        /// Supply a version number for the antctl binary.
+        ///
+        /// There should be no 'v' prefix.
+        ///
+        /// The version arguments are mutually exclusive with the --branch and --repo-owner
+        /// arguments. You can only supply version numbers or a custom branch, not both.
+        #[arg(long, verbatim_doc_comment)]
+        antctl_version: Option<String>,
+        /// The features to enable on the antnode binary.
+        ///
+        /// If not provided, the default feature set specified for the antnode binary are used.
+        ///
+        /// The features argument is mutually exclusive with the --antnode-version argument.
+        #[clap(long, verbatim_doc_comment)]
+        antnode_features: Option<Vec<String>>,
+        /// Supply a version number for the antnode binary.
+        ///
+        /// There should be no 'v' prefix.
+        ///
+        /// The version arguments are mutually exclusive with the --branch and --repo-owner
+        /// arguments. You can only supply version numbers or a custom branch, not both.
+        #[arg(long, verbatim_doc_comment)]
+        antnode_version: Option<String>,
+        /// The branch of the Github repository to build from.
+        ///
+        /// If used, all binaries will be built from this branch. It is typically used for testing
+        /// changes on a fork.
+        ///
+        /// This argument must be used in conjunction with the --repo-owner argument.
+        ///
+        /// The --branch and --repo-owner arguments are mutually exclusive with the binary version
+        /// arguments. You can only supply version numbers or a custom branch, not both.
+        #[arg(long, verbatim_doc_comment)]
+        branch: Option<String>,
+        /// The number of antnode services to run on each Peer Cache VM.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        /// argument.
+        #[clap(long)]
+        peer_cache_node_count: Option<u16>,
+        /// The number of Peer Cache node VMs to create.
+        ///
+        /// Each VM will run many antnode services.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        /// argument.
+        #[clap(long)]
+        peer_cache_node_vm_count: Option<u16>,
+        /// Override the size of the Peer Cache node VMs.
+        #[clap(long)]
+        peer_cache_node_vm_size: Option<String>,
+        /// The size of the volumes to attach to each Peer Cache node VM. This argument will set the size of all the
+        /// 7 attached volumes.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        /// argument.
+        #[clap(long)]
+        peer_cache_node_volume_size: Option<u16>,
+        /// Specify the chunk size for the custom binaries using a 64-bit integer.
+        ///
+        /// This option only applies if the --branch and --repo-owner arguments are used.
+        #[clap(long, value_parser = parse_chunk_size)]
+        chunk_size: Option<u64>,
+        /// If set to a non-zero value, the uploaders will also be accompanied by the specified
+        /// number of downloaders.
+        ///
+        /// This will be the number on each uploader VM. So if the value here is 2 and there are
+        /// 5 uploader VMs, there will be 10 downloaders across the 5 VMs.
+        #[clap(long, default_value_t = 0)]
+        downloaders_count: u16,
+        /// Provide environment variables for the antnode service.
+        ///
+        /// This is useful to set the antnode's log levels. Each variable should be comma
+        /// separated without any space.
+        ///
+        /// Example: --env SN_LOG=all,RUST_LOG=libp2p=debug
+        #[clap(name = "env", long, use_value_delimiter = true, value_parser = parse_environment_variables, verbatim_doc_comment)]
+        env_variables: Option<Vec<(String, String)>>,
+        /// The type of deployment.
+        ///
+        /// Possible values are 'development', 'production' or 'staging'. The value used will
+        /// determine the sizes of VMs, the number of VMs, and the number of nodes deployed on
+        /// them. The specification will increase in size from development, to staging, to
+        /// production.
+        ///
+        /// The default is 'development'.
+        #[clap(long, default_value_t = EnvironmentType::Development, value_parser = parse_deployment_type, verbatim_doc_comment)]
+        environment_type: EnvironmentType,
+        /// The address of the data payments contract.
+        #[arg(long)]
+        evm_data_payments_address: Option<String>,
+        /// The EVM network type to use for the deployment.
+        ///
+        /// Possible values are 'arbitrum-one' or 'custom'.
+        ///
+        /// If not used, the default is 'arbitrum-one'.
+        #[clap(long, default_value = "arbitrum-one", value_parser = parse_evm_network)]
+        evm_network_type: EvmNetwork,
+        /// The address of the payment token contract.
+        #[arg(long)]
+        evm_payment_token_address: Option<String>,
+        /// Override the size of the EVM node VMs.
+        #[clap(long)]
+        evm_node_vm_size: Option<String>,
+        /// The RPC URL for the EVM network.
+        ///
+        /// This argument only applies if the EVM network type is 'custom'.
+        #[arg(long)]
+        evm_rpc_url: Option<String>,
+        /// Override the maximum number of forks Ansible will use to execute tasks on target hosts.
+        ///
+        /// The default value from ansible.cfg is 50.
+        #[clap(long)]
+        forks: Option<usize>,
+        /// Override the size of the Full Cone NAT gateway VM.
+        #[clap(long)]
+        full_cone_nat_gateway_vm_size: Option<String>,
+        /// The number of antnode services to be run behind a Full Cone NAT Gateway on each private node VM.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        /// argument.
+        #[clap(long, verbatim_doc_comment)]
+        full_cone_private_node_count: Option<u16>,
+        /// The number of private node VMs to create. The private nodes will be behind a Full Cone NAT Gateway.
+        ///
+        /// Each VM will run many antnode services.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        #[clap(long, verbatim_doc_comment)]
+        full_cone_private_node_vm_count: Option<u16>,
+        /// The size of the volumes to attach to each private node VM. This argument will set the size of all the
+        /// 7 attached volumes.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        /// argument.
+        #[clap(long)]
+        full_cone_private_node_volume_size: Option<u16>,
+        /// The secret key for the wallet that will fund all the uploaders.
+        ///
+        /// This argument only applies when Arbitrum or Sepolia networks are used.
+        #[clap(long)]
+        funding_wallet_secret_key: Option<String>,
+        /// The size of the volumes to attach to each genesis node VM. This argument will set the size of all the
+        /// 7 attached volumes.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        /// argument.
+        #[clap(long)]
+        genesis_node_volume_size: Option<u16>,
+        /// The amount of gas to initially transfer to each uploader, in U256
+        ///
+        /// 1 ETH = 1_000_000_000_000_000_000. Defaults to 0.1 ETH
+        #[arg(long)]
+        initial_gas: Option<U256>,
+        /// The amount of tokens to initially transfer to each uploader, in U256
+        ///
+        /// 1 Token = 1_000_000_000_000_000_000. Defaults to 100 token.
+        #[arg(long)]
+        initial_tokens: Option<U256>,
+        /// The interval between starting each node in milliseconds.
+        #[clap(long, value_parser = |t: &str| -> Result<Duration> { Ok(t.parse().map(Duration::from_millis)?)}, default_value = "2000")]
+        interval: Duration,
+        /// Specify the logging format for the nodes.
+        ///
+        /// Valid values are "default" or "json".
+        ///
+        /// If the argument is not used, the default format will be applied.
+        #[clap(long, value_parser = LogFormat::parse_from_str, verbatim_doc_comment)]
+        log_format: Option<LogFormat>,
+        /// The name of the Logstash stack to forward logs to.
+        #[clap(long, default_value = "main")]
+        logstash_stack_name: String,
+        /// The maximum of archived log files to keep. After reaching this limit, the older files are deleted.
+        #[clap(long, default_value = "5")]
+        max_archived_log_files: u16,
+        /// The maximum number of log files to keep. After reaching this limit, the older files are archived.
+        #[clap(long, default_value = "10")]
+        max_log_files: u16,
+        /// The name of the environment
+        #[arg(short = 'n', long)]
+        name: String,
+        /// Specify the network ID to use for the node services. This is used to partition the network and will not allow
+        /// nodes with different network IDs to join.
+        ///
+        /// By default, the network ID is set to 1, which represents the mainnet.
+        #[clap(long, verbatim_doc_comment)]
+        network_id: Option<u8>,
+        /// Provide a name for the network contacts file to be uploaded to S3.
+        ///
+        /// If not used, the contacts file will have the same name as the environment.
+        #[arg(long)]
+        network_contacts_file_name: Option<String>,
+        /// The number of antnode services to run on each VM.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        /// argument.
+        #[clap(long)]
+        node_count: Option<u16>,
+        /// The number of node VMs to create.
+        ///
+        /// Each VM will run many antnode services.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        /// argument.
+        #[clap(long)]
+        node_vm_count: Option<u16>,
+        /// Override the size of the node VMs.
+        #[clap(long)]
+        node_vm_size: Option<String>,
+        /// The size of the volumes to attach to each node VM. This argument will set the size of all the 7 attached
+        /// volumes.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        /// argument.
+        #[clap(long)]
+        node_volume_size: Option<u16>,
+        /// The cloud provider to deploy to.
+        ///
+        /// Valid values are "aws" or "digital-ocean".
+        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
+        provider: CloudProvider,
+        /// If set to true, the RPC of the node will be accessible remotely.
+        ///
+        /// By default, the antnode RPC is only accessible via the 'localhost' and is not exposed for
+        /// security reasons.
+        #[clap(long, default_value_t = false, verbatim_doc_comment)]
+        public_rpc: bool,
+        /// The owner/org of the Github repository to build from.
+        ///
+        /// If used, all binaries will be built from this repository. It is typically used for
+        /// testing changes on a fork.
+        ///
+        /// This argument must be used in conjunction with the --repo-owner argument.
+        ///
+        /// The --branch and --repo-owner arguments are mutually exclusive with the binary version
+        /// arguments. You can only supply version numbers or a custom branch, not both.
+        #[arg(long, verbatim_doc_comment)]
+        repo_owner: Option<String>,
+        /// The rewards address for each of the antnode services.
+        #[arg(long, required = true)]
+        rewards_address: String,
+        /// Override the size of the Symmetric NAT gateway VM.
+        #[clap(long)]
+        symmetric_nat_gateway_vm_size: Option<String>,
+        /// The number of antnode services to be run behind a Symmetric NAT Gateway on each private node VM.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        /// argument.
+        #[clap(long, verbatim_doc_comment)]
+        symmetric_private_node_count: Option<u16>,
+        /// The number of private node VMs to create. The private nodes will be behind a Symmetric NAT Gateway.
+        ///
+        /// Each VM will run many antnode services.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        #[clap(long, verbatim_doc_comment)]
+        symmetric_private_node_vm_count: Option<u16>,
+        /// The size of the volumes to attach to each private node VM. This argument will set the size of all the
+        /// 7 attached volumes.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        /// argument.
+        #[clap(long)]
+        symmetric_private_node_volume_size: Option<u16>,
+        /// The desired number of uploaders per VM.
+        #[clap(long, default_value_t = 1)]
+        uploaders_count: u16,
+        /// The number of uploader VMs to create.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        /// argument.
+        #[clap(long)]
+        uploader_vm_count: Option<u16>,
+        /// Override the size of the uploader VMs.
+        #[clap(long)]
+        uploader_vm_size: Option<String>,
+    },
+    ExtendVolumeSize {
+        /// Set to run Ansible with more verbose output.
+        #[arg(long)]
+        ansible_verbose: bool,
+        /// The new size of the volumes attached to each private node VM that is behind a Full Cone NAT Gateway.
+        /// This argument will scale up the size of all the 7 attached volumes.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        /// argument.
+        #[clap(long)]
+        full_cone_private_node_volume_size: Option<u16>,
+        /// The new size of the volumes attached to each genesis node VM. This argument will scale up the size of all
+        /// the 7 attached volumes.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        /// argument.
+        #[clap(long)]
+        genesis_node_volume_size: Option<u16>,
+        /// The name of the environment.
+        #[arg(short = 'n', long)]
+        name: String,
+        /// The new size of the volumes attached to each node VM. This argument will scale up the size of all
+        /// the 7 attached volumes.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        /// argument.
+        #[clap(long)]
+        node_volume_size: Option<u16>,
+        /// The new size of the volumes attached to each Peer Cache node VM. This argument will scale up the size of all
+        /// the 7 attached volumes.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        /// argument.
+        #[clap(long)]
+        peer_cache_node_volume_size: Option<u16>,
+        /// The cloud provider for the environment.
+        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
+        provider: CloudProvider,
+        /// The new size of the volumes attached to each private node VM that is behind a Symmetric NAT Gateway.
+        /// This argument will scale up the size of all the 7 attached volumes.
+        ///
+        /// If the argument is not used, the value will be determined by the 'environment-type'
+        /// argument.
+        #[clap(long)]
+        symmetric_private_node_volume_size: Option<u16>,
+    },
+    /// Manage the funds in the network
+    #[clap(name = "funds", subcommand)]
+    Funds(FundsCommand),
+    Inventory {
+        /// If set to true, the inventory will be regenerated.
+        ///
+        /// This is useful if the testnet was created on another machine.
+        #[clap(long, default_value_t = false)]
+        force_regeneration: bool,
+        /// If set to true, all non-local listener addresses will be printed for each peer.
+        #[clap(long, default_value_t = false)]
+        full: bool,
+        /// The name of the environment
+        #[arg(short = 'n', long)]
+        name: String,
+        /// Provide a name for the network contacts file to be uploaded to S3.
+        ///
+        /// If not used, the contacts file will have the same name as the environment.
+        #[arg(long)]
+        network_contacts_file_name: Option<String>,
+        /// If set to true, only print the Peer Cache webservers
+        #[clap(long, default_value_t = false)]
+        peer_cache: bool,
+        /// The cloud provider that was used.
+        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
+        provider: CloudProvider,
+    },
+    #[clap(name = "logs", subcommand)]
+    Logs(LogCommands),
+    #[clap(name = "network", subcommand)]
+    Network(NetworkCommands),
+    /// Send a notification to Slack with testnet inventory details
+    Notify {
+        /// The name of the environment.
+        #[arg(short = 'n', long)]
+        name: String,
+    },
+    Setup {},
+    /// Start all nodes in an environment.
+    ///
+    /// This can be useful if all nodes did not upgrade successfully.
+    #[clap(name = "start")]
+    Start {
+        /// Provide a list of VM names to use as a custom inventory.
+        ///
+        /// This will start nodes on a particular subset of VMs.
+        #[clap(name = "custom-inventory", long, use_value_delimiter = true)]
+        custom_inventory: Option<Vec<String>>,
+        /// Maximum number of forks Ansible will use to execute tasks on target hosts.
+        #[clap(long, default_value_t = 50)]
+        forks: usize,
+        /// The interval between each node start in milliseconds.
+        #[clap(long, value_parser = |t: &str| -> Result<Duration> { Ok(t.parse().map(Duration::from_millis)?)}, default_value = "2000")]
+        interval: Duration,
+        /// The name of the environment.
+        #[arg(short = 'n', long)]
+        name: String,
+        /// Specify the type of node VM to start the antnode services on. If not provided, the antnode services on
+        /// all the node VMs will be started. This is mutually exclusive with the '--custom-inventory' argument.
+        ///
+        /// Valid values are "peer-cache", "genesis", "generic" and "private".
+        #[arg(long, conflicts_with = "custom-inventory")]
+        node_type: Option<NodeType>,
+        /// The cloud provider for the environment.
+        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
+        provider: CloudProvider,
+    },
+    /// Get the status of all nodes in the environment.
+    #[clap(name = "status")]
+    Status {
+        /// Maximum number of forks Ansible will use to execute tasks on target hosts.
+        #[clap(long, default_value_t = 50)]
+        forks: usize,
+        /// The name of the environment.
+        #[arg(short = 'n', long)]
+        name: String,
+        /// The cloud provider for the environment.
+        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
+        provider: CloudProvider,
+    },
+    /// Start the Telegraf service on all machines in the environment.
+    ///
+    /// This may be necessary for performing upgrades.
+    #[clap(name = "start-telegraf")]
+    StartTelegraf {
+        /// Provide a list of VM names to use as a custom inventory.
+        ///
+        /// This will stop Telegraf on a particular subset of VMs.
+        #[clap(name = "custom-inventory", long, use_value_delimiter = true)]
+        custom_inventory: Option<Vec<String>>,
+        /// Maximum number of forks Ansible will use to execute tasks on target hosts.
+        #[clap(long, default_value_t = 50)]
+        forks: usize,
+        /// The name of the environment.
+        #[arg(short = 'n', long)]
+        name: String,
+        /// Specify the type of node VM to start the telegraf services on. If not provided, the telegraf services on
+        /// all the node VMs will be started. This is mutually exclusive with the '--custom-inventory' argument.
+        ///
+        /// Valid values are "peer-cache", "genesis", "generic" and "private".
+        #[arg(long, conflicts_with = "custom-inventory")]
+        node_type: Option<NodeType>,
+        /// The cloud provider for the environment.
+        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
+        provider: CloudProvider,
+    },
+    /// Stop all nodes in an environment.
+    #[clap(name = "stop")]
+    Stop {
+        /// Provide a list of VM names to use as a custom inventory.
+        ///
+        /// This will stop nodes on a particular subset of VMs.
+        #[clap(name = "custom-inventory", long, use_value_delimiter = true)]
+        custom_inventory: Option<Vec<String>>,
+        /// Delay in seconds before stopping nodes.
+        ///
+        /// This can be useful when there is one node per machine.
+        #[clap(long)]
+        delay: Option<u64>,
+        /// Maximum number of forks Ansible will use to execute tasks on target hosts.
+        #[clap(long, default_value_t = 50)]
+        forks: usize,
+        /// The interval between each node stop in milliseconds.
+        #[clap(long, value_parser = |t: &str| -> Result<Duration> { Ok(t.parse().map(Duration::from_millis)?)}, default_value = "2000")]
+        interval: Duration,
+        /// The name of the environment.
+        #[arg(short = 'n', long)]
+        name: String,
+        /// Specify the type of node VM to stop the antnode services on. If not provided, the antnode services on
+        /// all the node VMs will be stopped. This is mutually exclusive with the '--custom-inventory' argument.
+        ///
+        /// Valid values are "peer-cache", "genesis", "generic" and "private".
+        #[arg(long, conflicts_with = "custom-inventory")]
+        node_type: Option<NodeType>,
+        /// The cloud provider for the environment.
+        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
+        provider: CloudProvider,
+    },
+    /// Stop the Telegraf service on all machines in the environment.
+    ///
+    /// This may be necessary for performing upgrades.
+    #[clap(name = "stop-telegraf")]
+    StopTelegraf {
+        /// Provide a list of VM names to use as a custom inventory.
+        ///
+        /// This will stop Telegraf on a particular subset of VMs.
+        #[clap(name = "custom-inventory", long, use_value_delimiter = true)]
+        custom_inventory: Option<Vec<String>>,
+        /// Maximum number of forks Ansible will use to execute tasks on target hosts.
+        #[clap(long, default_value_t = 50)]
+        forks: usize,
+        /// The name of the environment.
+        #[arg(short = 'n', long)]
+        name: String,
+        /// Specify the type of node VM to stop the telegraf services on. If not provided, the telegraf services on
+        /// all the node VMs will be stopped. This is mutually exclusive with the '--custom-inventory' argument.
+        ///
+        /// Valid values are "peer-cache", "genesis", "generic" and "private".
+        #[arg(long, conflicts_with = "custom-inventory")]
+        node_type: Option<NodeType>,
+        /// The cloud provider for the environment.
+        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
+        provider: CloudProvider,
+    },
+    /// Upgrade the node binaries of a testnet environment to the latest version.
+    Upgrade {
+        /// Set to run Ansible with more verbose output.
+        #[arg(long)]
+        ansible_verbose: bool,
+        /// Provide a list of VM names to use as a custom inventory.
+        ///
+        /// This will run the upgrade against this particular subset of VMs.
+        ///
+        /// It can be useful to save time and run the upgrade against particular machines that were
+        /// unreachable during the main run.
+        #[clap(name = "custom-inventory", long, use_value_delimiter = true)]
+        custom_inventory: Option<Vec<String>>,
+        /// Provide environment variables for the antnode service.
+        ///
+        /// These will override the values provided initially.
+        ///
+        /// This is useful to set antnode's log levels. Each variable should be comma separated
+        /// without any space.
+        ///
+        /// Example: --env SN_LOG=all,RUST_LOG=libp2p=debug
+        #[clap(name = "env", long, use_value_delimiter = true, value_parser = parse_environment_variables)]
+        env_variables: Option<Vec<(String, String)>>,
+        /// Set to force the node manager to accept the antnode version provided.
+        ///
+        /// This can be used to downgrade antnode to a known good version.
+        #[clap(long)]
+        force: bool,
+        /// Maximum number of forks Ansible will use to execute tasks on target hosts.
+        #[clap(long, default_value_t = 2)]
+        forks: usize,
+        /// The interval between each node upgrade.
+        #[clap(long, value_parser = |t: &str| -> Result<Duration> { Ok(t.parse().map(Duration::from_millis)?)}, default_value = "2000")]
+        interval: Duration,
+        /// The name of the environment
+        #[arg(short = 'n', long)]
+        name: String,
+        /// Specify the type of node VM to upgrade the antnode services on. If not provided, the antnode services on
+        /// all the node VMs will be upgraded. This is mutually exclusive with the '--custom-inventory' argument.
+        ///
+        /// Valid values are "peer-cache", "genesis", "generic" and "private".
+        #[arg(long, conflicts_with = "custom-inventory")]
+        node_type: Option<NodeType>,
+        /// Delay before an upgrade starts.
+        ///
+        /// Useful for upgrading Peer Cache nodes when there is one node per machine.
+        #[clap(long)]
+        pre_upgrade_delay: Option<u64>,
+        /// The cloud provider to deploy to.
+        ///
+        /// Valid values are "aws" or "digital-ocean".
+        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
+        provider: CloudProvider,
+        #[arg(long)]
+        /// Optionally supply a version number for the antnode binary to upgrade to.
+        ///
+        /// If not provided, the latest version will be used. A lower version number can be
+        /// specified to downgrade to a known good version.
+        ///
+        /// There should be no 'v' prefix.
+        version: Option<String>,
+    },
+    /// Upgrade antctl binaries to a particular version.
+    ///
+    /// Simple mechanism that copies over the existing binary.
+    #[clap(name = "upgrade-antctl")]
+    UpgradeAntctl {
+        /// Provide a list of VM names to use as a custom inventory.
+        ///
+        /// This will upgrade antctl on a particular subset of VMs.
+        #[clap(name = "custom-inventory", long, use_value_delimiter = true)]
+        custom_inventory: Option<Vec<String>>,
+        /// The name of the environment
+        #[arg(short = 'n', long)]
+        name: String,
+        /// Specify the type of VM to run the upgrade on.
+        ///
+        /// If not provided, the upgrade will take place on all VMs.
+        ///
+        /// This is mutually exclusive with the '--custom-inventory' argument.
+        ///
+        /// Valid values are "peer-cache", "genesis", "generic" and "private".
+        #[arg(long, conflicts_with = "custom-inventory")]
+        node_type: Option<NodeType>,
+        /// The cloud provider of the environment.
+        ///
+        /// Valid values are "aws" or "digital-ocean".
+        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
+        provider: CloudProvider,
+        /// Supply a version for the binary to be upgraded to.
+        ///
+        /// There should be no 'v' prefix.
+        #[arg(short = 'v', long)]
+        version: String,
+    },
+    /// Upgrade the node Telegraf configuration on an environment.
+    #[clap(name = "upgrade-node-telegraf-config")]
+    UpgradeNodeTelegrafConfig {
+        /// Maximum number of forks Ansible will use to execute tasks on target hosts.
+        #[clap(long, default_value_t = 50)]
+        forks: usize,
+        /// The name of the environment.
+        #[arg(short = 'n', long)]
+        name: String,
+        /// The cloud provider for the environment.
+        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
+        provider: CloudProvider,
+    },
+    /// Upgrade the uploader Telegraf configuration on an environment.
+    #[clap(name = "upgrade-uploader-telegraf-config")]
+    UpgradeUploaderTelegrafConfig {
+        /// Maximum number of forks Ansible will use to execute tasks on target hosts.
+        #[clap(long, default_value_t = 50)]
+        forks: usize,
+        /// The name of the environment.
+        #[arg(short = 'n', long)]
+        name: String,
+        /// The cloud provider for the environment.
+        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
+        provider: CloudProvider,
+    },
+    /// Manage uploaders for an environment
+    #[clap(name = "uploaders", subcommand)]
+    Uploaders(UploadersCommands),
+    /// Upscale VMs and node services for an existing network.
+    Upscale {
+        /// Set to run Ansible with more verbose output.
+        #[arg(long)]
+        ansible_verbose: bool,
+        /// Supply a version number for the antctl binary.
+        ///
+        /// There should be no 'v' prefix.
+        #[arg(long, verbatim_doc_comment)]
+        antctl_version: Option<String>,
+        /// Supply a version number for the antnode binary.
+        ///
+        /// There should be no 'v' prefix.
+        #[arg(long, verbatim_doc_comment)]
+        antnode_version: Option<String>,
+        /// Supply a version number for the safe binary to be used for new uploader VMs.
+        ///
+        /// There should be no 'v' prefix.
+        ///
+        /// This argument is required when the uploader count is supplied.
+        #[arg(long, verbatim_doc_comment)]
+        ant_version: Option<String>,
+        /// The name of a branch from which custom binaries were built.
+        ///
+        /// This only applies if the original deployment also used a custom branch. The upscale will
+        /// then use the same binaries that were built in the original deployment.
+        ///
+        /// This argument must be used in conjunction with the --repo-owner argument. It is mutually
+        /// exclusive with the version arguments.
+        #[arg(long, verbatim_doc_comment)]
+        branch: Option<String>,
+        /// The desired number of antnode services to be running behind a Full Cone NAT on each private node VM after
+        /// the scale.
+        ///
+        /// If there are currently 10 services running on each VM, and you want there to be 25, the
+        /// value used should be 25, rather than 15 as a delta to reach 25.
+        ///
+        /// This option is not applicable to a bootstrap deployment.
+        #[clap(long, verbatim_doc_comment)]
+        desired_full_cone_private_node_count: Option<u16>,
+        /// The desired number of private node VMs to be running behind a Full Cone NAT after the scale.
+        ///
+        /// If there are currently 10 VMs running, and you want there to be 20, use 20 as the
+        /// value, not 10 as a delta.
+        ///
+        /// This option is not applicable to a bootstrap deployment.
+        #[clap(long, verbatim_doc_comment)]
+        desired_full_cone_private_node_vm_count: Option<u16>,
+        /// The desired number of antnode services to be running on each node VM after the scale.
+        ///
+        /// If there are currently 10 services running on each VM, and you want there to be 25, the
+        /// value used should be 25, rather than 15 as a delta to reach 25.
+        #[clap(long, verbatim_doc_comment)]
+        desired_node_count: Option<u16>,
+        /// The desired number of node VMs to be running after the scale.
+        ///
+        /// If there are currently 10 VMs running, and you want there to be 25, the value used
+        /// should be 25, rather than 15 as a delta to reach 25.
+        #[clap(long, verbatim_doc_comment)]
+        desired_node_vm_count: Option<u16>,
+        /// The desired number of antnode services to be running on each Peer Cache VM after the
+        /// scale.
+        ///
+        /// If there are currently 10 services running on each VM, and you want there to be 25, the
+        /// value used should be 25, rather than 15 as a delta to reach 25.
+        ///
+        /// This option is not applicable to a bootstrap deployment.
+        #[clap(long, verbatim_doc_comment)]
+        desired_peer_cache_node_count: Option<u16>,
+        /// The desired number of Peer Cache VMs to be running after the scale.
+        ///
+        /// If there are currently 10 VMs running, and you want there to be 20, use 20 as the
+        /// value, not 10 as a delta.
+        ///
+        /// This option is not applicable to a bootstrap deployment.
+        #[clap(long, verbatim_doc_comment)]
+        desired_peer_cache_node_vm_count: Option<u16>,
+        /// The desired number of antnode services to be running behind a Symmetric NAT on each private node VM after
+        /// the scale.
+        ///
+        /// If there are currently 10 services running on each VM, and you want there to be 25, the
+        /// value used should be 25, rather than 15 as a delta to reach 25.
+        ///
+        /// This option is not applicable to a bootstrap deployment.
+        #[clap(long, verbatim_doc_comment)]
+        desired_symmetric_private_node_count: Option<u16>,
+        /// The desired number of private node VMs to be running behind a Symmetric NAT after the scale.
+        ///
+        /// If there are currently 10 VMs running, and you want there to be 20, use 20 as the
+        /// value, not 10 as a delta.
+        ///
+        /// This option is not applicable to a bootstrap deployment.
+        #[clap(long, verbatim_doc_comment)]
+        desired_symmetric_private_node_vm_count: Option<u16>,
+        /// The desired number of uploader VMs to be running after the scale.
+        ///
+        /// If there are currently 10 VMs running, and you want there to be 25, the value used
+        /// should be 25, rather than 15 as a delta to reach 25.
+        ///
+        /// This option is not applicable to a bootstrap deployment.
+        #[clap(long, verbatim_doc_comment)]
+        desired_uploader_vm_count: Option<u16>,
+        /// The desired number of uploaders to be running after the scale.
+        ///
+        /// If you want each uploader VM to run multiple uploader services, specify the total desired count.
+        #[clap(long, verbatim_doc_comment)]
+        desired_uploaders_count: Option<u16>,
+        /// The secret key for the wallet that will fund all the uploaders.
+        ///
+        /// This argument only applies when Arbitrum or Sepolia networks are used.
+        #[clap(long)]
+        funding_wallet_secret_key: Option<String>,
+        /// Set to only use Terraform to upscale the VMs and not run Ansible.
+        #[clap(long, default_value_t = false)]
+        infra_only: bool,
+        /// The interval between starting each node in milliseconds.
+        #[clap(long, value_parser = |t: &str| -> Result<Duration> { Ok(t.parse().map(Duration::from_millis)?)}, default_value = "2000")]
+        interval: Duration,
+        /// The maximum of archived log files to keep. After reaching this limit, the older files are deleted.
+        #[clap(long, default_value = "5")]
+        max_archived_log_files: u16,
+        /// The maximum number of log files to keep. After reaching this limit, the older files are archived.
+        #[clap(long, default_value = "10")]
+        max_log_files: u16,
+        /// The name of the existing network to upscale.
+        #[arg(short = 'n', long, verbatim_doc_comment)]
+        name: String,
+        /// Set to only run the Terraform plan rather than applying the changes.
+        ///
+        /// Can be useful to preview the upscale to make sure everything is ok and that no other
+        /// changes slipped in.
+        ///
+        /// The plan will run and then the command will exit without doing anything else.
+        #[clap(long, default_value_t = false)]
+        plan: bool,
+        /// The cloud provider for the network.
+        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
+        provider: CloudProvider,
+        /// If set to true, for new VMs the RPC of the node will be accessible remotely.
+        ///
+        /// By default, the antnode RPC is only accessible via the 'localhost' and is not exposed for
+        /// security reasons.
+        #[clap(long, default_value_t = false, verbatim_doc_comment)]
+        public_rpc: bool,
+        /// The repo owner of a branch from which custom binaries were built.
+        ///
+        /// This only applies if the original deployment also used a custom branch. The upscale will
+        /// then use the same binaries that were built in the original deployment.
+        ///
+        /// This argument must be used in conjunction with the --branch argument. It is mutually
+        /// exclusive with the version arguments.
+        #[arg(long, verbatim_doc_comment)]
+        repo_owner: Option<String>,
+    },
+    /// Update the peer multiaddr in the node registry.
+    ///
+    /// This will then cause the service definitions to be updated when an upgrade is performed.
+    UpdatePeer {
+        /// Provide a list of VM names to use as a custom inventory.
+        ///
+        /// This will update the peer on a particular subset of VMs.
+        #[clap(name = "custom-inventory", long, use_value_delimiter = true)]
+        custom_inventory: Option<Vec<String>>,
+        /// The name of the environment.
+        #[arg(short = 'n', long)]
+        name: String,
+        /// Specify the type of node VM to update the peer on. If not provided, the peer will be updated on
+        /// all the node VMs. This is mutually exclusive with the '--custom-inventory' argument.
+        ///
+        /// Valid values are "peer-cache", "genesis", "generic" and "private".
+        #[arg(long, conflicts_with = "custom-inventory")]
+        node_type: Option<NodeType>,
+        /// The new peer multiaddr to use.
+        #[arg(long)]
+        peer: String,
+        /// The cloud provider for the environment.
+        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
+        provider: CloudProvider,
+    },
+    /// Reset nodes to a specified count.
+    ///
+    /// This will stop all nodes, clear their data, and start the specified number of nodes.
+    #[clap(name = "reset-to-n-nodes")]
+    ResetToNNodes {
+        /// Provide a list of VM names to use as a custom inventory.
+        ///
+        /// This will reset nodes on a particular subset of VMs.
+        #[clap(name = "custom-inventory", long, use_value_delimiter = true)]
+        custom_inventory: Option<Vec<String>>,
+        /// The EVM network to use.
+        ///
+        /// Valid values are "arbitrum-one", "arbitrum-sepolia", or "custom".
+        #[clap(long, value_parser = parse_evm_network)]
+        evm_network_type: EvmNetwork,
+        /// Maximum number of forks Ansible will use to execute tasks on target hosts.
+        #[clap(long, default_value_t = 50)]
+        forks: usize,
+        /// The name of the environment.
+        #[arg(short = 'n', long)]
+        name: String,
+        /// The number of nodes to run after reset.
+        #[arg(long)]
+        node_count: u16,
+        /// Specify the type of node VM to reset the nodes on. If not provided, the nodes on
+        /// all the node VMs will be reset. This is mutually exclusive with the '--custom-inventory' argument.
+        ///
+        /// Valid values are "peer-cache", "genesis", "generic" and "private".
+        #[arg(long, conflicts_with = "custom-inventory")]
+        node_type: Option<NodeType>,
+        /// The cloud provider for the environment.
+        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
+        provider: CloudProvider,
+        /// The interval between starting each node in milliseconds.
+        #[clap(long, value_parser = |t: &str| -> Result<Duration> { Ok(t.parse().map(Duration::from_millis)?)}, default_value = "2000")]
+        start_interval: Duration,
+        /// The interval between stopping each node in milliseconds.
+        #[clap(long, value_parser = |t: &str| -> Result<Duration> { Ok(t.parse().map(Duration::from_millis)?)}, default_value = "2000")]
+        stop_interval: Duration,
+        /// Supply a version number for the antnode binary.
+        ///
+        /// If not provided, the latest version will be used.
+        #[arg(long)]
+        version: Option<String>,
+    },
+}
+
+/// Get the binary option for the deployment.
+///
+/// Versioned binaries are preferred first, since building from source adds significant time to the
+/// deployment. There are two options here. If no version arguments were supplied, the latest
+/// versions will be used. Otherwise, the specified versions will be used, and if any were not
+/// specified, the latest version will be used in its place.
+///
+/// The second option is to build from source, which is useful for testing changes from forks.
+///
+/// The usage of arguments are also validated here.
+#[allow(clippy::too_many_arguments)]
+async fn get_binary_option(
+    branch: Option<String>,
+    repo_owner: Option<String>,
+    ant_version: Option<String>,
+    antnode_version: Option<String>,
+    antctl_version: Option<String>,
+    antnode_features: Option<Vec<String>>,
+) -> Result<BinaryOption> {
+    let mut use_versions = true;
+
+    let branch_specified = branch.is_some() || repo_owner.is_some();
+    let versions_specified = antnode_version.is_some() || antctl_version.is_some();
+    if branch_specified && versions_specified {
+        return Err(
+            eyre!("Version numbers and branches cannot be supplied at the same time").suggestion(
+                "Please choose whether you want to use version numbers or build the binaries",
+            ),
+        );
+    }
+
+    if versions_specified && antnode_features.is_some() {
+        return Err(eyre!(
+            "The --antnode-features argument only applies if we are building binaries"
+        ));
+    }
+
+    if branch_specified {
+        if let (Some(_), None) | (None, Some(_)) = (&repo_owner, &branch) {
+            return Err(eyre!(
+                "The --branch and --repo-owner arguments must be supplied together"
+            ));
+        }
+        use_versions = false;
+    }
+
+    let binary_option = if use_versions {
+        print_with_banner("Binaries will be supplied from pre-built versions");
+
+        let ant_version = get_version_from_option(ant_version, &ReleaseType::Ant).await?;
+        let antnode_version =
+            get_version_from_option(antnode_version, &ReleaseType::AntNode).await?;
+        let antctl_version = get_version_from_option(antctl_version, &ReleaseType::AntCtl).await?;
+        BinaryOption::Versioned {
+            ant_version: Some(ant_version),
+            antnode_version,
+            antctl_version,
+        }
+    } else {
+        // Unwraps are justified here because it's already been asserted that both must have
+        // values.
+        let repo_owner = repo_owner.unwrap();
+        let branch = branch.unwrap();
+
+        print_with_banner(&format!(
+            "Binaries will be built from {}/{}",
+            repo_owner, branch
+        ));
+
+        let url = format!("https://github.com/{repo_owner}/autonomi/tree/{branch}",);
+        let response = reqwest::get(&url).await?;
+        if !response.status().is_success() {
+            bail!("The provided branch or owner does not exist: {url:?}");
+        }
+        BinaryOption::BuildFromSource {
+            repo_owner,
+            branch,
+            antnode_features: antnode_features.map(|list| list.join(",")),
+        }
+    };
+
+    Ok(binary_option)
+}
+
+pub fn get_custom_inventory(
+    inventory: &DeploymentInventory,
+    vm_list: &[String],
+) -> Result<Vec<VirtualMachine>> {
+    debug!("Attempting to use a custom inventory: {vm_list:?}");
+    let mut custom_vms = Vec::new();
+    for vm_name in vm_list.iter() {
+        let vm_list = inventory.vm_list();
+        let vm = vm_list
+            .iter()
+            .find(|vm| vm_name == &vm.name)
+            .ok_or_eyre(format!(
+                "{vm_name} is not in the inventory for this environment",
+            ))?;
+        custom_vms.push(vm.clone());
+    }
+
+    debug!("Retrieved custom inventory:");
+    for vm in &custom_vms {
+        debug!("  {} - {}", vm.name, vm.public_ip_addr);
+    }
+    Ok(custom_vms)
+}
+
+pub async fn get_version_from_option(
+    version: Option<String>,
+    release_type: &ReleaseType,
+) -> Result<Version> {
+    let release_repo = <dyn AntReleaseRepoActions>::default_config();
+    let version = if let Some(version) = version {
+        println!("Using {version} for {release_type}");
+        version
+    } else {
+        println!("Getting latest version for {release_type}...");
+        let version = release_repo
+            .get_latest_version(release_type)
+            .await?
+            .to_string();
+        println!("Using {version} for {release_type}");
+        version
+    };
+    Ok(version.parse()?)
+}
+
+pub fn parse_chunk_size(val: &str) -> Result<u64> {
+    let size = val.parse::<u64>()?;
+    if size == 0 {
+        Err(eyre!("chunk_size must be a positive integer"))
+    } else {
+        Ok(size)
+    }
+}
+
+pub fn parse_deployment_type(val: &str) -> Result<EnvironmentType> {
+    match val {
+        "development" => Ok(EnvironmentType::Development),
+        "production" => Ok(EnvironmentType::Production),
+        "staging" => Ok(EnvironmentType::Staging),
+        _ => Err(eyre!(
+            "Supported deployment types are 'development', 'production' or 'staging'."
+        )),
+    }
+}
+
+// Since delimiter is on, we get element of the csv and not the entire csv.
+pub fn parse_environment_variables(env_var: &str) -> Result<(String, String)> {
+    let parts: Vec<&str> = env_var.splitn(2, '=').collect();
+    if parts.len() != 2 {
+        return Err(eyre!(
+            "Environment variable must be in the format KEY=VALUE or KEY=INNER_KEY=VALUE.\nMultiple key-value pairs can be given with a comma between them."
+        ));
+    }
+    Ok((parts[0].to_string(), parts[1].to_string()))
+}
+
+pub fn parse_evm_network(s: &str) -> Result<EvmNetwork, String> {
+    match s.to_lowercase().as_str() {
+        "anvil" => Ok(EvmNetwork::Anvil),
+        "arbitrum-one" => Ok(EvmNetwork::ArbitrumOne),
+        "arbitrum-sepolia" => Ok(EvmNetwork::ArbitrumSepolia),
+        "custom" => Ok(EvmNetwork::Custom),
+        _ => Err(format!("Invalid EVM network type: {}", s)),
+    }
+}
+
+pub fn parse_provider(val: &str) -> Result<CloudProvider> {
+    match val {
+        "aws" => Ok(CloudProvider::Aws),
+        "digital-ocean" => Ok(CloudProvider::DigitalOcean),
+        _ => Err(eyre!(
+            "The only supported providers are 'aws' or 'digital-ocean'"
+        )),
+    }
+}
+
+fn print_with_banner(s: &str) {
+    let banner = "=".repeat(s.len());
+    println!("{}\n{}\n{}", banner, s, banner);
+}

--- a/src/cmd/nodes.rs
+++ b/src/cmd/nodes.rs
@@ -1,0 +1,277 @@
+// Copyright (c) 2023, MaidSafe.
+// All rights reserved.
+//
+// This SAFE Network Software is licensed under the BSD-3-Clause license.
+// Please see the LICENSE file for more details.
+
+use super::{get_custom_inventory, get_version_from_option};
+
+use ant_releases::ReleaseType;
+use color_eyre::{eyre::eyre, Result};
+use libp2p::multiaddr::Multiaddr;
+use sn_testnet_deploy::{
+    ansible::{
+        extra_vars::ExtraVarsDocBuilder,
+        inventory::{generate_custom_environment_inventory, AnsibleInventoryType},
+        AnsiblePlaybook,
+    },
+    inventory::DeploymentInventoryService,
+    CloudProvider, EvmNetwork, NodeType, TestnetDeployBuilder,
+};
+use std::{str::FromStr, time::Duration};
+
+pub async fn handle_start_command(
+    custom_inventory: Option<Vec<String>>,
+    forks: usize,
+    interval: Duration,
+    name: String,
+    node_type: Option<NodeType>,
+    provider: CloudProvider,
+) -> Result<()> {
+    let testnet_deployer = TestnetDeployBuilder::default()
+        .ansible_forks(forks)
+        .environment_name(&name)
+        .provider(provider)
+        .build()?;
+
+    // This is required in the case where the command runs in a remote environment, where
+    // there won't be an existing inventory, which is required to retrieve the node
+    // registry files used to determine the status.
+    let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
+    let inventory = inventory_service
+        .generate_or_retrieve_inventory(&name, true, None)
+        .await?;
+    if inventory.is_empty() {
+        return Err(eyre!("The {name} environment does not exist"));
+    }
+
+    let custom_inventory = if let Some(custom_inventory) = custom_inventory {
+        let custom_vms = get_custom_inventory(&inventory, &custom_inventory)?;
+        Some(custom_vms)
+    } else {
+        None
+    };
+
+    testnet_deployer.start(interval, node_type, custom_inventory)?;
+
+    Ok(())
+}
+
+pub async fn handle_stop_command(
+    custom_inventory: Option<Vec<String>>,
+    delay: Option<u64>,
+    forks: usize,
+    interval: Duration,
+    name: String,
+    node_type: Option<NodeType>,
+    provider: CloudProvider,
+) -> Result<()> {
+    // Use a large number of forks for retrieving the inventory from a large deployment.
+    // Then if a smaller number of forks is specified, we will recreate the deployer
+    // with the smaller fork value.
+    let testnet_deployer = TestnetDeployBuilder::default()
+        .ansible_forks(50)
+        .environment_name(&name)
+        .provider(provider)
+        .build()?;
+    let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
+    let inventory = inventory_service
+        .generate_or_retrieve_inventory(&name, true, None)
+        .await?;
+    if inventory.is_empty() {
+        return Err(eyre!("The {name} environment does not exist"));
+    }
+
+    let testnet_deployer = TestnetDeployBuilder::default()
+        .ansible_forks(forks)
+        .environment_name(&name)
+        .provider(provider)
+        .build()?;
+    let custom_inventory = if let Some(custom_inventory) = custom_inventory {
+        let custom_vms = get_custom_inventory(&inventory, &custom_inventory)?;
+        Some(custom_vms)
+    } else {
+        None
+    };
+
+    testnet_deployer.stop(interval, node_type, custom_inventory, delay)?;
+
+    Ok(())
+}
+
+pub async fn handle_status_command(
+    forks: usize,
+    name: String,
+    provider: CloudProvider,
+) -> Result<()> {
+    let testnet_deployer = TestnetDeployBuilder::default()
+        .ansible_forks(forks)
+        .environment_name(&name)
+        .provider(provider)
+        .build()?;
+
+    // This is required in the case where the command runs in a remote environment, where
+    // there won't be an existing inventory, which is required to retrieve the node
+    // registry files used to determine the status.
+    let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
+    let inventory = inventory_service
+        .generate_or_retrieve_inventory(&name, true, None)
+        .await?;
+    if inventory.is_empty() {
+        return Err(eyre!("The {name} environment does not exist"));
+    }
+
+    testnet_deployer.status()?;
+    Ok(())
+}
+
+pub async fn handle_update_peer_command(
+    custom_inventory: Option<Vec<String>>,
+    name: String,
+    node_type: Option<NodeType>,
+    peer: String,
+    provider: CloudProvider,
+) -> Result<()> {
+    if let Err(e) = Multiaddr::from_str(&peer) {
+        return Err(eyre!("Invalid peer multiaddr: {}", e));
+    }
+
+    let testnet_deployer = TestnetDeployBuilder::default()
+        .environment_name(&name)
+        .provider(provider)
+        .build()?;
+
+    let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
+    let inventory = inventory_service
+        .generate_or_retrieve_inventory(&name, true, None)
+        .await?;
+
+    let custom_inventory = if let Some(custom_inventory) = custom_inventory {
+        let custom_vms = get_custom_inventory(&inventory, &custom_inventory)?;
+        Some(custom_vms)
+    } else {
+        None
+    };
+
+    let mut extra_vars = ExtraVarsDocBuilder::default();
+    extra_vars.add_variable("peer", &peer);
+
+    let inventory_type = if let Some(custom_inventory) = custom_inventory {
+        println!("Updating peers against a custom inventory");
+        generate_custom_environment_inventory(
+            &custom_inventory,
+            &name,
+            &testnet_deployer
+                .ansible_provisioner
+                .ansible_runner
+                .working_directory_path
+                .join("inventory"),
+        )?;
+        AnsibleInventoryType::Custom
+    } else {
+        let inventory_type = match node_type {
+            Some(NodeType::FullConePrivateNode) => AnsibleInventoryType::FullConePrivateNodes,
+            Some(NodeType::Genesis) => AnsibleInventoryType::Genesis,
+            Some(NodeType::Generic) => AnsibleInventoryType::Nodes,
+            Some(NodeType::PeerCache) => AnsibleInventoryType::PeerCacheNodes,
+            Some(NodeType::SymmetricPrivateNode) => AnsibleInventoryType::SymmetricPrivateNodes,
+            None => AnsibleInventoryType::Nodes,
+        };
+        println!("Updating peers against {inventory_type:?}");
+        inventory_type
+    };
+
+    testnet_deployer
+        .ansible_provisioner
+        .ansible_runner
+        .run_playbook(
+            AnsiblePlaybook::UpdatePeer,
+            inventory_type,
+            Some(extra_vars.build()),
+        )?;
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn handle_reset_to_n_nodes_command(
+    custom_inventory: Option<Vec<String>>,
+    evm_network_type: EvmNetwork,
+    forks: usize,
+    name: String,
+    node_count: u16,
+    node_type: Option<NodeType>,
+    provider: CloudProvider,
+    start_interval: Duration,
+    stop_interval: Duration,
+    version: Option<String>,
+) -> Result<()> {
+    // We will use 50 forks for the initial run to retrieve the inventory, then recreate the
+    // deployer using the custom fork value.
+    let testnet_deployer = TestnetDeployBuilder::default()
+        .ansible_forks(50)
+        .environment_name(&name)
+        .provider(provider)
+        .build()?;
+    let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
+    let inventory = inventory_service
+        .generate_or_retrieve_inventory(&name, true, None)
+        .await?;
+    if inventory.is_empty() {
+        return Err(eyre!("The {name} environment does not exist"));
+    }
+
+    let testnet_deployer = TestnetDeployBuilder::default()
+        .ansible_forks(forks)
+        .environment_name(&name)
+        .provider(provider)
+        .build()?;
+    testnet_deployer.init().await?;
+
+    let antnode_version = get_version_from_option(version, &ReleaseType::AntNode).await?;
+    let mut extra_vars = ExtraVarsDocBuilder::default();
+    extra_vars.add_variable("environment_name", &name);
+    extra_vars.add_variable("evm_network_type", &evm_network_type.to_string());
+    extra_vars.add_variable("node_count", &node_count.to_string());
+    extra_vars.add_variable("start_interval", &start_interval.as_millis().to_string());
+    extra_vars.add_variable("stop_interval", &stop_interval.as_millis().to_string());
+    extra_vars.add_variable("version", &antnode_version.to_string());
+
+    let ansible_runner = &testnet_deployer.ansible_provisioner.ansible_runner;
+
+    if let Some(custom_inventory) = custom_inventory {
+        println!("Running the playbook with a custom inventory");
+        let custom_vms = get_custom_inventory(&inventory, &custom_inventory)?;
+        generate_custom_environment_inventory(
+            &custom_vms,
+            &name,
+            &ansible_runner.working_directory_path.join("inventory"),
+        )?;
+        ansible_runner.run_playbook(
+            AnsiblePlaybook::ResetToNNodes,
+            AnsibleInventoryType::Custom,
+            Some(extra_vars.build()),
+        )?;
+        return Ok(());
+    }
+
+    if let Some(node_type) = node_type {
+        println!("Running the playbook for {node_type:?} nodes");
+        ansible_runner.run_playbook(
+            AnsiblePlaybook::ResetToNNodes,
+            node_type.to_ansible_inventory_type(),
+            Some(extra_vars.build()),
+        )?;
+        return Ok(());
+    }
+
+    println!("Running the playbook for all node types");
+    for node_inv_type in AnsibleInventoryType::iter_node_type() {
+        ansible_runner.run_playbook(
+            AnsiblePlaybook::ResetToNNodes,
+            node_inv_type,
+            Some(extra_vars.build()),
+        )?;
+    }
+    Ok(())
+}

--- a/src/cmd/telegraf.rs
+++ b/src/cmd/telegraf.rs
@@ -1,0 +1,134 @@
+// Copyright (c) 2023, MaidSafe.
+// All rights reserved.
+//
+// This SAFE Network Software is licensed under the BSD-3-Clause license.
+// Please see the LICENSE file for more details.
+
+use color_eyre::{eyre::eyre, Result};
+use sn_testnet_deploy::{inventory::DeploymentInventoryService, TestnetDeployBuilder};
+
+pub async fn handle_start_telegraf_command(
+    custom_inventory: Option<Vec<String>>,
+    forks: usize,
+    name: String,
+    node_type: Option<sn_testnet_deploy::NodeType>,
+    provider: sn_testnet_deploy::CloudProvider,
+) -> Result<()> {
+    let testnet_deployer = TestnetDeployBuilder::default()
+        .ansible_forks(forks)
+        .environment_name(&name)
+        .provider(provider)
+        .build()?;
+
+    // This is required in the case where the command runs in a remote environment, where
+    // there won't be an existing inventory, which is required to retrieve the node
+    // registry files used to determine the status.
+    let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
+    let inventory = inventory_service
+        .generate_or_retrieve_inventory(&name, true, None)
+        .await?;
+    if inventory.is_empty() {
+        return Err(eyre!("The {name} environment does not exist"));
+    }
+
+    let custom_inventory = if let Some(custom_inventory) = custom_inventory {
+        let custom_vms = super::get_custom_inventory(&inventory, &custom_inventory)?;
+        Some(custom_vms)
+    } else {
+        None
+    };
+
+    testnet_deployer.start_telegraf(node_type, custom_inventory)?;
+
+    Ok(())
+}
+
+pub async fn handle_stop_telegraf_command(
+    custom_inventory: Option<Vec<String>>,
+    forks: usize,
+    name: String,
+    node_type: Option<sn_testnet_deploy::NodeType>,
+    provider: sn_testnet_deploy::CloudProvider,
+) -> Result<()> {
+    let testnet_deployer = TestnetDeployBuilder::default()
+        .ansible_forks(forks)
+        .environment_name(&name)
+        .provider(provider)
+        .build()?;
+
+    // This is required in the case where the command runs in a remote environment, where
+    // there won't be an existing inventory, which is required to retrieve the node
+    // registry files used to determine the status.
+    let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
+    let inventory = inventory_service
+        .generate_or_retrieve_inventory(&name, true, None)
+        .await?;
+    if inventory.is_empty() {
+        return Err(eyre!("The {name} environment does not exist"));
+    }
+
+    let custom_inventory = if let Some(custom_inventory) = custom_inventory {
+        let custom_vms = super::get_custom_inventory(&inventory, &custom_inventory)?;
+        Some(custom_vms)
+    } else {
+        None
+    };
+
+    testnet_deployer.stop_telegraf(node_type, custom_inventory)?;
+
+    Ok(())
+}
+
+pub async fn handle_upgrade_node_telegraf_config(
+    forks: usize,
+    name: String,
+    provider: sn_testnet_deploy::CloudProvider,
+) -> Result<()> {
+    let testnet_deployer = TestnetDeployBuilder::default()
+        .ansible_forks(forks)
+        .environment_name(&name)
+        .provider(provider)
+        .build()?;
+
+    // This is required in the case where the command runs in a remote environment, where
+    // there won't be an existing inventory, which is required to retrieve the node
+    // registry files used to determine the status.
+    let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
+    let inventory = inventory_service
+        .generate_or_retrieve_inventory(&name, true, None)
+        .await?;
+    if inventory.is_empty() {
+        return Err(eyre!("The {name} environment does not exist"));
+    }
+
+    testnet_deployer.upgrade_node_telegraf(&name)?;
+
+    Ok(())
+}
+
+pub async fn handle_upgrade_uploader_telegraf_config(
+    forks: usize,
+    name: String,
+    provider: sn_testnet_deploy::CloudProvider,
+) -> Result<()> {
+    let testnet_deployer = TestnetDeployBuilder::default()
+        .ansible_forks(forks)
+        .environment_name(&name)
+        .provider(provider)
+        .build()?;
+
+    // This is required in the case where the command runs in a remote environment, where
+    // there won't be an existing inventory, which is required to retrieve the node
+    // registry files used to determine the status.
+    let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
+    let inventory = inventory_service
+        .generate_or_retrieve_inventory(&name, true, None)
+        .await?;
+    if inventory.is_empty() {
+        return Err(eyre!("The {name} environment does not exist"));
+    }
+
+    testnet_deployer.upgrade_uploader_telegraf(&name)?;
+
+    Ok(())
+}

--- a/src/cmd/upgrade.rs
+++ b/src/cmd/upgrade.rs
@@ -1,0 +1,111 @@
+// Copyright (c) 2023, MaidSafe.
+// All rights reserved.
+//
+// This SAFE Network Software is licensed under the BSD-3-Clause license.
+// Please see the LICENSE file for more details.
+
+use super::get_custom_inventory;
+use crate::{DeploymentInventoryService, TestnetDeployBuilder};
+use color_eyre::{eyre::eyre, Result};
+use sn_testnet_deploy::{CloudProvider, NodeType, UpgradeOptions};
+use std::time::Duration;
+
+#[allow(clippy::too_many_arguments)]
+pub async fn handle_upgrade_command(
+    ansible_verbose: bool,
+    custom_inventory: Option<Vec<String>>,
+    env_variables: Option<Vec<(String, String)>>,
+    force: bool,
+    forks: usize,
+    interval: Duration,
+    name: String,
+    node_type: Option<NodeType>,
+    provider: CloudProvider,
+    pre_upgrade_delay: Option<u64>,
+    version: Option<String>,
+) -> Result<()> {
+    // The upgrade intentionally uses a small value for `forks`, but this is far too slow
+    // for retrieving the inventory from a large deployment. Therefore, we will use 50
+    // forks for the initial run to retrieve the inventory, then recreate the deployer
+    // using the smaller fork value.
+    let testnet_deployer = TestnetDeployBuilder::default()
+        .ansible_forks(50)
+        .environment_name(&name)
+        .provider(provider)
+        .build()?;
+    let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
+    let inventory = inventory_service
+        .generate_or_retrieve_inventory(&name, true, None)
+        .await?;
+    if inventory.is_empty() {
+        return Err(eyre!("The {name} environment does not exist"));
+    }
+
+    let custom_inventory = if let Some(custom_inventory) = custom_inventory {
+        let custom_vms = get_custom_inventory(&inventory, &custom_inventory)?;
+        Some(custom_vms)
+    } else {
+        None
+    };
+
+    let testnet_deployer = TestnetDeployBuilder::default()
+        .ansible_forks(forks)
+        .ansible_verbose_mode(ansible_verbose)
+        .environment_name(&name)
+        .provider(provider)
+        .build()?;
+    testnet_deployer.upgrade(UpgradeOptions {
+        ansible_verbose,
+        custom_inventory,
+        env_variables,
+        force,
+        forks,
+        interval,
+        name: name.clone(),
+        node_type,
+        provider,
+        pre_upgrade_delay,
+        version,
+    })?;
+
+    // Recreate the deployer with an increased number of forks for retrieving the status.
+    let testnet_deployer = TestnetDeployBuilder::default()
+        .ansible_forks(50)
+        .environment_name(&name)
+        .provider(provider)
+        .build()?;
+    testnet_deployer.status()?;
+
+    Ok(())
+}
+
+pub async fn handle_upgrade_antctl_command(
+    custom_inventory: Option<Vec<String>>,
+    name: String,
+    node_type: Option<NodeType>,
+    provider: CloudProvider,
+    version: String,
+) -> Result<()> {
+    let testnet_deployer = TestnetDeployBuilder::default()
+        .ansible_forks(50)
+        .environment_name(&name)
+        .provider(provider)
+        .build()?;
+    let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
+    let inventory = inventory_service
+        .generate_or_retrieve_inventory(&name, true, None)
+        .await?;
+    if inventory.is_empty() {
+        return Err(eyre!("The {name} environment does not exist"));
+    }
+
+    let custom_inventory = if let Some(custom_inventory) = custom_inventory {
+        let custom_vms = get_custom_inventory(&inventory, &custom_inventory)?;
+        Some(custom_vms)
+    } else {
+        None
+    };
+
+    testnet_deployer.upgrade_antctl(version.parse()?, node_type, custom_inventory)?;
+    Ok(())
+}

--- a/src/cmd/uploaders.rs
+++ b/src/cmd/uploaders.rs
@@ -1,0 +1,274 @@
+// Copyright (c) 2023, MaidSafe.
+// All rights reserved.
+//
+// This SAFE Network Software is licensed under the BSD-3-Clause license.
+// Please see the LICENSE file for more details.
+
+use super::*;
+use alloy::primitives::U256;
+use ant_releases::ReleaseType;
+use color_eyre::eyre::{eyre, Result};
+use sn_testnet_deploy::{
+    ansible::{extra_vars::ExtraVarsDocBuilder, inventory::AnsibleInventoryType, AnsiblePlaybook},
+    inventory::DeploymentInventoryService,
+    upscale::UpscaleOptions,
+    TestnetDeployBuilder,
+};
+
+#[derive(Subcommand, Debug)]
+pub enum UploadersCommands {
+    /// Start all uploaders for an environment
+    Start {
+        /// The name of the environment
+        #[arg(long)]
+        name: String,
+        /// The cloud provider that was used.
+        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
+        provider: CloudProvider,
+    },
+    /// Stop all uploaders for an environment.
+    Stop {
+        /// The name of the environment
+        #[arg(long)]
+        name: String,
+        /// The cloud provider that was used.
+        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
+        provider: CloudProvider,
+    },
+    /// Upgrade the uploaders for a given environment.
+    Upgrade {
+        /// The name of the environment.
+        #[arg(short = 'n', long)]
+        name: String,
+
+        /// The cloud provider for the environment.
+        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
+        provider: CloudProvider,
+
+        /// Optionally supply a version for the safe client binary to upgrade to.
+        ///
+        /// If not provided, the latest version will be used.
+        #[arg(long)]
+        version: Option<String>,
+    },
+    /// Upscale uploaders for an existing network.
+    Upscale {
+        /// Supply a version number for the autonomi binary to be used for new uploader VMs.
+        ///
+        /// There should be no 'v' prefix.
+        #[arg(long, verbatim_doc_comment)]
+        autonomi_version: String,
+        /// The desired number of uploader VMs to be running after the scale.
+        ///
+        /// If there are currently 10 VMs running, and you want there to be 25, the value used
+        /// should be 25, rather than 15 as a delta to reach 25.
+        #[clap(long, verbatim_doc_comment)]
+        desired_uploader_vm_count: Option<u16>,
+        /// The desired number of uploaders to be running after the scale.
+        ///
+        /// If you want each uploader VM to run multiple uploader services, specify the total desired count.
+        #[clap(long, verbatim_doc_comment)]
+        desired_uploaders_count: Option<u16>,
+        /// The secret key for the wallet that will fund all the uploaders.
+        ///
+        /// This argument only applies when Arbitrum or Sepolia networks are used.
+        #[clap(long)]
+        funding_wallet_secret_key: Option<String>,
+        /// The amount of gas tokens to transfer to each uploader.
+        /// Must be a decimal value between 0 and 1, e.g. "0.1"
+        #[clap(long)]
+        gas_amount: Option<String>,
+        /// Set to only use Terraform to upscale the VMs and not run Ansible.
+        #[clap(long, default_value_t = false)]
+        infra_only: bool,
+        /// The name of the environment
+        #[arg(short = 'n', long)]
+        name: String,
+        /// Set to only run the Terraform plan rather than applying the changes.
+        ///
+        /// Can be useful to preview the upscale to make sure everything is ok and that no other
+        /// changes slipped in.
+        ///
+        /// The plan will run and then the command will exit without doing anything else.
+        #[clap(long, default_value_t = false)]
+        plan: bool,
+        /// Set to skip the Terraform infrastructure run and only run the Ansible provisioning.
+        #[clap(long, default_value_t = false)]
+        provision_only: bool,
+        /// The cloud provider for the environment.
+        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
+        provider: CloudProvider,
+    },
+}
+
+pub async fn handle_uploaders_command(cmd: UploadersCommands) -> Result<()> {
+    match cmd {
+        UploadersCommands::Start { name, provider } => {
+            let testnet_deployer = TestnetDeployBuilder::default()
+                .environment_name(&name)
+                .provider(provider)
+                .build()?;
+            let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
+            inventory_service
+                .generate_or_retrieve_inventory(&name, true, None)
+                .await?;
+
+            let ansible_runner = testnet_deployer.ansible_provisioner.ansible_runner;
+            ansible_runner.run_playbook(
+                AnsiblePlaybook::StartUploaders,
+                AnsibleInventoryType::Uploaders,
+                None,
+            )?;
+            Ok(())
+        }
+        UploadersCommands::Stop { name, provider } => {
+            let testnet_deployer = TestnetDeployBuilder::default()
+                .environment_name(&name)
+                .provider(provider)
+                .build()?;
+            let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
+            inventory_service
+                .generate_or_retrieve_inventory(&name, true, None)
+                .await?;
+
+            let ansible_runner = testnet_deployer.ansible_provisioner.ansible_runner;
+            ansible_runner.run_playbook(
+                AnsiblePlaybook::StopUploaders,
+                AnsibleInventoryType::Uploaders,
+                None,
+            )?;
+            Ok(())
+        }
+        UploadersCommands::Upgrade {
+            name,
+            provider,
+            version,
+        } => {
+            let version = get_version_from_option(version, &ReleaseType::Ant).await?;
+
+            let testnet_deploy = TestnetDeployBuilder::default()
+                .environment_name(&name)
+                .provider(provider)
+                .build()?;
+            let inventory_service = DeploymentInventoryService::from(&testnet_deploy);
+
+            let inventory = inventory_service
+                .generate_or_retrieve_inventory(&name, true, None)
+                .await?;
+            if inventory.is_empty() {
+                return Err(eyre!("The '{}' environment does not exist", name));
+            }
+
+            let ansible_runner = testnet_deploy.ansible_provisioner.ansible_runner;
+            let mut extra_vars = ExtraVarsDocBuilder::default();
+            extra_vars.add_variable("testnet_name", &name);
+            extra_vars.add_variable("ant_version", &version.to_string());
+            ansible_runner.run_playbook(
+                AnsiblePlaybook::UpgradeUploaders,
+                AnsibleInventoryType::Uploaders,
+                Some(extra_vars.build()),
+            )?;
+
+            Ok(())
+        }
+        UploadersCommands::Upscale {
+            autonomi_version,
+            desired_uploader_vm_count,
+            desired_uploaders_count,
+            funding_wallet_secret_key,
+            gas_amount,
+            infra_only,
+            name,
+            plan,
+            provision_only,
+            provider,
+        } => {
+            let gas_amount = if let Some(amount) = gas_amount {
+                let amount: f64 = amount.parse().map_err(|_| {
+                    eyre!("Invalid gas amount format. Must be a decimal value, e.g. '0.1'")
+                })?;
+                if amount <= 0.0 || amount >= 1.0 {
+                    return Err(eyre!("Gas amount must be between 0 and 1"));
+                }
+                // Convert to wei (1 ETH = 1e18 wei)
+                let wei_amount = (amount * 1e18) as u64;
+                Some(U256::from(wei_amount))
+            } else {
+                None
+            };
+
+            println!("Upscaling uploaders...");
+            let testnet_deployer = TestnetDeployBuilder::default()
+                .environment_name(&name)
+                .provider(provider)
+                .build()?;
+            testnet_deployer.init().await?;
+
+            let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
+            let inventory = inventory_service
+                .generate_or_retrieve_inventory(&name, true, None)
+                .await?;
+
+            testnet_deployer
+                .upscale_uploaders(&UpscaleOptions {
+                    ansible_verbose: false,
+                    current_inventory: inventory,
+                    desired_full_cone_private_node_count: None,
+                    desired_full_cone_private_node_vm_count: None,
+                    desired_node_count: None,
+                    desired_node_vm_count: None,
+                    desired_peer_cache_node_count: None,
+                    desired_peer_cache_node_vm_count: None,
+                    desired_symmetric_private_node_count: None,
+                    desired_symmetric_private_node_vm_count: None,
+                    desired_uploader_vm_count,
+                    desired_uploaders_count,
+                    funding_wallet_secret_key,
+                    gas_amount,
+                    max_archived_log_files: 1,
+                    max_log_files: 1,
+                    infra_only,
+                    interval: Duration::from_millis(2000),
+                    plan,
+                    provision_only,
+                    public_rpc: false,
+                    ant_version: Some(autonomi_version),
+                    token_amount: None,
+                })
+                .await?;
+
+            if plan {
+                return Ok(());
+            }
+
+            println!("Generating new inventory after upscale...");
+            let max_retries = 3;
+            let mut retries = 0;
+            let inventory = loop {
+                match inventory_service
+                    .generate_or_retrieve_inventory(&name, true, None)
+                    .await
+                {
+                    Ok(inv) => break inv,
+                    Err(e) if retries < max_retries => {
+                        retries += 1;
+                        eprintln!("Failed to generate inventory on attempt {retries}: {:?}", e);
+                        eprintln!("Will retry up to {max_retries} times...");
+                    }
+                    Err(_) => {
+                        eprintln!("Failed to generate inventory after {max_retries} attempts");
+                        eprintln!(
+                            "Please try running the `inventory` command or workflow separately"
+                        );
+                        return Ok(());
+                    }
+                }
+            };
+
+            inventory.print_report(false)?;
+            inventory.save()?;
+
+            Ok(())
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,6 @@ pub mod infra;
 pub mod inventory;
 pub mod logs;
 pub mod logstash;
-pub mod network_commands;
 pub mod reserved_ip;
 pub mod rpc_client;
 pub mod s3;
@@ -53,7 +52,7 @@ use serde_json::json;
 use std::{
     fs::File,
     io::{BufRead, BufReader, BufWriter, Write},
-    net::{IpAddr, SocketAddr},
+    net::IpAddr,
     path::{Path, PathBuf},
     process::{Command, Stdio},
     str::FromStr,
@@ -259,27 +258,6 @@ impl FromStr for EnvironmentType {
             _ => Err(Error::EnvironmentNameFromStringError(s.to_string())),
         }
     }
-}
-
-pub struct DeployOptions {
-    pub binary_option: BinaryOption,
-    pub current_inventory: DeploymentInventory,
-    pub env_variables: Option<Vec<(String, String)>>,
-    pub evm_network: EvmNetwork,
-    pub evm_node_vm_size: Option<String>,
-    pub log_format: Option<LogFormat>,
-    pub logstash_details: Option<(String, Vec<SocketAddr>)>,
-    pub name: String,
-    pub node_count: u16,
-    pub node_vm_count: Option<u16>,
-    pub node_vm_size: Option<String>,
-    pub peer_cache_node_count: u16,
-    pub peer_cache_node_vm_count: Option<u16>,
-    pub peer_cache_node_vm_size: Option<String>,
-    pub public_rpc: bool,
-    pub rewards_address: String,
-    pub uploader_vm_count: Option<u16>,
-    pub uploader_vm_size: Option<String>,
 }
 
 /// Specify the binary option for the deployment.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,1487 +3,26 @@
 // This SAFE Network Software is licensed under the BSD-3-Clause license.
 // Please see the LICENSE file for more details.
 
-use alloy::primitives::{Address, U256};
-use ant_releases::{AntReleaseRepoActions, ReleaseType};
-use clap::{Parser, Subcommand};
-use color_eyre::{
-    eyre::{bail, eyre, OptionExt},
-    Help, Result,
+mod cmd;
+
+use crate::cmd::{
+    network::{ChurnCommands, NetworkCommands},
+    nodes, telegraf, Commands,
 };
+use clap::Parser;
+use color_eyre::Result;
 use dotenv::dotenv;
-use evmlib::Network;
-use log::debug;
-use semver::Version;
 use sn_testnet_deploy::{
-    ansible::{
-        extra_vars::ExtraVarsDocBuilder,
-        inventory::{generate_custom_environment_inventory, AnsibleInventoryType},
-        AnsiblePlaybook,
-    },
-    bootstrap::BootstrapOptions,
-    calculate_size_per_attached_volume,
-    deploy::DeployOptions,
-    error::Error,
-    funding::FundingOptions,
-    get_environment_details,
-    infra::InfraRunOptions,
-    inventory::{
-        get_data_directory, DeploymentInventory, DeploymentInventoryService, VirtualMachine,
-    },
-    logstash::LogstashDeployBuilder,
-    network_commands, notify_slack,
-    setup::setup_dotenv_file,
-    upscale::UpscaleOptions,
-    BinaryOption, CloudProvider, EnvironmentType, EvmNetwork, LogFormat, NodeType,
-    TestnetDeployBuilder, UpgradeOptions,
+    inventory::DeploymentInventoryService, setup::setup_dotenv_file, CloudProvider,
+    EnvironmentType, TestnetDeployBuilder,
 };
-use std::{env, net::IpAddr};
-use std::{str::FromStr, time::Duration};
+use std::env;
 
 #[derive(Parser, Debug)]
 #[clap(name = "sn-testnet-deploy", version = env!("CARGO_PKG_VERSION"))]
 struct Opt {
     #[command(subcommand)]
     command: Commands,
-}
-
-#[allow(clippy::large_enum_variant)]
-#[derive(Subcommand, Debug)]
-enum Commands {
-    /// Bootstrap a new network from an existing deployment.
-    Bootstrap {
-        /// Supply a version number for the antctl binary.
-        ///
-        /// There should be no 'v' prefix.
-        ///
-        /// The version arguments are mutually exclusive with the --branch and --repo-owner
-        /// arguments. You can only supply version numbers or a custom branch, not both.
-        #[arg(long, verbatim_doc_comment)]
-        antctl_version: Option<String>,
-        /// The features to enable on the antnode binary.
-        ///
-        /// If not provided, the default feature set specified for the antnode binary are used.
-        ///
-        /// The features argument is mutually exclusive with the --antnode-version argument.
-        #[clap(long, verbatim_doc_comment)]
-        antnode_features: Option<Vec<String>>,
-        /// Supply a version number for the antnode binary.
-        ///
-        /// There should be no 'v' prefix.
-        ///
-        /// The version arguments are mutually exclusive with the --branch and --repo-owner
-        /// arguments. You can only supply version numbers or a custom branch, not both.
-        #[arg(long, verbatim_doc_comment)]
-        antnode_version: Option<String>,
-        /// Set to run Ansible with more verbose output.
-        #[arg(long)]
-        ansible_verbose: bool,
-        /// The branch of the Github repository to build from.
-        ///
-        /// If used, all binaries will be built from this branch. It is typically used for testing
-        /// changes on a fork.
-        ///
-        /// This argument must be used in conjunction with the --repo-owner argument.
-        ///
-        /// The --branch and --repo-owner arguments are mutually exclusive with the binary version
-        /// arguments. You can only supply version numbers or a custom branch, not both.
-        #[arg(long, verbatim_doc_comment)]
-        branch: Option<String>,
-        /// The network contacts URL to bootstrap from.
-        ///
-        /// Either this or the `bootstrap-peer` argument must be provided.
-        bootstrap_network_contacts_url: Option<String>,
-        /// The peer from an existing network that we can bootstrap from.
-        ///
-        /// Either this or the `bootstrap-network-contacts-url` argument must be provided.
-        #[arg(long)]
-        bootstrap_peer: Option<String>,
-        /// Specify the chunk size for the custom binaries using a 64-bit integer.
-        ///
-        /// This option only applies if the --branch and --repo-owner arguments are used.
-        #[clap(long, value_parser = parse_chunk_size)]
-        chunk_size: Option<u64>,
-        /// The type of deployment.
-        ///
-        /// Possible values are 'development', 'production' or 'staging'. The value used will
-        /// determine the sizes of VMs, the number of VMs, and the number of nodes deployed on
-        /// them. The specification will increase in size from development, to staging, to
-        /// production.
-        ///
-        /// The default is 'development'.
-        #[clap(long, default_value_t = EnvironmentType::Development, value_parser = parse_deployment_type, verbatim_doc_comment)]
-        environment_type: EnvironmentType,
-        /// Provide environment variables for the antnode service.
-        ///
-        /// This is useful to set the antnode's log levels. Each variable should be comma
-        /// separated without any space.
-        ///
-        /// Example: --env SN_LOG=all,RUST_LOG=libp2p=debug
-        #[clap(name = "env", long, use_value_delimiter = true, value_parser = parse_environment_variables, verbatim_doc_comment)]
-        env_variables: Option<Vec<(String, String)>>,
-        /// The address of the data payments contract.
-        ///
-        /// This argument must match the same contract address used in the existing network.
-        #[arg(long)]
-        evm_data_payments_address: Option<String>,
-        /// The EVM network to use.
-        ///
-        /// Valid values are "arbitrum-one", "arbitrum-sepolia", or "custom".
-        #[clap(long, default_value_t = EvmNetwork::ArbitrumOne, value_parser = parse_evm_network)]
-        evm_network_type: EvmNetwork,
-        /// The address of the payment token contract.
-        ///
-        /// This argument must match the same contract address used in the existing network.
-        #[arg(long)]
-        evm_payment_token_address: Option<String>,
-        /// The RPC URL for the EVM network.
-        ///
-        /// This argument only applies if the EVM network type is 'custom'.
-        #[arg(long)]
-        evm_rpc_url: Option<String>,
-        /// Override the maximum number of forks Ansible will use to execute tasks on target hosts.
-        ///
-        /// The default value from ansible.cfg is 50.
-        #[clap(long)]
-        forks: Option<usize>,
-        /// The number of antnode services to be run behind a Full Cone NAT Gateway on each private node VM.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        /// argument.
-        #[clap(long, verbatim_doc_comment)]
-        full_cone_private_node_count: Option<u16>,
-        /// The number of private node VMs to create. The private nodes will be behind a Full Cone NAT Gateway.
-        ///
-        /// Each VM will run many antnode services.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        #[clap(long, verbatim_doc_comment)]
-        full_cone_private_node_vm_count: Option<u16>,
-        /// The size of the volumes to attach to each private node VM. This argument will set the size of all the
-        /// 7 attached volumes.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        /// argument.
-        #[clap(long)]
-        full_cone_private_node_volume_size: Option<u16>,
-        /// The interval between starting each node in milliseconds.
-        #[clap(long, value_parser = |t: &str| -> Result<Duration> { Ok(t.parse().map(Duration::from_millis)?)}, default_value = "2000")]
-        interval: Duration,
-        /// Specify the logging format for the nodes.
-        ///
-        /// Valid values are "default" or "json".
-        ///
-        /// If the argument is not used, the default format will be applied.
-        #[clap(long, value_parser = LogFormat::parse_from_str, verbatim_doc_comment)]
-        log_format: Option<LogFormat>,
-        /// The maximum of archived log files to keep. After reaching this limit, the older files are deleted.
-        #[clap(long, default_value = "5")]
-        max_archived_log_files: u16,
-        /// The maximum number of log files to keep. After reaching this limit, the older files are archived.
-        #[clap(long, default_value = "10")]
-        max_log_files: u16,
-        /// The name of the environment
-        #[arg(short = 'n', long)]
-        name: String,
-        /// Specify the network ID to use for the node services. This is used to partition the network and will not allow
-        /// nodes with different network IDs to join.
-        ///
-        /// By default, the network ID is set to 1, which represents the mainnet.
-        #[clap(long, verbatim_doc_comment)]
-        network_id: Option<u8>,
-        /// The number of antnode services to run on each VM.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        /// argument.
-        #[clap(long)]
-        node_count: Option<u16>,
-        /// The number of node VMs to create.
-        ///
-        /// Each VM will run many antnode services.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        /// argument.
-        #[clap(long)]
-        node_vm_count: Option<u16>,
-        /// Override the size of the node VMs.
-        #[clap(long)]
-        node_vm_size: Option<String>,
-        /// The size of the volumes to attach to each node VM. This argument will set the size of all the 7 attached
-        /// volumes.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        /// argument.
-        #[clap(long)]
-        node_volume_size: Option<u16>,
-        /// The cloud provider to deploy to.
-        ///
-        /// Valid values are "aws" or "digital-ocean".
-        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
-        provider: CloudProvider,
-        /// The owner/org of the Github repository to build from.
-        ///
-        /// If used, all binaries will be built from this repository. It is typically used for
-        /// testing changes on a fork.
-        ///
-        /// This argument must be used in conjunction with the --repo-owner argument.
-        ///
-        /// The --branch and --repo-owner arguments are mutually exclusive with the binary version
-        /// arguments. You can only supply version numbers or a custom branch, not both.
-        #[arg(long, verbatim_doc_comment)]
-        repo_owner: Option<String>,
-        /// The rewards address for each of the antnode services.
-        #[arg(long, required = true)]
-        rewards_address: String,
-        /// The number of antnode services to be run behind a Symmetric NAT Gateway on each private node VM.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        /// argument.
-        #[clap(long, verbatim_doc_comment)]
-        symmetric_private_node_count: Option<u16>,
-        /// The number of private node VMs to create. The private nodes will be behind a Symmetric NAT Gateway.
-        ///
-        /// Each VM will run many antnode services.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        #[clap(long, verbatim_doc_comment)]
-        symmetric_private_node_vm_count: Option<u16>,
-        /// The size of the volumes to attach to each private node VM. This argument will set the size of all the
-        /// 7 attached volumes.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        /// argument.
-        #[clap(long)]
-        symmetric_private_node_volume_size: Option<u16>,
-    },
-    /// Clean a deployed testnet environment.
-    Clean {
-        /// The name of the environment.
-        #[arg(short = 'n', long)]
-        name: String,
-        /// The cloud provider for the environment.
-        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
-        provider: CloudProvider,
-    },
-    /// Configure a swapfile on all nodes in the environment.
-    ConfigureSwapfile {
-        /// The name of the environment.
-        #[arg(short = 'n', long)]
-        name: String,
-        /// The size of the swapfile in GB.
-        #[arg(short = 's', long)]
-        size: u16,
-        /// Set to also configure swapfile on the PeerCache nodes.
-        #[arg(long)]
-        peer_cache: bool,
-        /// The cloud provider for the environment.
-        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
-        provider: CloudProvider,
-    },
-    /// Deploy a new testnet environment using the latest version of the antnode binary.
-    Deploy {
-        /// Set to run Ansible with more verbose output.
-        #[arg(long)]
-        ansible_verbose: bool,
-        /// Supply a version number for the ant binary.
-        ///
-        /// There should be no 'v' prefix.
-        ///
-        /// The version arguments are mutually exclusive with the --branch and --repo-owner
-        /// arguments. You can only supply version numbers or a custom branch, not both.
-        #[arg(long, verbatim_doc_comment)]
-        ant_version: Option<String>,
-        /// Supply a version number for the antctl binary.
-        ///
-        /// There should be no 'v' prefix.
-        ///
-        /// The version arguments are mutually exclusive with the --branch and --repo-owner
-        /// arguments. You can only supply version numbers or a custom branch, not both.
-        #[arg(long, verbatim_doc_comment)]
-        antctl_version: Option<String>,
-        /// The features to enable on the antnode binary.
-        ///
-        /// If not provided, the default feature set specified for the antnode binary are used.
-        ///
-        /// The features argument is mutually exclusive with the --antnode-version argument.
-        #[clap(long, verbatim_doc_comment)]
-        antnode_features: Option<Vec<String>>,
-        /// Supply a version number for the antnode binary.
-        ///
-        /// There should be no 'v' prefix.
-        ///
-        /// The version arguments are mutually exclusive with the --branch and --repo-owner
-        /// arguments. You can only supply version numbers or a custom branch, not both.
-        #[arg(long, verbatim_doc_comment)]
-        antnode_version: Option<String>,
-        /// The branch of the Github repository to build from.
-        ///
-        /// If used, all binaries will be built from this branch. It is typically used for testing
-        /// changes on a fork.
-        ///
-        /// This argument must be used in conjunction with the --repo-owner argument.
-        ///
-        /// The --branch and --repo-owner arguments are mutually exclusive with the binary version
-        /// arguments. You can only supply version numbers or a custom branch, not both.
-        #[arg(long, verbatim_doc_comment)]
-        branch: Option<String>,
-        /// The number of antnode services to run on each Peer Cache VM.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        /// argument.
-        #[clap(long)]
-        peer_cache_node_count: Option<u16>,
-        /// The number of Peer Cache node VMs to create.
-        ///
-        /// Each VM will run many antnode services.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        /// argument.
-        #[clap(long)]
-        peer_cache_node_vm_count: Option<u16>,
-        /// Override the size of the Peer Cache node VMs.
-        #[clap(long)]
-        peer_cache_node_vm_size: Option<String>,
-        /// The size of the volumes to attach to each Peer Cache node VM. This argument will set the size of all the
-        /// 7 attached volumes.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        /// argument.
-        #[clap(long)]
-        peer_cache_node_volume_size: Option<u16>,
-        /// Specify the chunk size for the custom binaries using a 64-bit integer.
-        ///
-        /// This option only applies if the --branch and --repo-owner arguments are used.
-        #[clap(long, value_parser = parse_chunk_size)]
-        chunk_size: Option<u64>,
-        /// If set to a non-zero value, the uploaders will also be accompanied by the specified
-        /// number of downloaders.
-        ///
-        /// This will be the number on each uploader VM. So if the value here is 2 and there are
-        /// 5 uploader VMs, there will be 10 downloaders across the 5 VMs.
-        #[clap(long, default_value_t = 0)]
-        downloaders_count: u16,
-        /// Provide environment variables for the antnode service.
-        ///
-        /// This is useful to set the antnode's log levels. Each variable should be comma
-        /// separated without any space.
-        ///
-        /// Example: --env SN_LOG=all,RUST_LOG=libp2p=debug
-        #[clap(name = "env", long, use_value_delimiter = true, value_parser = parse_environment_variables, verbatim_doc_comment)]
-        env_variables: Option<Vec<(String, String)>>,
-        /// The type of deployment.
-        ///
-        /// Possible values are 'development', 'production' or 'staging'. The value used will
-        /// determine the sizes of VMs, the number of VMs, and the number of nodes deployed on
-        /// them. The specification will increase in size from development, to staging, to
-        /// production.
-        ///
-        /// The default is 'development'.
-        #[clap(long, default_value_t = EnvironmentType::Development, value_parser = parse_deployment_type, verbatim_doc_comment)]
-        environment_type: EnvironmentType,
-        /// The address of the data payments contract.
-        #[arg(long)]
-        evm_data_payments_address: Option<String>,
-        /// The EVM network type to use for the deployment.
-        ///
-        /// Possible values are 'arbitrum-one' or 'custom'.
-        ///
-        /// If not used, the default is 'arbitrum-one'.
-        #[clap(long, default_value = "arbitrum-one", value_parser = parse_evm_network)]
-        evm_network_type: EvmNetwork,
-        /// The address of the payment token contract.
-        #[arg(long)]
-        evm_payment_token_address: Option<String>,
-        /// Override the size of the EVM node VMs.
-        #[clap(long)]
-        evm_node_vm_size: Option<String>,
-        /// The RPC URL for the EVM network.
-        ///
-        /// This argument only applies if the EVM network type is 'custom'.
-        #[arg(long)]
-        evm_rpc_url: Option<String>,
-        /// Override the maximum number of forks Ansible will use to execute tasks on target hosts.
-        ///
-        /// The default value from ansible.cfg is 50.
-        #[clap(long)]
-        forks: Option<usize>,
-        /// Override the size of the Full Cone NAT gateway VM.
-        #[clap(long)]
-        full_cone_nat_gateway_vm_size: Option<String>,
-        /// The number of antnode services to be run behind a Full Cone NAT Gateway on each private node VM.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        /// argument.
-        #[clap(long, verbatim_doc_comment)]
-        full_cone_private_node_count: Option<u16>,
-        /// The number of private node VMs to create. The private nodes will be behind a Full Cone NAT Gateway.
-        ///
-        /// Each VM will run many antnode services.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        #[clap(long, verbatim_doc_comment)]
-        full_cone_private_node_vm_count: Option<u16>,
-        /// The size of the volumes to attach to each private node VM. This argument will set the size of all the
-        /// 7 attached volumes.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        /// argument.
-        #[clap(long)]
-        full_cone_private_node_volume_size: Option<u16>,
-        /// The secret key for the wallet that will fund all the uploaders.
-        ///
-        /// This argument only applies when Arbitrum or Sepolia networks are used.
-        #[clap(long)]
-        funding_wallet_secret_key: Option<String>,
-        /// The size of the volumes to attach to each genesis node VM. This argument will set the size of all the
-        /// 7 attached volumes.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        /// argument.
-        #[clap(long)]
-        genesis_node_volume_size: Option<u16>,
-        /// The amount of gas to initially transfer to each uploader, in U256
-        ///
-        /// 1 ETH = 1_000_000_000_000_000_000. Defaults to 0.1 ETH
-        #[arg(long)]
-        initial_gas: Option<U256>,
-        /// The amount of tokens to initially transfer to each uploader, in U256
-        ///
-        /// 1 Token = 1_000_000_000_000_000_000. Defaults to 100 token.
-        #[arg(long)]
-        initial_tokens: Option<U256>,
-        /// The interval between starting each node in milliseconds.
-        #[clap(long, value_parser = |t: &str| -> Result<Duration> { Ok(t.parse().map(Duration::from_millis)?)}, default_value = "2000")]
-        interval: Duration,
-        /// Specify the logging format for the nodes.
-        ///
-        /// Valid values are "default" or "json".
-        ///
-        /// If the argument is not used, the default format will be applied.
-        #[clap(long, value_parser = LogFormat::parse_from_str, verbatim_doc_comment)]
-        log_format: Option<LogFormat>,
-        /// The name of the Logstash stack to forward logs to.
-        #[clap(long, default_value = "main")]
-        logstash_stack_name: String,
-        /// The maximum of archived log files to keep. After reaching this limit, the older files are deleted.
-        #[clap(long, default_value = "5")]
-        max_archived_log_files: u16,
-        /// The maximum number of log files to keep. After reaching this limit, the older files are archived.
-        #[clap(long, default_value = "10")]
-        max_log_files: u16,
-        /// The name of the environment
-        #[arg(short = 'n', long)]
-        name: String,
-        /// Specify the network ID to use for the node services. This is used to partition the network and will not allow
-        /// nodes with different network IDs to join.
-        ///
-        /// By default, the network ID is set to 1, which represents the mainnet.
-        #[clap(long, verbatim_doc_comment)]
-        network_id: Option<u8>,
-        /// Provide a name for the network contacts file to be uploaded to S3.
-        ///
-        /// If not used, the contacts file will have the same name as the environment.
-        #[arg(long)]
-        network_contacts_file_name: Option<String>,
-        /// The number of antnode services to run on each VM.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        /// argument.
-        #[clap(long)]
-        node_count: Option<u16>,
-        /// The number of node VMs to create.
-        ///
-        /// Each VM will run many antnode services.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        /// argument.
-        #[clap(long)]
-        node_vm_count: Option<u16>,
-        /// Override the size of the node VMs.
-        #[clap(long)]
-        node_vm_size: Option<String>,
-        /// The size of the volumes to attach to each node VM. This argument will set the size of all the 7 attached
-        /// volumes.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        /// argument.
-        #[clap(long)]
-        node_volume_size: Option<u16>,
-        /// The cloud provider to deploy to.
-        ///
-        /// Valid values are "aws" or "digital-ocean".
-        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
-        provider: CloudProvider,
-        /// If set to true, the RPC of the node will be accessible remotely.
-        ///
-        /// By default, the antnode RPC is only accessible via the 'localhost' and is not exposed for
-        /// security reasons.
-        #[clap(long, default_value_t = false, verbatim_doc_comment)]
-        public_rpc: bool,
-        /// The owner/org of the Github repository to build from.
-        ///
-        /// If used, all binaries will be built from this repository. It is typically used for
-        /// testing changes on a fork.
-        ///
-        /// This argument must be used in conjunction with the --repo-owner argument.
-        ///
-        /// The --branch and --repo-owner arguments are mutually exclusive with the binary version
-        /// arguments. You can only supply version numbers or a custom branch, not both.
-        #[arg(long, verbatim_doc_comment)]
-        repo_owner: Option<String>,
-        /// The rewards address for each of the antnode services.
-        #[arg(long, required = true)]
-        rewards_address: String,
-        /// Override the size of the Symmetric NAT gateway VM.
-        #[clap(long)]
-        symmetric_nat_gateway_vm_size: Option<String>,
-        /// The number of antnode services to be run behind a Symmetric NAT Gateway on each private node VM.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        /// argument.
-        #[clap(long, verbatim_doc_comment)]
-        symmetric_private_node_count: Option<u16>,
-        /// The number of private node VMs to create. The private nodes will be behind a Symmetric NAT Gateway.
-        ///
-        /// Each VM will run many antnode services.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        #[clap(long, verbatim_doc_comment)]
-        symmetric_private_node_vm_count: Option<u16>,
-        /// The size of the volumes to attach to each private node VM. This argument will set the size of all the
-        /// 7 attached volumes.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        /// argument.
-        #[clap(long)]
-        symmetric_private_node_volume_size: Option<u16>,
-        /// The desired number of uploaders per VM.
-        #[clap(long, default_value_t = 1)]
-        uploaders_count: u16,
-        /// The number of uploader VMs to create.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        /// argument.
-        #[clap(long)]
-        uploader_vm_count: Option<u16>,
-        /// Override the size of the uploader VMs.
-        #[clap(long)]
-        uploader_vm_size: Option<String>,
-    },
-    ExtendVolumeSize {
-        /// Set to run Ansible with more verbose output.
-        #[arg(long)]
-        ansible_verbose: bool,
-        /// The new size of the volumes attached to each private node VM that is behind a Full Cone NAT Gateway.
-        /// This argument will scale up the size of all the 7 attached volumes.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        /// argument.
-        #[clap(long)]
-        full_cone_private_node_volume_size: Option<u16>,
-        /// The new size of the volumes attached to each genesis node VM. This argument will scale up the size of all
-        /// the 7 attached volumes.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        /// argument.
-        #[clap(long)]
-        genesis_node_volume_size: Option<u16>,
-        /// The name of the environment.
-        #[arg(short = 'n', long)]
-        name: String,
-        /// The new size of the volumes attached to each node VM. This argument will scale up the size of all
-        /// the 7 attached volumes.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        /// argument.
-        #[clap(long)]
-        node_volume_size: Option<u16>,
-        /// The new size of the volumes attached to each Peer Cache node VM. This argument will scale up the size of all
-        /// the 7 attached volumes.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        /// argument.
-        #[clap(long)]
-        peer_cache_node_volume_size: Option<u16>,
-        /// The cloud provider for the environment.
-        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
-        provider: CloudProvider,
-        /// The new size of the volumes attached to each private node VM that is behind a Symmetric NAT Gateway.
-        /// This argument will scale up the size of all the 7 attached volumes.
-        ///
-        /// If the argument is not used, the value will be determined by the 'environment-type'
-        /// argument.
-        #[clap(long)]
-        symmetric_private_node_volume_size: Option<u16>,
-    },
-    /// Manage the faucet for an environment
-    #[clap(name = "faucet", subcommand)]
-    Faucet(FaucetCommands),
-    /// Manage the funds in the network
-    #[clap(name = "funds", subcommand)]
-    Funds(FundsCommand),
-    Inventory {
-        /// If set to true, the inventory will be regenerated.
-        ///
-        /// This is useful if the testnet was created on another machine.
-        #[clap(long, default_value_t = false)]
-        force_regeneration: bool,
-        /// If set to true, all non-local listener addresses will be printed for each peer.
-        #[clap(long, default_value_t = false)]
-        full: bool,
-        /// The name of the environment
-        #[arg(short = 'n', long)]
-        name: String,
-        /// Provide a name for the network contacts file to be uploaded to S3.
-        ///
-        /// If not used, the contacts file will have the same name as the environment.
-        #[arg(long)]
-        network_contacts_file_name: Option<String>,
-        /// If set to true, only print the Peer Cache webservers
-        #[clap(long, default_value_t = false)]
-        peer_cache: bool,
-        /// The cloud provider that was used.
-        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
-        provider: CloudProvider,
-    },
-    #[clap(name = "logs", subcommand)]
-    Logs(LogCommands),
-    #[clap(name = "logstash", subcommand)]
-    Logstash(LogstashCommands),
-    #[clap(name = "network", subcommand)]
-    Network(NetworkCommands),
-    /// Send a notification to Slack with testnet inventory details
-    Notify {
-        /// The name of the environment.
-        #[arg(short = 'n', long)]
-        name: String,
-    },
-    Setup {},
-    /// Start all nodes in an environment.
-    ///
-    /// This can be useful if all nodes did not upgrade successfully.
-    #[clap(name = "start")]
-    Start {
-        /// Provide a list of VM names to use as a custom inventory.
-        ///
-        /// This will start nodes on a particular subset of VMs.
-        #[clap(name = "custom-inventory", long, use_value_delimiter = true)]
-        custom_inventory: Option<Vec<String>>,
-        /// Maximum number of forks Ansible will use to execute tasks on target hosts.
-        #[clap(long, default_value_t = 50)]
-        forks: usize,
-        /// The interval between each node start in milliseconds.
-        #[clap(long, value_parser = |t: &str| -> Result<Duration> { Ok(t.parse().map(Duration::from_millis)?)}, default_value = "2000")]
-        interval: Duration,
-        /// The name of the environment.
-        #[arg(short = 'n', long)]
-        name: String,
-        /// Specify the type of node VM to start the antnode services on. If not provided, the antnode services on
-        /// all the node VMs will be started. This is mutually exclusive with the '--custom-inventory' argument.
-        ///
-        /// Valid values are "peer-cache", "genesis", "generic" and "private".
-        #[arg(long, conflicts_with = "custom-inventory")]
-        node_type: Option<NodeType>,
-        /// The cloud provider for the environment.
-        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
-        provider: CloudProvider,
-    },
-    /// Get the status of all nodes in the environment.
-    #[clap(name = "status")]
-    Status {
-        /// Maximum number of forks Ansible will use to execute tasks on target hosts.
-        #[clap(long, default_value_t = 50)]
-        forks: usize,
-        /// The name of the environment.
-        #[arg(short = 'n', long)]
-        name: String,
-        /// The cloud provider for the environment.
-        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
-        provider: CloudProvider,
-    },
-    /// Start the Telegraf service on all machines in the environment.
-    ///
-    /// This may be necessary for performing upgrades.
-    #[clap(name = "start-telegraf")]
-    StartTelegraf {
-        /// Provide a list of VM names to use as a custom inventory.
-        ///
-        /// This will stop Telegraf on a particular subset of VMs.
-        #[clap(name = "custom-inventory", long, use_value_delimiter = true)]
-        custom_inventory: Option<Vec<String>>,
-        /// Maximum number of forks Ansible will use to execute tasks on target hosts.
-        #[clap(long, default_value_t = 50)]
-        forks: usize,
-        /// The name of the environment.
-        #[arg(short = 'n', long)]
-        name: String,
-        /// Specify the type of node VM to start the telegraf services on. If not provided, the telegraf services on
-        /// all the node VMs will be started. This is mutually exclusive with the '--custom-inventory' argument.
-        ///
-        /// Valid values are "peer-cache", "genesis", "generic" and "private".
-        #[arg(long, conflicts_with = "custom-inventory")]
-        node_type: Option<NodeType>,
-        /// The cloud provider for the environment.
-        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
-        provider: CloudProvider,
-    },
-    /// Stop all nodes in an environment.
-    #[clap(name = "stop")]
-    Stop {
-        /// Provide a list of VM names to use as a custom inventory.
-        ///
-        /// This will stop nodes on a particular subset of VMs.
-        #[clap(name = "custom-inventory", long, use_value_delimiter = true)]
-        custom_inventory: Option<Vec<String>>,
-        /// Delay in seconds before stopping nodes.
-        ///
-        /// This can be useful when there is one node per machine.
-        #[clap(long)]
-        delay: Option<u64>,
-        /// Maximum number of forks Ansible will use to execute tasks on target hosts.
-        #[clap(long, default_value_t = 50)]
-        forks: usize,
-        /// The interval between each node stop in milliseconds.
-        #[clap(long, value_parser = |t: &str| -> Result<Duration> { Ok(t.parse().map(Duration::from_millis)?)}, default_value = "2000")]
-        interval: Duration,
-        /// The name of the environment.
-        #[arg(short = 'n', long)]
-        name: String,
-        /// Specify the type of node VM to stop the antnode services on. If not provided, the antnode services on
-        /// all the node VMs will be stopped. This is mutually exclusive with the '--custom-inventory' argument.
-        ///
-        /// Valid values are "peer-cache", "genesis", "generic" and "private".
-        #[arg(long, conflicts_with = "custom-inventory")]
-        node_type: Option<NodeType>,
-        /// The cloud provider for the environment.
-        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
-        provider: CloudProvider,
-    },
-    /// Stop the Telegraf service on all machines in the environment.
-    ///
-    /// This may be necessary for performing upgrades.
-    #[clap(name = "stop-telegraf")]
-    StopTelegraf {
-        /// Provide a list of VM names to use as a custom inventory.
-        ///
-        /// This will stop Telegraf on a particular subset of VMs.
-        #[clap(name = "custom-inventory", long, use_value_delimiter = true)]
-        custom_inventory: Option<Vec<String>>,
-        /// Maximum number of forks Ansible will use to execute tasks on target hosts.
-        #[clap(long, default_value_t = 50)]
-        forks: usize,
-        /// The name of the environment.
-        #[arg(short = 'n', long)]
-        name: String,
-        /// Specify the type of node VM to stop the telegraf services on. If not provided, the telegraf services on
-        /// all the node VMs will be stopped. This is mutually exclusive with the '--custom-inventory' argument.
-        ///
-        /// Valid values are "peer-cache", "genesis", "generic" and "private".
-        #[arg(long, conflicts_with = "custom-inventory")]
-        node_type: Option<NodeType>,
-        /// The cloud provider for the environment.
-        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
-        provider: CloudProvider,
-    },
-    /// Upgrade the node binaries of a testnet environment to the latest version.
-    Upgrade {
-        /// Set to run Ansible with more verbose output.
-        #[arg(long)]
-        ansible_verbose: bool,
-        /// Provide a list of VM names to use as a custom inventory.
-        ///
-        /// This will run the upgrade against this particular subset of VMs.
-        ///
-        /// It can be useful to save time and run the upgrade against particular machines that were
-        /// unreachable during the main run.
-        #[clap(name = "custom-inventory", long, use_value_delimiter = true)]
-        custom_inventory: Option<Vec<String>>,
-        /// Provide environment variables for the antnode service.
-        ///
-        /// These will override the values provided initially.
-        ///
-        /// This is useful to set antnode's log levels. Each variable should be comma separated
-        /// without any space.
-        ///
-        /// Example: --env SN_LOG=all,RUST_LOG=libp2p=debug
-        #[clap(name = "env", long, use_value_delimiter = true, value_parser = parse_environment_variables)]
-        env_variables: Option<Vec<(String, String)>>,
-        /// Set to force the node manager to accept the antnode version provided.
-        ///
-        /// This can be used to downgrade antnode to a known good version.
-        #[clap(long)]
-        force: bool,
-        /// Maximum number of forks Ansible will use to execute tasks on target hosts.
-        #[clap(long, default_value_t = 2)]
-        forks: usize,
-        /// The interval between each node upgrade.
-        #[clap(long, value_parser = |t: &str| -> Result<Duration> { Ok(t.parse().map(Duration::from_millis)?)}, default_value = "2000")]
-        interval: Duration,
-        /// The name of the environment
-        #[arg(short = 'n', long)]
-        name: String,
-        /// Specify the type of node VM to upgrade the antnode services on. If not provided, the antnode services on
-        /// all the node VMs will be upgraded. This is mutually exclusive with the '--custom-inventory' argument.
-        ///
-        /// Valid values are "peer-cache", "genesis", "generic" and "private".
-        #[arg(long, conflicts_with = "custom-inventory")]
-        node_type: Option<NodeType>,
-        /// Delay before an upgrade starts.
-        ///
-        /// Useful for upgrading Peer Cache nodes when there is one node per machine.
-        #[clap(long)]
-        pre_upgrade_delay: Option<u64>,
-        /// The cloud provider to deploy to.
-        ///
-        /// Valid values are "aws" or "digital-ocean".
-        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
-        provider: CloudProvider,
-        #[arg(long)]
-        /// Optionally supply a version number for the antnode binary to upgrade to.
-        ///
-        /// If not provided, the latest version will be used. A lower version number can be
-        /// specified to downgrade to a known good version.
-        ///
-        /// There should be no 'v' prefix.
-        version: Option<String>,
-    },
-    /// Upgrade antctl binaries to a particular version.
-    ///
-    /// Simple mechanism that copies over the existing binary.
-    #[clap(name = "upgrade-antctl")]
-    UpgradeAntctl {
-        /// Provide a list of VM names to use as a custom inventory.
-        ///
-        /// This will upgrade antctl on a particular subset of VMs.
-        #[clap(name = "custom-inventory", long, use_value_delimiter = true)]
-        custom_inventory: Option<Vec<String>>,
-        /// The name of the environment
-        #[arg(short = 'n', long)]
-        name: String,
-        /// Specify the type of VM to run the upgrade on.
-        ///
-        /// If not provided, the upgrade will take place on all VMs.
-        ///
-        /// This is mutually exclusive with the '--custom-inventory' argument.
-        ///
-        /// Valid values are "peer-cache", "genesis", "generic" and "private".
-        #[arg(long, conflicts_with = "custom-inventory")]
-        node_type: Option<NodeType>,
-        /// The cloud provider of the environment.
-        ///
-        /// Valid values are "aws" or "digital-ocean".
-        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
-        provider: CloudProvider,
-        /// Supply a version for the binary to be upgraded to.
-        ///
-        /// There should be no 'v' prefix.
-        #[arg(short = 'v', long)]
-        version: String,
-    },
-    /// Upgrade the node Telegraf configuration on an environment.
-    #[clap(name = "upgrade-node-telegraf-config")]
-    UpgradeNodeTelegrafConfig {
-        /// Maximum number of forks Ansible will use to execute tasks on target hosts.
-        #[clap(long, default_value_t = 50)]
-        forks: usize,
-        /// The name of the environment.
-        #[arg(short = 'n', long)]
-        name: String,
-        /// The cloud provider for the environment.
-        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
-        provider: CloudProvider,
-    },
-    /// Upgrade the uploader Telegraf configuration on an environment.
-    #[clap(name = "upgrade-uploader-telegraf-config")]
-    UpgradeUploaderTelegrafConfig {
-        /// Maximum number of forks Ansible will use to execute tasks on target hosts.
-        #[clap(long, default_value_t = 50)]
-        forks: usize,
-        /// The name of the environment.
-        #[arg(short = 'n', long)]
-        name: String,
-        /// The cloud provider for the environment.
-        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
-        provider: CloudProvider,
-    },
-    /// Manage uploaders for an environment
-    #[clap(name = "uploaders", subcommand)]
-    Uploaders(UploadersCommands),
-    /// Upscale VMs and node services for an existing network.
-    Upscale {
-        /// Set to run Ansible with more verbose output.
-        #[arg(long)]
-        ansible_verbose: bool,
-        /// Supply a version number for the antctl binary.
-        ///
-        /// There should be no 'v' prefix.
-        #[arg(long, verbatim_doc_comment)]
-        antctl_version: Option<String>,
-        /// Supply a version number for the antnode binary.
-        ///
-        /// There should be no 'v' prefix.
-        #[arg(long, verbatim_doc_comment)]
-        antnode_version: Option<String>,
-        /// Supply a version number for the safe binary to be used for new uploader VMs.
-        ///
-        /// There should be no 'v' prefix.
-        ///
-        /// This argument is required when the uploader count is supplied.
-        #[arg(long, verbatim_doc_comment)]
-        ant_version: Option<String>,
-        /// The name of a branch from which custom binaries were built.
-        ///
-        /// This only applies if the original deployment also used a custom branch. The upscale will
-        /// then use the same binaries that were built in the original deployment.
-        ///
-        /// This argument must be used in conjunction with the --repo-owner argument. It is mutually
-        /// exclusive with the version arguments.
-        #[arg(long, verbatim_doc_comment)]
-        branch: Option<String>,
-        /// The desired number of antnode services to be running behind a Full Cone NAT on each private node VM after
-        /// the scale.
-        ///
-        /// If there are currently 10 services running on each VM, and you want there to be 25, the
-        /// value used should be 25, rather than 15 as a delta to reach 25.
-        ///
-        /// This option is not applicable to a bootstrap deployment.
-        #[clap(long, verbatim_doc_comment)]
-        desired_full_cone_private_node_count: Option<u16>,
-        /// The desired number of private node VMs to be running behind a Full Cone NAT after the scale.
-        ///
-        /// If there are currently 10 VMs running, and you want there to be 20, use 20 as the
-        /// value, not 10 as a delta.
-        ///
-        /// This option is not applicable to a bootstrap deployment.
-        #[clap(long, verbatim_doc_comment)]
-        desired_full_cone_private_node_vm_count: Option<u16>,
-        /// The desired number of antnode services to be running on each node VM after the scale.
-        ///
-        /// If there are currently 10 services running on each VM, and you want there to be 25, the
-        /// value used should be 25, rather than 15 as a delta to reach 25.
-        #[clap(long, verbatim_doc_comment)]
-        desired_node_count: Option<u16>,
-        /// The desired number of node VMs to be running after the scale.
-        ///
-        /// If there are currently 10 VMs running, and you want there to be 25, the value used
-        /// should be 25, rather than 15 as a delta to reach 25.
-        #[clap(long, verbatim_doc_comment)]
-        desired_node_vm_count: Option<u16>,
-        /// The desired number of antnode services to be running on each Peer Cache VM after the
-        /// scale.
-        ///
-        /// If there are currently 10 services running on each VM, and you want there to be 25, the
-        /// value used should be 25, rather than 15 as a delta to reach 25.
-        ///
-        /// This option is not applicable to a bootstrap deployment.
-        #[clap(long, verbatim_doc_comment)]
-        desired_peer_cache_node_count: Option<u16>,
-        /// The desired number of Peer Cache VMs to be running after the scale.
-        ///
-        /// If there are currently 10 VMs running, and you want there to be 20, use 20 as the
-        /// value, not 10 as a delta.
-        ///
-        /// This option is not applicable to a bootstrap deployment.
-        #[clap(long, verbatim_doc_comment)]
-        desired_peer_cache_node_vm_count: Option<u16>,
-        /// The desired number of antnode services to be running behind a Symmetric NAT on each private node VM after
-        /// the scale.
-        ///
-        /// If there are currently 10 services running on each VM, and you want there to be 25, the
-        /// value used should be 25, rather than 15 as a delta to reach 25.
-        ///
-        /// This option is not applicable to a bootstrap deployment.
-        #[clap(long, verbatim_doc_comment)]
-        desired_symmetric_private_node_count: Option<u16>,
-        /// The desired number of private node VMs to be running behind a Symmetric NAT after the scale.
-        ///
-        /// If there are currently 10 VMs running, and you want there to be 20, use 20 as the
-        /// value, not 10 as a delta.
-        ///
-        /// This option is not applicable to a bootstrap deployment.
-        #[clap(long, verbatim_doc_comment)]
-        desired_symmetric_private_node_vm_count: Option<u16>,
-        /// The desired number of uploader VMs to be running after the scale.
-        ///
-        /// If there are currently 10 VMs running, and you want there to be 25, the value used
-        /// should be 25, rather than 15 as a delta to reach 25.
-        ///
-        /// This option is not applicable to a bootstrap deployment.
-        #[clap(long, verbatim_doc_comment)]
-        desired_uploader_vm_count: Option<u16>,
-        /// The desired number of uploaders to be running after the scale.
-        ///
-        /// If you want each uploader VM to run multiple uploader services, specify the total desired count.
-        #[clap(long, verbatim_doc_comment)]
-        desired_uploaders_count: Option<u16>,
-        /// The secret key for the wallet that will fund all the uploaders.
-        ///
-        /// This argument only applies when Arbitrum or Sepolia networks are used.
-        #[clap(long)]
-        funding_wallet_secret_key: Option<String>,
-        /// Set to only use Terraform to upscale the VMs and not run Ansible.
-        #[clap(long, default_value_t = false)]
-        infra_only: bool,
-        /// The interval between starting each node in milliseconds.
-        #[clap(long, value_parser = |t: &str| -> Result<Duration> { Ok(t.parse().map(Duration::from_millis)?)}, default_value = "2000")]
-        interval: Duration,
-        /// The maximum of archived log files to keep. After reaching this limit, the older files are deleted.
-        #[clap(long, default_value = "5")]
-        max_archived_log_files: u16,
-        /// The maximum number of log files to keep. After reaching this limit, the older files are archived.
-        #[clap(long, default_value = "10")]
-        max_log_files: u16,
-        /// The name of the existing network to upscale.
-        #[arg(short = 'n', long, verbatim_doc_comment)]
-        name: String,
-        /// Set to only run the Terraform plan rather than applying the changes.
-        ///
-        /// Can be useful to preview the upscale to make sure everything is ok and that no other
-        /// changes slipped in.
-        ///
-        /// The plan will run and then the command will exit without doing anything else.
-        #[clap(long, default_value_t = false)]
-        plan: bool,
-        /// The cloud provider for the network.
-        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
-        provider: CloudProvider,
-        /// If set to true, for new VMs the RPC of the node will be accessible remotely.
-        ///
-        /// By default, the antnode RPC is only accessible via the 'localhost' and is not exposed for
-        /// security reasons.
-        #[clap(long, default_value_t = false, verbatim_doc_comment)]
-        public_rpc: bool,
-        /// The repo owner of a branch from which custom binaries were built.
-        ///
-        /// This only applies if the original deployment also used a custom branch. The upscale will
-        /// then use the same binaries that were built in the original deployment.
-        ///
-        /// This argument must be used in conjunction with the --branch argument. It is mutually
-        /// exclusive with the version arguments.
-        #[arg(long, verbatim_doc_comment)]
-        repo_owner: Option<String>,
-    },
-    /// Update the peer multiaddr in the node registry.
-    ///
-    /// This will then cause the service definitions to be updated when an upgrade is performed.
-    UpdatePeer {
-        /// Provide a list of VM names to use as a custom inventory.
-        ///
-        /// This will update the peer on a particular subset of VMs.
-        #[clap(name = "custom-inventory", long, use_value_delimiter = true)]
-        custom_inventory: Option<Vec<String>>,
-        /// The name of the environment.
-        #[arg(short = 'n', long)]
-        name: String,
-        /// Specify the type of node VM to update the peer on. If not provided, the peer will be updated on
-        /// all the node VMs. This is mutually exclusive with the '--custom-inventory' argument.
-        ///
-        /// Valid values are "peer-cache", "genesis", "generic" and "private".
-        #[arg(long, conflicts_with = "custom-inventory")]
-        node_type: Option<NodeType>,
-        /// The new peer multiaddr to use.
-        #[arg(long)]
-        peer: String,
-        /// The cloud provider for the environment.
-        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
-        provider: CloudProvider,
-    },
-    /// Reset nodes to a specified count.
-    ///
-    /// This will stop all nodes, clear their data, and start the specified number of nodes.
-    #[clap(name = "reset-to-n-nodes")]
-    ResetToNNodes {
-        /// Provide a list of VM names to use as a custom inventory.
-        ///
-        /// This will reset nodes on a particular subset of VMs.
-        #[clap(name = "custom-inventory", long, use_value_delimiter = true)]
-        custom_inventory: Option<Vec<String>>,
-        /// The EVM network to use.
-        ///
-        /// Valid values are "arbitrum-one", "arbitrum-sepolia", or "custom".
-        #[clap(long, value_parser = parse_evm_network)]
-        evm_network_type: EvmNetwork,
-        /// Maximum number of forks Ansible will use to execute tasks on target hosts.
-        #[clap(long, default_value_t = 50)]
-        forks: usize,
-        /// The name of the environment.
-        #[arg(short = 'n', long)]
-        name: String,
-        /// The number of nodes to run after reset.
-        #[arg(long)]
-        node_count: u16,
-        /// Specify the type of node VM to reset the nodes on. If not provided, the nodes on
-        /// all the node VMs will be reset. This is mutually exclusive with the '--custom-inventory' argument.
-        ///
-        /// Valid values are "peer-cache", "genesis", "generic" and "private".
-        #[arg(long, conflicts_with = "custom-inventory")]
-        node_type: Option<NodeType>,
-        /// The cloud provider for the environment.
-        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
-        provider: CloudProvider,
-        /// The interval between starting each node in milliseconds.
-        #[clap(long, value_parser = |t: &str| -> Result<Duration> { Ok(t.parse().map(Duration::from_millis)?)}, default_value = "2000")]
-        start_interval: Duration,
-        /// The interval between stopping each node in milliseconds.
-        #[clap(long, value_parser = |t: &str| -> Result<Duration> { Ok(t.parse().map(Duration::from_millis)?)}, default_value = "2000")]
-        stop_interval: Duration,
-        /// Supply a version number for the antnode binary.
-        ///
-        /// If not provided, the latest version will be used.
-        #[arg(long)]
-        version: Option<String>,
-    },
-}
-
-#[derive(Subcommand, Debug)]
-enum LogCommands {
-    /// Removes all the rotated log files from the the node VMs.
-    Cleanup {
-        /// The name of the environment
-        #[arg(short = 'n', long)]
-        name: String,
-        /// The cloud provider that was used.
-        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
-        provider: CloudProvider,
-        /// Setup a cron job to perform the cleanup periodically.
-        #[clap(long)]
-        setup_cron: bool,
-    },
-    /// Retrieve the logs for a given environment by copying them from all the VMs.
-    ///
-    /// This will write the logs to 'logs/<name>', relative to the current directory.
-    Copy {
-        /// The name of the environment
-        #[arg(short = 'n', long)]
-        name: String,
-        /// The cloud provider that was used.
-        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
-        provider: CloudProvider,
-        /// Should we copy the resource-usage.logs only
-        #[arg(short = 'r', long)]
-        resources_only: bool,
-    },
-    /// Retrieve the logs for a given environment from S3.
-    ///
-    /// This will write the logs to 'logs/<name>', relative to the current directory.
-    Get {
-        /// The name of the environment
-        #[arg(short = 'n', long)]
-        name: String,
-    },
-    /// Reassemble retrieved logs from their parts.
-    ///
-    /// The logs must have already been retrieved using the 'get' command and be present at
-    /// 'logs/<name>'.
-    ///
-    /// This will write the logs to 'logs/<name>-reassembled', relative to the current directory.
-    ///
-    /// The original logs are left intact so you can sync again if need be.
-    Reassemble {
-        /// The name of the environment for which logs have already been retrieved
-        #[arg(short = 'n', long)]
-        name: String,
-    },
-    /// Run a ripgrep query through all the logs from all the VMs and copy the results.
-    ///
-    /// The results will be written to `logs/<name>/<vm>/rg-timestamp.log`
-    Rg {
-        /// The ripgrep arguments that are directly passed to ripgrep. The text to search for should be put inside
-        /// single quotes. The dir to search for is set automatically, so do not provide one.
-        ///
-        /// Example command: `cargo run --release -- logs rg --name <name> --args "'ValidSpendRecordPutFromNetwork' -z -a"`
-        #[arg(short = 'a', long, allow_hyphen_values(true))]
-        args: String,
-        /// The name of the environment
-        #[arg(short = 'n', long)]
-        name: String,
-        /// The cloud provider that was used.
-        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
-        provider: CloudProvider,
-    },
-    /// Remove the logs from a given environment from the bucket on S3.
-    Rm {
-        /// The name of the environment for which logs have already been retrieved
-        #[arg(short = 'n', long)]
-        name: String,
-    },
-    /// Rsync the logs from all the VMs for a given environment.
-    /// Rerunning the same command will sync only the changed log files without copying everything from the beginning.
-    ///
-    /// This will write the logs to 'logs/<name>', relative to the current directory.
-    Rsync {
-        /// The name of the environment
-        #[arg(short = 'n', long)]
-        name: String,
-        /// The cloud provider that was used.
-        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
-        provider: CloudProvider,
-        /// Optionally only sync the logs for the VMs that contain the following string.
-        #[arg(long)]
-        vm_filter: Option<String>,
-    },
-}
-
-#[derive(Subcommand, Debug)]
-enum LogstashCommands {
-    /// Clean a deployed Logstash environment.
-    Clean {
-        /// The name of the environment.
-        #[arg(short = 'n', long)]
-        name: String,
-        /// The cloud provider for the environment.
-        #[clap(long, value_parser = parse_provider, verbatim_doc_comment)]
-        provider: CloudProvider,
-    },
-    /// Deploy the Logstash infrastructure to support log forwarding to S3.
-    Deploy {
-        /// The name of the Logstash environment
-        #[arg(short = 'n', long)]
-        name: String,
-        /// The cloud provider to provision on
-        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
-        provider: CloudProvider,
-        /// The number of VMs to create.
-        ///
-        /// Use this to horizontally scale Logstash if need be.
-        #[clap(long, default_value = "1")]
-        vm_count: u16,
-    },
-}
-
-// Administer or perform activities on a deployed network.
-#[derive(Subcommand, Debug)]
-enum NetworkCommands {
-    /// Restart nodes in the testnet to simulate the churn of nodes.
-    #[clap(name = "churn", subcommand)]
-    ChurnCommands(ChurnCommands),
-    /// Modifies the log levels for all the antnode services through RPC requests.
-    UpdateNodeLogLevel {
-        /// The number of nodes to update concurrently.
-        #[clap(long, short = 'c', default_value_t = 10)]
-        concurrent_updates: usize,
-        /// Change the log level of the antnode. This accepts a comma-separated list of log levels for different modules
-        /// or specific keywords like "all" or "v".
-        ///
-        /// Example: --level libp2p=DEBUG,tokio=INFO,all,sn_client=ERROR
-        #[clap(name = "level", long)]
-        log_level: String,
-        /// The name of the environment
-        #[arg(short = 'n', long)]
-        name: String,
-    },
-}
-
-#[derive(Subcommand, Debug)]
-enum ChurnCommands {
-    /// Churn nodes at fixed intervals.
-    FixedInterval {
-        /// The number of time each node in the network is restarted.
-        #[clap(long, default_value_t = 1)]
-        churn_cycles: usize,
-        /// The number of nodes to restart concurrently per VM.
-        #[clap(long, short = 'c', default_value_t = 2)]
-        concurrent_churns: usize,
-        /// The interval between each node churn.
-        #[clap(long, value_parser = |t: &str| -> Result<Duration> { Ok(t.parse().map(Duration::from_secs)?)}, default_value = "60")]
-        interval: Duration,
-        /// The name of the environment.
-        #[arg(short = 'n', long)]
-        name: String,
-        /// The cloud provider that was used.
-        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
-        provider: CloudProvider,
-        /// Whether to retain the same PeerId on restart.
-        #[clap(long, default_value_t = false)]
-        retain_peer_id: bool,
-    },
-    /// Churn nodes at random intervals.
-    RandomInterval {
-        /// Number of nodes to restart in the given time frame.
-        #[clap(long, default_value_t = 10)]
-        churn_count: usize,
-        /// The number of time each node in the network is restarted.
-        #[clap(long, default_value_t = 1)]
-        churn_cycles: usize,
-        /// The name of the environment.
-        #[arg(short = 'n', long)]
-        name: String,
-        /// The cloud provider that was used.
-        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
-        provider: CloudProvider,
-        /// Whether to retain the same PeerId on restart.
-        #[clap(long, default_value_t = false)]
-        retain_peer_id: bool,
-        /// The time frame in which the churn_count nodes are restarted.
-        /// Nodes are restarted at a rate of churn_count/time_frame with random delays between each restart.
-        #[clap(long, value_parser = |t: &str| -> Result<Duration> { Ok(t.parse().map(Duration::from_secs)?)}, default_value = "600")]
-        time_frame: Duration,
-    },
-}
-
-#[derive(Subcommand, Debug)]
-enum UploadersCommands {
-    /// Start all uploaders for an environment
-    Start {
-        /// The name of the environment
-        #[arg(long)]
-        name: String,
-        /// The cloud provider that was used.
-        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
-        provider: CloudProvider,
-    },
-    /// Stop all uploaders for an environment.
-    Stop {
-        /// The name of the environment
-        #[arg(long)]
-        name: String,
-        /// The cloud provider that was used.
-        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
-        provider: CloudProvider,
-    },
-    /// Upgrade the uploaders for a given environment.
-    Upgrade {
-        /// The name of the environment.
-        #[arg(short = 'n', long)]
-        name: String,
-
-        /// The cloud provider for the environment.
-        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
-        provider: CloudProvider,
-
-        /// Optionally supply a version for the safe client binary to upgrade to.
-        ///
-        /// If not provided, the latest version will be used.
-        #[arg(long)]
-        version: Option<String>,
-    },
-    /// Upscale uploaders for an existing network.
-    Upscale {
-        /// Supply a version number for the autonomi binary to be used for new uploader VMs.
-        ///
-        /// There should be no 'v' prefix.
-        #[arg(long, verbatim_doc_comment)]
-        autonomi_version: String,
-        /// The desired number of uploader VMs to be running after the scale.
-        ///
-        /// If there are currently 10 VMs running, and you want there to be 25, the value used
-        /// should be 25, rather than 15 as a delta to reach 25.
-        #[clap(long, verbatim_doc_comment)]
-        desired_uploader_vm_count: Option<u16>,
-        /// The desired number of uploaders to be running after the scale.
-        ///
-        /// If you want each uploader VM to run multiple uploader services, specify the total desired count.
-        #[clap(long, verbatim_doc_comment)]
-        desired_uploaders_count: Option<u16>,
-        /// The secret key for the wallet that will fund all the uploaders.
-        ///
-        /// This argument only applies when Arbitrum or Sepolia networks are used.
-        #[clap(long)]
-        funding_wallet_secret_key: Option<String>,
-        /// The amount of gas tokens to transfer to each uploader.
-        /// Must be a decimal value between 0 and 1, e.g. "0.1"
-        #[clap(long)]
-        gas_amount: Option<String>,
-        /// Set to only use Terraform to upscale the VMs and not run Ansible.
-        #[clap(long, default_value_t = false)]
-        infra_only: bool,
-        /// The name of the environment
-        #[arg(short = 'n', long)]
-        name: String,
-        /// Set to only run the Terraform plan rather than applying the changes.
-        ///
-        /// Can be useful to preview the upscale to make sure everything is ok and that no other
-        /// changes slipped in.
-        ///
-        /// The plan will run and then the command will exit without doing anything else.
-        #[clap(long, default_value_t = false)]
-        plan: bool,
-        /// Set to skip the Terraform infrastructure run and only run the Ansible provisioning.
-        #[clap(long, default_value_t = false)]
-        provision_only: bool,
-        /// The cloud provider for the environment.
-        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
-        provider: CloudProvider,
-    },
-}
-
-#[derive(Subcommand, Debug)]
-enum FaucetCommands {
-    /// Fund the uploaders from the faucet
-    ///
-    /// This command requires the faucet to be running, so run the 'faucet start' command first.
-    FundUploaders {
-        /// The name of the environment
-        #[arg(long)]
-        name: String,
-        /// The cloud provider that was used
-        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
-        provider: CloudProvider,
-        /// Set to a non-zero value to fund each uploader wallet multiple times.
-        ///
-        /// The faucet will distribute one token on each playbook run.
-        #[clap(long, default_value_t = 0)]
-        repeat: u8,
-    },
-    /// Start the faucet for the environment
-    Start {
-        /// The name of the environment
-        #[arg(long)]
-        name: String,
-        /// The cloud provider that was used.
-        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
-        provider: CloudProvider,
-    },
-    /// Stop the faucet for the environment
-    Stop {
-        /// The name of the environment
-        #[arg(long)]
-        name: String,
-        /// The cloud provider that was used.
-        #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
-        provider: CloudProvider,
-    },
-}
-
-#[derive(Subcommand, Debug)]
-enum FundsCommand {
-    /// Deposit tokens and gas from the provided funding wallet secret key to all the uploaders
-    Deposit {
-        /// The secret key for the wallet that will fund all the uploaders.
-        ///
-        /// This argument only applies when Arbitrum or Sepolia networks are used.
-        #[clap(long)]
-        funding_wallet_secret_key: Option<String>,
-        /// The number of gas to transfer, in U256
-        ///
-        /// 1 ETH = 1_000_000_000_000_000_000. Defaults to 0.1 ETH
-        #[arg(long)]
-        gas_to_transfer: Option<U256>,
-        /// The name of the environment.
-        #[arg(short = 'n', long)]
-        name: String,
-        /// The cloud provider for the environment.
-        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
-        provider: CloudProvider,
-        /// The number of tokens to transfer, in U256
-        ///
-        /// 1 Token = 1_000_000_000_000_000_000. Defaults to 100 token.
-        #[arg(long)]
-        tokens_to_transfer: Option<U256>,
-    },
-    /// Drain all the tokens and gas from the uploaders to the funding wallet.
-    Drain {
-        /// The name of the environment.
-        #[arg(short = 'n', long)]
-        name: String,
-        /// The cloud provider for the environment.
-        #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
-        provider: CloudProvider,
-        /// The address of the wallet that will receive all the tokens and gas.
-        ///
-        /// This argument is optional, the funding wallet address from the S3 environment file will be used by default.
-        #[clap(long)]
-        to_address: Option<String>,
-    },
 }
 
 #[tokio::main]
@@ -1530,143 +69,43 @@ async fn main() -> Result<()> {
             repo_owner,
             rewards_address,
         } => {
-            if bootstrap_network_contacts_url.is_none() && bootstrap_peer.is_none() {
-                return Err(eyre!(
-                    "Either bootstrap-peer or bootstrap-network-contacts-url must be provided"
-                ));
-            }
-
-            if evm_network_type == EvmNetwork::Anvil {
-                return Err(eyre!(
-                    "The anvil network type cannot be used for bootstrapping. 
-                    Use the custom network type, supplying the Anvil contract addresses and RPC URL
-                    from the previous network. They can be found in the network's inventory."
-                ));
-            }
-
-            if evm_network_type == EvmNetwork::Custom
-                && (evm_data_payments_address.is_none()
-                    || evm_payment_token_address.is_none()
-                    || evm_rpc_url.is_none())
-            {
-                return Err(eyre!(
-                    "When using a custom EVM network, you must supply evm-data-payments-address, evm-payment-token-address, and evm-rpc-url"
-                ));
-            }
-
-            if evm_network_type != EvmNetwork::Custom && evm_rpc_url.is_some() {
-                return Err(eyre!(
-                    "EVM RPC URL can only be set for a custom EVM network"
-                ));
-            }
-
-            let binary_option = get_binary_option(
-                branch,
-                repo_owner,
-                None,
-                antnode_version,
+            cmd::deployments::handle_bootstrap(
+                ansible_verbose,
                 antctl_version,
                 antnode_features,
+                antnode_version,
+                bootstrap_network_contacts_url,
+                bootstrap_peer,
+                branch,
+                chunk_size,
+                environment_type,
+                env_variables,
+                evm_data_payments_address,
+                evm_network_type,
+                evm_payment_token_address,
+                evm_rpc_url,
+                full_cone_private_node_count,
+                full_cone_private_node_vm_count,
+                full_cone_private_node_volume_size,
+                forks,
+                interval,
+                log_format,
+                name,
+                network_id,
+                node_count,
+                node_vm_count,
+                node_volume_size,
+                node_vm_size,
+                max_archived_log_files,
+                max_log_files,
+                symmetric_private_node_count,
+                symmetric_private_node_vm_count,
+                symmetric_private_node_volume_size,
+                provider,
+                repo_owner,
+                rewards_address,
             )
             .await?;
-
-            let mut builder = TestnetDeployBuilder::default();
-            builder
-                .ansible_verbose_mode(ansible_verbose)
-                .deployment_type(environment_type.clone())
-                .environment_name(&name)
-                .provider(provider);
-            if let Some(forks) = forks {
-                builder.ansible_forks(forks);
-            }
-            let testnet_deployer = builder.build()?;
-
-            let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-            inventory_service
-                .generate_or_retrieve_inventory(&name, true, Some(binary_option.clone()))
-                .await?;
-
-            match testnet_deployer.init().await {
-                Ok(_) => {}
-                Err(e @ Error::LogsForPreviousTestnetExist(_)) => {
-                    return Err(eyre!(e)
-                        .wrap_err(format!(
-                            "Logs already exist for a previous testnet with the \
-                                    name '{name}'"
-                        ))
-                        .suggestion(
-                            "If you wish to keep them, retrieve the logs with the 'logs get' \
-                                command, then remove them with 'logs rm'. If you don't need them, \
-                                simply run 'logs rm'. Then you can proceed with deploying your \
-                                new testnet.",
-                        ));
-                }
-                Err(e) => {
-                    return Err(eyre!(e));
-                }
-            }
-
-            let node_count = node_count.unwrap_or(environment_type.get_default_node_count());
-            let symmetric_private_node_count = symmetric_private_node_count
-                .unwrap_or(environment_type.get_default_symmetric_private_node_count());
-            let full_cone_private_node_count = full_cone_private_node_count
-                .unwrap_or(environment_type.get_default_full_cone_private_node_count());
-
-            testnet_deployer
-                .bootstrap(&BootstrapOptions {
-                    binary_option,
-                    bootstrap_network_contacts_url,
-                    bootstrap_peer,
-                    environment_type: environment_type.clone(),
-                    env_variables,
-                    evm_data_payments_address,
-                    evm_network: evm_network_type,
-                    evm_payment_token_address,
-                    evm_rpc_url,
-                    full_cone_private_node_count,
-                    full_cone_private_node_vm_count,
-                    full_cone_private_node_volume_size: full_cone_private_node_volume_size.or_else(
-                        || {
-                            Some(calculate_size_per_attached_volume(
-                                full_cone_private_node_count,
-                            ))
-                        },
-                    ),
-                    interval,
-                    log_format,
-                    name: name.clone(),
-                    network_id,
-                    node_count,
-                    node_vm_count,
-                    node_vm_size,
-                    node_volume_size: node_volume_size
-                        .or_else(|| Some(calculate_size_per_attached_volume(node_count))),
-                    max_archived_log_files,
-                    max_log_files,
-                    output_inventory_dir_path: inventory_service
-                        .working_directory_path
-                        .join("ansible")
-                        .join("inventory"),
-                    symmetric_private_node_vm_count,
-                    symmetric_private_node_count,
-                    symmetric_private_node_volume_size: symmetric_private_node_volume_size.or_else(
-                        || {
-                            Some(calculate_size_per_attached_volume(
-                                symmetric_private_node_count,
-                            ))
-                        },
-                    ),
-                    rewards_address,
-                    chunk_size,
-                })
-                .await?;
-
-            let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-            let new_inventory = inventory_service
-                .generate_or_retrieve_inventory(&name, true, None)
-                .await?;
-            new_inventory.print_report(false)?;
-            new_inventory.save()?;
             Ok(())
         }
         Commands::Clean { name, provider } => {
@@ -1731,195 +170,60 @@ async fn main() -> Result<()> {
             uploader_vm_size,
             uploaders_count,
         } => {
-            if evm_network_type == EvmNetwork::Custom {
-                if evm_data_payments_address.is_none() {
-                    return Err(eyre!(
-                        "Data payments address must be provided for custom EVM network"
-                    ));
-                }
-                if evm_payment_token_address.is_none() {
-                    return Err(eyre!(
-                        "Payment token address must be provided for custom EVM network"
-                    ));
-                }
-                if evm_rpc_url.is_none() {
-                    return Err(eyre!("RPC URL must be provided for custom EVM network"));
-                }
-            }
-
-            if funding_wallet_secret_key.is_none() && evm_network_type != EvmNetwork::Anvil {
-                return Err(eyre!(
-                    "Wallet secret key is required for Arbitrum or Sepolia networks"
-                ));
-            }
-
-            let binary_option = get_binary_option(
-                branch,
-                repo_owner,
+            cmd::deployments::handle_deploy(
+                ansible_verbose,
                 ant_version,
-                antnode_version,
                 antctl_version,
                 antnode_features,
+                antnode_version,
+                branch,
+                chunk_size,
+                downloaders_count,
+                env_variables,
+                environment_type,
+                evm_data_payments_address,
+                evm_network_type,
+                evm_node_vm_size,
+                evm_payment_token_address,
+                evm_rpc_url,
+                full_cone_nat_gateway_vm_size,
+                full_cone_private_node_count,
+                full_cone_private_node_vm_count,
+                full_cone_private_node_volume_size,
+                forks,
+                funding_wallet_secret_key,
+                genesis_node_volume_size,
+                initial_gas,
+                initial_tokens,
+                interval,
+                log_format,
+                logstash_stack_name,
+                max_archived_log_files,
+                max_log_files,
+                name,
+                network_id,
+                network_contacts_file_name,
+                node_count,
+                node_vm_count,
+                node_vm_size,
+                node_volume_size,
+                peer_cache_node_count,
+                peer_cache_node_vm_count,
+                peer_cache_node_vm_size,
+                peer_cache_node_volume_size,
+                symmetric_nat_gateway_vm_size,
+                symmetric_private_node_count,
+                symmetric_private_node_vm_count,
+                symmetric_private_node_volume_size,
+                provider,
+                public_rpc,
+                repo_owner,
+                rewards_address,
+                uploader_vm_count,
+                uploader_vm_size,
+                uploaders_count,
             )
             .await?;
-
-            let mut builder = TestnetDeployBuilder::default();
-            builder
-                .ansible_verbose_mode(ansible_verbose)
-                .deployment_type(environment_type.clone())
-                .environment_name(&name)
-                .provider(provider);
-            if let Some(forks) = forks {
-                builder.ansible_forks(forks);
-            }
-            let testnet_deployer = builder.build()?;
-
-            let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-            let inventory = inventory_service
-                .generate_or_retrieve_inventory(&name, true, Some(binary_option.clone()))
-                .await?;
-
-            match testnet_deployer.init().await {
-                Ok(_) => {}
-                Err(e @ Error::LogsForPreviousTestnetExist(_)) => {
-                    return Err(eyre!(e)
-                        .wrap_err(format!(
-                            "Logs already exist for a previous testnet with the \
-                                    name '{name}'"
-                        ))
-                        .suggestion(
-                            "If you wish to keep them, retrieve the logs with the 'logs get' \
-                                command, then remove them with 'logs rm'. If you don't need them, \
-                                simply run 'logs rm'. Then you can proceed with deploying your \
-                                new testnet.",
-                        ));
-                }
-                Err(e) => {
-                    return Err(eyre!(e));
-                }
-            }
-
-            let logstash_details = {
-                let logstash_deploy = LogstashDeployBuilder::default()
-                    .environment_name(&name)
-                    .provider(provider)
-                    .build()?;
-                let stack_hosts = logstash_deploy
-                    .get_stack_hosts(&logstash_stack_name)
-                    .await?;
-                if stack_hosts.is_empty() {
-                    None
-                } else {
-                    Some((logstash_stack_name, stack_hosts))
-                }
-            };
-
-            let peer_cache_node_count = peer_cache_node_count
-                .unwrap_or(environment_type.get_default_peer_cache_node_count());
-            let node_count = node_count.unwrap_or(environment_type.get_default_node_count());
-            let symmetric_private_node_count = symmetric_private_node_count
-                .unwrap_or(environment_type.get_default_symmetric_private_node_count());
-            let full_cone_private_node_count = full_cone_private_node_count
-                .unwrap_or(environment_type.get_default_full_cone_private_node_count());
-
-            testnet_deployer
-                .deploy(&DeployOptions {
-                    binary_option: binary_option.clone(),
-                    chunk_size,
-                    current_inventory: inventory,
-                    downloaders_count,
-                    env_variables,
-                    environment_type: environment_type.clone(),
-                    evm_data_payments_address,
-                    evm_network: evm_network_type,
-                    evm_node_vm_size,
-                    evm_payment_token_address,
-                    evm_rpc_url,
-                    funding_wallet_secret_key,
-                    full_cone_nat_gateway_vm_size,
-                    full_cone_private_node_count,
-                    full_cone_private_node_vm_count,
-                    full_cone_private_node_volume_size: full_cone_private_node_volume_size.or_else(
-                        || {
-                            Some(calculate_size_per_attached_volume(
-                                full_cone_private_node_count,
-                            ))
-                        },
-                    ),
-                    genesis_node_volume_size: genesis_node_volume_size
-                        .or_else(|| Some(calculate_size_per_attached_volume(1))),
-                    initial_gas,
-                    initial_tokens,
-                    interval,
-                    log_format,
-                    logstash_details,
-                    max_archived_log_files,
-                    max_log_files,
-                    name: name.clone(),
-                    network_id,
-                    node_count,
-                    node_vm_count,
-                    node_vm_size,
-                    node_volume_size: node_volume_size
-                        .or_else(|| Some(calculate_size_per_attached_volume(node_count))),
-                    output_inventory_dir_path: inventory_service
-                        .working_directory_path
-                        .join("ansible")
-                        .join("inventory"),
-                    peer_cache_node_count,
-                    peer_cache_node_vm_count,
-                    peer_cache_node_vm_size,
-                    peer_cache_node_volume_size: peer_cache_node_volume_size.or_else(|| {
-                        Some(calculate_size_per_attached_volume(peer_cache_node_count))
-                    }),
-                    symmetric_nat_gateway_vm_size,
-                    symmetric_private_node_count,
-                    symmetric_private_node_vm_count,
-                    symmetric_private_node_volume_size: symmetric_private_node_volume_size.or_else(
-                        || {
-                            Some(calculate_size_per_attached_volume(
-                                symmetric_private_node_count,
-                            ))
-                        },
-                    ),
-                    public_rpc,
-                    rewards_address,
-                    uploader_vm_count,
-                    uploader_vm_size,
-                    uploaders_count,
-                })
-                .await?;
-
-            let max_retries = 3;
-            let mut retries = 0;
-            let inventory = loop {
-                match inventory_service
-                    .generate_or_retrieve_inventory(&name, true, Some(binary_option.clone()))
-                    .await
-                {
-                    Ok(inv) => break inv,
-                    Err(e) if retries < max_retries => {
-                        retries += 1;
-                        eprintln!("Failed to generate inventory on attempt {retries}: {:?}", e);
-                        eprintln!("Will retry up to {max_retries} times...");
-                    }
-                    Err(_) => {
-                        eprintln!("Failed to generate inventory after {max_retries} attempts");
-                        eprintln!(
-                            "Please try running the `inventory` command or workflow separately"
-                        );
-                        return Ok(());
-                    }
-                }
-            };
-
-            inventory.print_report(false)?;
-            inventory.save()?;
-
-            inventory_service
-                .upload_network_contacts(&inventory, network_contacts_file_name)
-                .await?;
-
             Ok(())
         }
         Commands::ExtendVolumeSize {
@@ -1932,250 +236,22 @@ async fn main() -> Result<()> {
             provider,
             symmetric_private_node_volume_size,
         } => {
-            if peer_cache_node_volume_size.is_none()
-                && genesis_node_volume_size.is_none()
-                && node_volume_size.is_none()
-                && symmetric_private_node_volume_size.is_none()
-                && full_cone_private_node_volume_size.is_none()
-            {
-                return Err(eyre!("At least one volume size must be provided"));
-            }
-
-            println!("Extending attached volume size...");
-            let testnet_deployer = TestnetDeployBuilder::default()
-                .ansible_verbose_mode(ansible_verbose)
-                .environment_name(&name)
-                .provider(provider)
-                .build()?;
-            testnet_deployer.init().await?;
-
-            let environemt_details =
-                get_environment_details(&name, &testnet_deployer.s3_repository).await?;
-
-            let mut infra_run_options = InfraRunOptions::generate_existing(
-                &name,
-                &testnet_deployer.terraform_runner,
-                &environemt_details,
+            cmd::misc::handle_extend_volume_size(
+                ansible_verbose,
+                genesis_node_volume_size,
+                full_cone_private_node_volume_size,
+                node_volume_size,
+                name,
+                peer_cache_node_volume_size,
+                provider,
+                symmetric_private_node_volume_size,
             )
             .await?;
-            println!("Obtained infra run options from previous deployment {infra_run_options:?}");
-            let mut node_types = Vec::new();
-
-            if peer_cache_node_volume_size.is_some() {
-                infra_run_options.peer_cache_node_volume_size = peer_cache_node_volume_size;
-                node_types.push(AnsibleInventoryType::PeerCacheNodes);
-            }
-            if genesis_node_volume_size.is_some() {
-                infra_run_options.genesis_node_volume_size = genesis_node_volume_size;
-                node_types.push(AnsibleInventoryType::Genesis);
-            }
-            if node_volume_size.is_some() {
-                infra_run_options.node_volume_size = node_volume_size;
-                node_types.push(AnsibleInventoryType::Nodes);
-            }
-            if symmetric_private_node_volume_size.is_some() {
-                infra_run_options.symmetric_private_node_volume_size =
-                    symmetric_private_node_volume_size;
-                node_types.push(AnsibleInventoryType::SymmetricPrivateNodes);
-            }
-            if full_cone_private_node_volume_size.is_some() {
-                infra_run_options.full_cone_private_node_volume_size =
-                    full_cone_private_node_volume_size;
-                node_types.push(AnsibleInventoryType::FullConePrivateNodes);
-            }
-
-            println!("Running infra update with new volume sizes: {infra_run_options:?}");
-            testnet_deployer
-                .create_or_update_infra(&infra_run_options)
-                .map_err(|err| {
-                    println!("Failed to create infra {err:?}");
-                    err
-                })?;
-
-            for node_type in node_types {
-                println!("Extending volume size for {node_type} nodes...");
-                testnet_deployer
-                    .ansible_provisioner
-                    .ansible_runner
-                    .run_playbook(AnsiblePlaybook::ExtendVolumeSize, node_type, None)?;
-            }
-
             Ok(())
         }
-        Commands::Faucet(uploaders_cmd) => match uploaders_cmd {
-            FaucetCommands::FundUploaders {
-                name,
-                provider,
-                repeat,
-            } => {
-                let testnet_deployer = TestnetDeployBuilder::default()
-                    .ansible_forks(1)
-                    .environment_name(&name)
-                    .provider(provider)
-                    .build()?;
-                let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-                let inventory = inventory_service
-                    .generate_or_retrieve_inventory(&name, true, None)
-                    .await?;
-
-                let ansible_runner = testnet_deployer.ansible_provisioner.ansible_runner;
-
-                let playbook_runs = repeat + 1;
-                for _ in 0..playbook_runs {
-                    ansible_runner.run_playbook(
-                        AnsiblePlaybook::FundUploaders,
-                        AnsibleInventoryType::Uploaders,
-                        Some(build_fund_faucet_extra_vars_doc(
-                            &inventory.get_genesis_ip().ok_or_else(||
-                                eyre!("Genesis node not found. Most likely this is a bootstrap deployment."))?,
-                            &inventory.genesis_multiaddr.clone().ok_or_else(||
-                                eyre!("Genesis node not found. Most likely this is a bootstrap deployment."))?,
-                        )?)
-                    )?;
-                }
-
-                Ok(())
-            }
-            FaucetCommands::Start { name, provider } => {
-                let testnet_deployer = TestnetDeployBuilder::default()
-                    .environment_name(&name)
-                    .provider(provider)
-                    .build()?;
-                let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-                inventory_service
-                    .generate_or_retrieve_inventory(&name, true, None)
-                    .await?;
-
-                let ansible_runner = testnet_deployer.ansible_provisioner.ansible_runner;
-                ansible_runner.run_playbook(
-                    AnsiblePlaybook::StartFaucet,
-                    AnsibleInventoryType::Genesis,
-                    None,
-                )?;
-                Ok(())
-            }
-            FaucetCommands::Stop { name, provider } => {
-                let testnet_deployer = TestnetDeployBuilder::default()
-                    .environment_name(&name)
-                    .provider(provider)
-                    .build()?;
-                let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-                inventory_service
-                    .generate_or_retrieve_inventory(&name, true, None)
-                    .await?;
-
-                let ansible_runner = testnet_deployer.ansible_provisioner.ansible_runner;
-                ansible_runner.run_playbook(
-                    AnsiblePlaybook::StopFaucet,
-                    AnsibleInventoryType::Genesis,
-                    None,
-                )?;
-                Ok(())
-            }
-        },
         Commands::Funds(funds_cmd) => {
-            match funds_cmd {
-                FundsCommand::Deposit {
-                    funding_wallet_secret_key,
-                    gas_to_transfer,
-                    name,
-                    provider,
-                    tokens_to_transfer,
-                } => {
-                    let testnet_deployer = TestnetDeployBuilder::default()
-                        .environment_name(&name)
-                        .provider(provider)
-                        .build()?;
-                    let inventory_services = DeploymentInventoryService::from(&testnet_deployer);
-                    inventory_services
-                        .generate_or_retrieve_inventory(&name, true, None)
-                        .await?;
-
-                    let environment_details =
-                        get_environment_details(&name, &inventory_services.s3_repository).await?;
-
-                    let options = FundingOptions {
-                        evm_data_payments_address: environment_details.evm_data_payments_address,
-                        evm_payment_token_address: environment_details.evm_payment_token_address,
-                        evm_rpc_url: environment_details.evm_rpc_url,
-                        evm_network: environment_details.evm_network,
-                        funding_wallet_secret_key,
-                        uploaders_count: None,
-                        token_amount: tokens_to_transfer,
-                        gas_amount: gas_to_transfer,
-                    };
-                    testnet_deployer
-                        .ansible_provisioner
-                        .deposit_funds_to_uploaders(&options)
-                        .await?;
-
-                    Ok(())
-                }
-                FundsCommand::Drain {
-                    name,
-                    provider,
-                    to_address,
-                } => {
-                    let testnet_deployer = TestnetDeployBuilder::default()
-                        .environment_name(&name)
-                        .provider(provider)
-                        .build()?;
-
-                    let inventory_services = DeploymentInventoryService::from(&testnet_deployer);
-                    inventory_services
-                        .generate_or_retrieve_inventory(&name, true, None)
-                        .await?;
-
-                    let environment_details =
-                        get_environment_details(&name, &inventory_services.s3_repository).await?;
-
-                    let to_address = if let Some(to_address) = to_address {
-                        Address::from_str(&to_address)?
-                    } else if let Some(to_address) = environment_details.funding_wallet_address {
-                        Address::from_str(&to_address)?
-                    } else {
-                        return Err(eyre!(
-                        "No to-address was provided and no funding wallet address was found in the environment details"
-                    ));
-                    };
-
-                    let network = match environment_details.evm_network {
-                        EvmNetwork::Anvil => {
-                            return Err(eyre!("Draining funds from uploaders is not supported for an Anvil network"));
-                        }
-                        EvmNetwork::ArbitrumOne => Network::ArbitrumOne,
-                        EvmNetwork::ArbitrumSepolia => Network::ArbitrumSepolia,
-                        EvmNetwork::Custom => {
-                            if let (
-                                Some(emv_data_payments_address),
-                                Some(evm_payment_token_address),
-                                Some(evm_rpc_url),
-                            ) = (
-                                environment_details.evm_data_payments_address,
-                                environment_details.evm_payment_token_address,
-                                environment_details.evm_rpc_url,
-                            ) {
-                                Network::new_custom(
-                                    &evm_rpc_url,
-                                    &evm_payment_token_address,
-                                    &emv_data_payments_address,
-                                )
-                            } else {
-                                return Err(eyre!(
-                                    "Custom EVM details not found in the environment details"
-                                ));
-                            }
-                        }
-                    };
-
-                    testnet_deployer
-                        .ansible_provisioner
-                        .drain_funds_from_uploaders(to_address, network)
-                        .await?;
-
-                    Ok(())
-                }
-            }
+            cmd::funds::handle_funds_command(funds_cmd).await?;
+            Ok(())
         }
         Commands::Inventory {
             force_regeneration,
@@ -2185,130 +261,21 @@ async fn main() -> Result<()> {
             peer_cache,
             provider,
         } => {
-            let testnet_deployer = TestnetDeployBuilder::default()
-                .environment_name(&name)
-                .provider(provider)
-                .build()?;
-
-            let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-            let inventory = inventory_service
-                .generate_or_retrieve_inventory(&name, force_regeneration, None)
-                .await?;
-
-            if peer_cache {
-                inventory.print_peer_cache_webserver();
-            } else {
-                inventory.print_report(full)?;
-            }
-
-            inventory.save()?;
-
-            inventory_service
-                .upload_network_contacts(&inventory, network_contacts_file_name)
-                .await?;
-
+            cmd::misc::handle_inventory(
+                force_regeneration,
+                full,
+                name,
+                network_contacts_file_name,
+                peer_cache,
+                provider,
+            )
+            .await?;
             Ok(())
         }
-        Commands::Logs(log_cmd) => match log_cmd {
-            LogCommands::Cleanup {
-                name,
-                provider,
-                setup_cron,
-            } => {
-                let testnet_deployer = TestnetDeployBuilder::default()
-                    .environment_name(&name)
-                    .provider(provider)
-                    .build()?;
-                testnet_deployer.init().await?;
-                let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-                inventory_service.setup_environment_inventory(&name)?;
-
-                testnet_deployer.cleanup_node_logs(setup_cron)?;
-                Ok(())
-            }
-            LogCommands::Copy {
-                name,
-                provider,
-                resources_only,
-            } => {
-                let testnet_deployer = TestnetDeployBuilder::default()
-                    .environment_name(&name)
-                    .provider(provider)
-                    .build()?;
-                testnet_deployer.init().await?;
-                let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-                inventory_service.setup_environment_inventory(&name)?;
-
-                testnet_deployer.copy_logs(&name, resources_only)?;
-                Ok(())
-            }
-            LogCommands::Get { name } => {
-                sn_testnet_deploy::logs::get_logs(&name).await?;
-                Ok(())
-            }
-            LogCommands::Reassemble { name } => {
-                sn_testnet_deploy::logs::reassemble_logs(&name)?;
-                Ok(())
-            }
-            LogCommands::Rg {
-                args,
-                name,
-                provider,
-            } => {
-                let testnet_deployer = TestnetDeployBuilder::default()
-                    .environment_name(&name)
-                    .provider(provider)
-                    .build()?;
-                testnet_deployer.init().await?;
-                let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-                inventory_service.setup_environment_inventory(&name)?;
-
-                testnet_deployer.ripgrep_logs(&name, &args)?;
-                Ok(())
-            }
-
-            LogCommands::Rm { name } => {
-                sn_testnet_deploy::logs::rm_logs(&name).await?;
-                Ok(())
-            }
-            LogCommands::Rsync {
-                name,
-                provider,
-                vm_filter,
-            } => {
-                let testnet_deployer = TestnetDeployBuilder::default()
-                    .environment_name(&name)
-                    .provider(provider)
-                    .build()?;
-                testnet_deployer.init().await?;
-                let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-                inventory_service.setup_environment_inventory(&name)?;
-
-                testnet_deployer.rsync_logs(&name, vm_filter)?;
-                Ok(())
-            }
-        },
-        Commands::Logstash(logstash_cmd) => match logstash_cmd {
-            LogstashCommands::Clean { name, provider } => {
-                let logstash_deploy = LogstashDeployBuilder::default()
-                    .provider(provider)
-                    .build()?;
-                logstash_deploy.clean(&name).await?;
-                Ok(())
-            }
-            LogstashCommands::Deploy {
-                name,
-                provider,
-                vm_count,
-            } => {
-                let logstash_deploy = LogstashDeployBuilder::default()
-                    .provider(provider)
-                    .build()?;
-                logstash_deploy.init(&name).await?;
-                logstash_deploy.deploy(&name, vm_count)?;
-                Ok(())
-            }
-        },
+        Commands::Logs(log_cmd) => {
+            cmd::logs::handle_logs_command(log_cmd).await?;
+            Ok(())
+        }
         Commands::Network(NetworkCommands::ChurnCommands(churn_cmds)) => {
             let (name, provider) = match &churn_cmds {
                 ChurnCommands::FixedInterval { name, provider, .. } => (name, provider),
@@ -2332,7 +299,7 @@ async fn main() -> Result<()> {
                     retain_peer_id,
                     ..
                 } => {
-                    network_commands::perform_fixed_interval_network_churn(
+                    cmd::network::handle_fixed_interval_network_churn(
                         inventory,
                         interval,
                         concurrent_churns,
@@ -2348,7 +315,7 @@ async fn main() -> Result<()> {
                     time_frame,
                     ..
                 } => {
-                    network_commands::perform_random_interval_network_churn(
+                    cmd::network::handle_random_interval_network_churn(
                         inventory,
                         time_frame,
                         churn_count,
@@ -2365,27 +332,11 @@ async fn main() -> Result<()> {
             log_level,
             name,
         }) => {
-            let inventory_path = get_data_directory()?.join(format!("{name}-inventory.json"));
-            if !inventory_path.exists() {
-                return Err(eyre!("There is no inventory for the {name} testnet")
-                    .suggestion("Please run the inventory command to generate it"));
-            }
-
-            let inventory = DeploymentInventory::read(&inventory_path)?;
-            network_commands::update_node_log_levels(inventory, log_level, concurrent_updates)
-                .await?;
-
+            cmd::network::handle_update_node_log_level(concurrent_updates, log_level, name).await?;
             Ok(())
         }
         Commands::Notify { name } => {
-            let inventory_path = get_data_directory()?.join(format!("{name}-inventory.json"));
-            if !inventory_path.exists() {
-                return Err(eyre!("There is no inventory for the {name} testnet")
-                    .suggestion("Please run the inventory command to generate it"));
-            }
-
-            let inventory = DeploymentInventory::read(&inventory_path)?;
-            notify_slack(inventory).await?;
+            cmd::misc::handle_notify(name).await?;
             Ok(())
         }
         Commands::Setup {} => {
@@ -2400,32 +351,15 @@ async fn main() -> Result<()> {
             node_type,
             provider,
         } => {
-            let testnet_deployer = TestnetDeployBuilder::default()
-                .ansible_forks(forks)
-                .environment_name(&name)
-                .provider(provider)
-                .build()?;
-
-            // This is required in the case where the command runs in a remote environment, where
-            // there won't be an existing inventory, which is required to retrieve the node
-            // registry files used to determine the status.
-            let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-            let inventory = inventory_service
-                .generate_or_retrieve_inventory(&name, true, None)
-                .await?;
-            if inventory.is_empty() {
-                return Err(eyre!("The {name} environment does not exist"));
-            }
-
-            let custom_inventory = if let Some(custom_inventory) = custom_inventory {
-                let custom_vms = get_custom_inventory(&inventory, &custom_inventory)?;
-                Some(custom_vms)
-            } else {
-                None
-            };
-
-            testnet_deployer.start(interval, node_type, custom_inventory)?;
-
+            nodes::handle_start_command(
+                custom_inventory,
+                forks,
+                interval,
+                name,
+                node_type,
+                provider,
+            )
+            .await?;
             Ok(())
         }
         Commands::StartTelegraf {
@@ -2435,32 +369,14 @@ async fn main() -> Result<()> {
             node_type,
             provider,
         } => {
-            let testnet_deployer = TestnetDeployBuilder::default()
-                .ansible_forks(forks)
-                .environment_name(&name)
-                .provider(provider)
-                .build()?;
-
-            // This is required in the case where the command runs in a remote environment, where
-            // there won't be an existing inventory, which is required to retrieve the node
-            // registry files used to determine the status.
-            let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-            let inventory = inventory_service
-                .generate_or_retrieve_inventory(&name, true, None)
-                .await?;
-            if inventory.is_empty() {
-                return Err(eyre!("The {name} environment does not exist"));
-            }
-
-            let custom_inventory = if let Some(custom_inventory) = custom_inventory {
-                let custom_vms = get_custom_inventory(&inventory, &custom_inventory)?;
-                Some(custom_vms)
-            } else {
-                None
-            };
-
-            testnet_deployer.start_telegraf(node_type, custom_inventory)?;
-
+            telegraf::handle_start_telegraf_command(
+                custom_inventory,
+                forks,
+                name,
+                node_type,
+                provider,
+            )
+            .await?;
             Ok(())
         }
         Commands::Status {
@@ -2468,24 +384,7 @@ async fn main() -> Result<()> {
             name,
             provider,
         } => {
-            let testnet_deployer = TestnetDeployBuilder::default()
-                .ansible_forks(forks)
-                .environment_name(&name)
-                .provider(provider)
-                .build()?;
-
-            // This is required in the case where the command runs in a remote environment, where
-            // there won't be an existing inventory, which is required to retrieve the node
-            // registry files used to determine the status.
-            let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-            let inventory = inventory_service
-                .generate_or_retrieve_inventory(&name, true, None)
-                .await?;
-            if inventory.is_empty() {
-                return Err(eyre!("The {name} environment does not exist"));
-            }
-
-            testnet_deployer.status()?;
+            nodes::handle_status_command(forks, name, provider).await?;
             Ok(())
         }
         Commands::Stop {
@@ -2497,36 +396,16 @@ async fn main() -> Result<()> {
             node_type,
             provider,
         } => {
-            // Use a large number of forks for retrieving the inventory from a large deployment.
-            // Then if a smaller number of forks is specified, we will recreate the deployer
-            // with the smaller fork value.
-            let testnet_deployer = TestnetDeployBuilder::default()
-                .ansible_forks(50)
-                .environment_name(&name)
-                .provider(provider)
-                .build()?;
-            let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-            let inventory = inventory_service
-                .generate_or_retrieve_inventory(&name, true, None)
-                .await?;
-            if inventory.is_empty() {
-                return Err(eyre!("The {name} environment does not exist"));
-            }
-
-            let testnet_deployer = TestnetDeployBuilder::default()
-                .ansible_forks(forks)
-                .environment_name(&name)
-                .provider(provider)
-                .build()?;
-            let custom_inventory = if let Some(custom_inventory) = custom_inventory {
-                let custom_vms = get_custom_inventory(&inventory, &custom_inventory)?;
-                Some(custom_vms)
-            } else {
-                None
-            };
-
-            testnet_deployer.stop(interval, node_type, custom_inventory, delay)?;
-
+            nodes::handle_stop_command(
+                custom_inventory,
+                delay,
+                forks,
+                interval,
+                name,
+                node_type,
+                provider,
+            )
+            .await?;
             Ok(())
         }
         Commands::StopTelegraf {
@@ -2536,32 +415,14 @@ async fn main() -> Result<()> {
             node_type,
             provider,
         } => {
-            let testnet_deployer = TestnetDeployBuilder::default()
-                .ansible_forks(forks)
-                .environment_name(&name)
-                .provider(provider)
-                .build()?;
-
-            // This is required in the case where the command runs in a remote environment, where
-            // there won't be an existing inventory, which is required to retrieve the node
-            // registry files used to determine the status.
-            let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-            let inventory = inventory_service
-                .generate_or_retrieve_inventory(&name, true, None)
-                .await?;
-            if inventory.is_empty() {
-                return Err(eyre!("The {name} environment does not exist"));
-            }
-
-            let custom_inventory = if let Some(custom_inventory) = custom_inventory {
-                let custom_vms = get_custom_inventory(&inventory, &custom_inventory)?;
-                Some(custom_vms)
-            } else {
-                None
-            };
-
-            testnet_deployer.stop_telegraf(node_type, custom_inventory)?;
-
+            telegraf::handle_stop_telegraf_command(
+                custom_inventory,
+                forks,
+                name,
+                node_type,
+                provider,
+            )
+            .await?;
             Ok(())
         }
         Commands::ConfigureSwapfile {
@@ -2570,34 +431,7 @@ async fn main() -> Result<()> {
             peer_cache,
             size,
         } => {
-            let testnet_deployer = TestnetDeployBuilder::default()
-                .environment_name(&name)
-                .provider(provider)
-                .build()?;
-
-            let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-            let inventory = inventory_service
-                .generate_or_retrieve_inventory(&name, true, None)
-                .await?;
-            if inventory.is_empty() {
-                return Err(eyre!("The {name} environment does not exist"));
-            }
-
-            let ansible_runner = testnet_deployer.ansible_provisioner.ansible_runner;
-            ansible_runner.run_playbook(
-                AnsiblePlaybook::ConfigureSwapfile,
-                AnsibleInventoryType::Nodes,
-                Some(build_swapfile_extra_vars_doc(size)?),
-            )?;
-
-            if peer_cache {
-                ansible_runner.run_playbook(
-                    AnsiblePlaybook::ConfigureSwapfile,
-                    AnsibleInventoryType::PeerCacheNodes,
-                    Some(build_swapfile_extra_vars_doc(size)?),
-                )?;
-            }
-
+            cmd::misc::handle_configure_swapfile(name, provider, peer_cache, size).await?;
             Ok(())
         }
         Commands::Upgrade {
@@ -2613,58 +447,20 @@ async fn main() -> Result<()> {
             pre_upgrade_delay,
             version,
         } => {
-            // The upgrade intentionally uses a small value for `forks`, but this is far too slow
-            // for retrieving the inventory from a large deployment. Therefore, we will use 50
-            // forks for the initial run to retrieve the inventory, then recreate the deployer
-            // using the smaller fork value.
-            let testnet_deployer = TestnetDeployBuilder::default()
-                .ansible_forks(50)
-                .environment_name(&name)
-                .provider(provider)
-                .build()?;
-            let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-            let inventory = inventory_service
-                .generate_or_retrieve_inventory(&name, true, None)
-                .await?;
-            if inventory.is_empty() {
-                return Err(eyre!("The {name} environment does not exist"));
-            }
-
-            let custom_inventory = if let Some(custom_inventory) = custom_inventory {
-                let custom_vms = get_custom_inventory(&inventory, &custom_inventory)?;
-                Some(custom_vms)
-            } else {
-                None
-            };
-
-            let testnet_deployer = TestnetDeployBuilder::default()
-                .ansible_forks(forks)
-                .ansible_verbose_mode(ansible_verbose)
-                .environment_name(&name)
-                .provider(provider)
-                .build()?;
-            testnet_deployer.upgrade(UpgradeOptions {
+            cmd::upgrade::handle_upgrade_command(
                 ansible_verbose,
                 custom_inventory,
                 env_variables,
                 force,
                 forks,
                 interval,
-                name: name.clone(),
+                name,
                 node_type,
                 provider,
                 pre_upgrade_delay,
                 version,
-            })?;
-
-            // Recreate the deployer with an increased number of forks for retrieving the status.
-            let testnet_deployer = TestnetDeployBuilder::default()
-                .ansible_forks(50)
-                .environment_name(&name)
-                .provider(provider)
-                .build()?;
-            testnet_deployer.status()?;
-
+            )
+            .await?;
             Ok(())
         }
         Commands::UpgradeAntctl {
@@ -2674,27 +470,14 @@ async fn main() -> Result<()> {
             provider,
             version,
         } => {
-            let testnet_deployer = TestnetDeployBuilder::default()
-                .ansible_forks(50)
-                .environment_name(&name)
-                .provider(provider)
-                .build()?;
-            let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-            let inventory = inventory_service
-                .generate_or_retrieve_inventory(&name, true, None)
-                .await?;
-            if inventory.is_empty() {
-                return Err(eyre!("The {name} environment does not exist"));
-            }
-
-            let custom_inventory = if let Some(custom_inventory) = custom_inventory {
-                let custom_vms = get_custom_inventory(&inventory, &custom_inventory)?;
-                Some(custom_vms)
-            } else {
-                None
-            };
-
-            testnet_deployer.upgrade_antctl(version.parse()?, node_type, custom_inventory)?;
+            cmd::upgrade::handle_upgrade_antctl_command(
+                custom_inventory,
+                name,
+                node_type,
+                provider,
+                version,
+            )
+            .await?;
             Ok(())
         }
         Commands::UpgradeNodeTelegrafConfig {
@@ -2702,25 +485,7 @@ async fn main() -> Result<()> {
             name,
             provider,
         } => {
-            let testnet_deployer = TestnetDeployBuilder::default()
-                .ansible_forks(forks)
-                .environment_name(&name)
-                .provider(provider)
-                .build()?;
-
-            // This is required in the case where the command runs in a remote environment, where
-            // there won't be an existing inventory, which is required to retrieve the node
-            // registry files used to determine the status.
-            let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-            let inventory = inventory_service
-                .generate_or_retrieve_inventory(&name, true, None)
-                .await?;
-            if inventory.is_empty() {
-                return Err(eyre!("The {name} environment does not exist"));
-            }
-
-            testnet_deployer.upgrade_node_telegraf(&name)?;
-
+            telegraf::handle_upgrade_node_telegraf_config(forks, name, provider).await?;
             Ok(())
         }
         Commands::UpgradeUploaderTelegrafConfig {
@@ -2728,196 +493,13 @@ async fn main() -> Result<()> {
             name,
             provider,
         } => {
-            let testnet_deployer = TestnetDeployBuilder::default()
-                .ansible_forks(forks)
-                .environment_name(&name)
-                .provider(provider)
-                .build()?;
-
-            // This is required in the case where the command runs in a remote environment, where
-            // there won't be an existing inventory, which is required to retrieve the node
-            // registry files used to determine the status.
-            let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-            let inventory = inventory_service
-                .generate_or_retrieve_inventory(&name, true, None)
-                .await?;
-            if inventory.is_empty() {
-                return Err(eyre!("The {name} environment does not exist"));
-            }
-
-            testnet_deployer.upgrade_uploader_telegraf(&name)?;
-
+            telegraf::handle_upgrade_uploader_telegraf_config(forks, name, provider).await?;
             Ok(())
         }
-        Commands::Uploaders(uploaders_cmd) => match uploaders_cmd {
-            UploadersCommands::Start { name, provider } => {
-                let testnet_deployer = TestnetDeployBuilder::default()
-                    .environment_name(&name)
-                    .provider(provider)
-                    .build()?;
-                let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-                inventory_service
-                    .generate_or_retrieve_inventory(&name, true, None)
-                    .await?;
-
-                let ansible_runner = testnet_deployer.ansible_provisioner.ansible_runner;
-                ansible_runner.run_playbook(
-                    AnsiblePlaybook::StartUploaders,
-                    AnsibleInventoryType::Uploaders,
-                    None,
-                )?;
-                Ok(())
-            }
-            UploadersCommands::Stop { name, provider } => {
-                let testnet_deployer = TestnetDeployBuilder::default()
-                    .environment_name(&name)
-                    .provider(provider)
-                    .build()?;
-                let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-                inventory_service
-                    .generate_or_retrieve_inventory(&name, true, None)
-                    .await?;
-
-                let ansible_runner = testnet_deployer.ansible_provisioner.ansible_runner;
-                ansible_runner.run_playbook(
-                    AnsiblePlaybook::StopUploaders,
-                    AnsibleInventoryType::Uploaders,
-                    None,
-                )?;
-                Ok(())
-            }
-            UploadersCommands::Upgrade {
-                name,
-                provider,
-                version,
-            } => {
-                let version = get_version_from_option(version, &ReleaseType::Ant).await?;
-
-                let testnet_deploy = TestnetDeployBuilder::default()
-                    .environment_name(&name)
-                    .provider(provider)
-                    .build()?;
-                let inventory_service = DeploymentInventoryService::from(&testnet_deploy);
-
-                let inventory = inventory_service
-                    .generate_or_retrieve_inventory(&name, true, None)
-                    .await?;
-                if inventory.is_empty() {
-                    return Err(eyre!("The '{}' environment does not exist", name));
-                }
-
-                let ansible_runner = testnet_deploy.ansible_provisioner.ansible_runner;
-                let mut extra_vars = ExtraVarsDocBuilder::default();
-                extra_vars.add_variable("testnet_name", &name);
-                extra_vars.add_variable("ant_version", &version.to_string());
-                ansible_runner.run_playbook(
-                    AnsiblePlaybook::UpgradeUploaders,
-                    AnsibleInventoryType::Uploaders,
-                    Some(extra_vars.build()),
-                )?;
-
-                Ok(())
-            }
-            UploadersCommands::Upscale {
-                autonomi_version,
-                desired_uploader_vm_count,
-                desired_uploaders_count,
-                funding_wallet_secret_key,
-                gas_amount,
-                infra_only,
-                name,
-                plan,
-                provision_only,
-                provider,
-            } => {
-                let gas_amount = if let Some(amount) = gas_amount {
-                    let amount: f64 = amount.parse().map_err(|_| {
-                        eyre!("Invalid gas amount format. Must be a decimal value, e.g. '0.1'")
-                    })?;
-                    if amount <= 0.0 || amount >= 1.0 {
-                        return Err(eyre!("Gas amount must be between 0 and 1"));
-                    }
-                    // Convert to wei (1 ETH = 1e18 wei)
-                    let wei_amount = (amount * 1e18) as u64;
-                    Some(U256::from(wei_amount))
-                } else {
-                    None
-                };
-
-                println!("Upscaling uploaders...");
-                let testnet_deployer = TestnetDeployBuilder::default()
-                    .environment_name(&name)
-                    .provider(provider)
-                    .build()?;
-                testnet_deployer.init().await?;
-
-                let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-                let inventory = inventory_service
-                    .generate_or_retrieve_inventory(&name, true, None)
-                    .await?;
-
-                testnet_deployer
-                    .upscale_uploaders(&UpscaleOptions {
-                        ansible_verbose: false,
-                        current_inventory: inventory,
-                        desired_full_cone_private_node_count: None,
-                        desired_full_cone_private_node_vm_count: None,
-                        desired_node_count: None,
-                        desired_node_vm_count: None,
-                        desired_peer_cache_node_count: None,
-                        desired_peer_cache_node_vm_count: None,
-                        desired_symmetric_private_node_count: None,
-                        desired_symmetric_private_node_vm_count: None,
-                        desired_uploader_vm_count,
-                        desired_uploaders_count,
-                        funding_wallet_secret_key,
-                        gas_amount,
-                        max_archived_log_files: 1,
-                        max_log_files: 1,
-                        infra_only,
-                        interval: Duration::from_millis(2000),
-                        plan,
-                        provision_only,
-                        public_rpc: false,
-                        ant_version: Some(autonomi_version),
-                        token_amount: None,
-                    })
-                    .await?;
-
-                if plan {
-                    return Ok(());
-                }
-
-                println!("Generating new inventory after upscale...");
-                let max_retries = 3;
-                let mut retries = 0;
-                let inventory = loop {
-                    match inventory_service
-                        .generate_or_retrieve_inventory(&name, true, None)
-                        .await
-                    {
-                        Ok(inv) => break inv,
-                        Err(e) if retries < max_retries => {
-                            retries += 1;
-                            eprintln!("Failed to generate inventory on attempt {retries}: {:?}", e);
-                            eprintln!("Will retry up to {max_retries} times...");
-                        }
-                        Err(_) => {
-                            eprintln!("Failed to generate inventory after {max_retries} attempts");
-                            eprintln!(
-                                "Please try running the `inventory` command or workflow separately"
-                            );
-                            return Ok(());
-                        }
-                    }
-                };
-
-                inventory.print_report(false)?;
-                inventory.save()?;
-
-                Ok(())
-            }
-        },
+        Commands::Uploaders(uploaders_cmd) => {
+            cmd::uploaders::handle_uploaders_command(uploaders_cmd).await?;
+            Ok(())
+        }
         Commands::Upscale {
             ansible_verbose,
             ant_version,
@@ -2945,147 +527,34 @@ async fn main() -> Result<()> {
             public_rpc,
             repo_owner,
         } => {
-            if branch.is_some() && repo_owner.is_none() {
-                return Err(eyre!(
-                    "The --repo-owner argument is required when --branch is used"
-                ));
-            }
-
-            if branch.is_some()
-                && (antnode_version.is_some() || antctl_version.is_some() || ant_version.is_some())
-            {
-                return Err(eyre!(
-                    "The version arguments cannot be used when --branch is specified"
-                ));
-            }
-
-            if desired_uploader_vm_count.is_some() && ant_version.is_none() {
-                return Err(eyre!(
-                    "The ant version is required to upscale the uploaders"
-                ));
-            }
-
-            if (desired_uploader_vm_count.is_some() || desired_uploaders_count.is_some())
-                && funding_wallet_secret_key.is_none()
-            {
-                return Err(eyre!(
-                    "The funding wallet secret key is required to upscale the uploaders"
-                ));
-            }
-
-            println!("Upscaling deployment...");
-            let testnet_deployer = TestnetDeployBuilder::default()
-                .ansible_verbose_mode(ansible_verbose)
-                .environment_name(&name)
-                .provider(provider)
-                .build()?;
-            testnet_deployer.init().await?;
-
-            let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-            let mut inventory = inventory_service
-                .generate_or_retrieve_inventory(&name, true, None)
-                .await?;
-
-            if branch.is_some() {
-                println!("The upscale will use the binaries built in the original deployment");
-                inventory.binary_option = BinaryOption::BuildFromSource {
-                    antnode_features: None,
-                    branch: branch.unwrap(),
-                    repo_owner: repo_owner.unwrap(),
-                };
-            } else if antnode_version.is_some() || antctl_version.is_some() {
-                match &inventory.binary_option {
-                    BinaryOption::Versioned {
-                        ant_version: _,
-                        antnode_version: existing_antnode_version,
-                        antctl_version: existing_antctl_version,
-                    } => {
-                        let new_antnode_version = antnode_version
-                            .map(|v| v.parse().expect("Invalid antnode version"))
-                            .unwrap_or(existing_antnode_version.clone());
-                        let new_antctl_version = antctl_version
-                            .map(|v| v.parse().expect("Invalid antctl version"))
-                            .unwrap_or(existing_antctl_version.clone());
-
-                        println!("The upscale will use the following override binary versions:");
-                        println!("antnode: {}", new_antnode_version);
-                        println!("antctl: {}", new_antctl_version);
-
-                        inventory.binary_option = BinaryOption::Versioned {
-                            ant_version: None,
-                            antnode_version: new_antnode_version,
-                            antctl_version: new_antctl_version,
-                        };
-                    }
-                    BinaryOption::BuildFromSource { .. } => {
-                        return Err(eyre!(
-                            "Cannot override versions when the deployment uses BuildFromSource"
-                        ));
-                    }
-                }
-            }
-
-            inventory.binary_option.print();
-
-            testnet_deployer
-                .upscale(&UpscaleOptions {
-                    ansible_verbose,
-                    ant_version,
-                    current_inventory: inventory,
-                    desired_node_count,
-                    desired_full_cone_private_node_count,
-                    desired_full_cone_private_node_vm_count,
-                    desired_node_vm_count,
-                    desired_peer_cache_node_count,
-                    desired_peer_cache_node_vm_count,
-                    desired_symmetric_private_node_count,
-                    desired_symmetric_private_node_vm_count,
-                    desired_uploader_vm_count,
-                    desired_uploaders_count,
-                    funding_wallet_secret_key,
-                    gas_amount: None,
-                    infra_only,
-                    interval,
-                    max_archived_log_files,
-                    max_log_files,
-                    plan,
-                    provision_only: false,
-                    public_rpc,
-                    token_amount: None,
-                })
-                .await?;
-
-            if plan {
-                return Ok(());
-            }
-
-            println!("Generating new inventory after upscale...");
-            let max_retries = 3;
-            let mut retries = 0;
-            let inventory = loop {
-                match inventory_service
-                    .generate_or_retrieve_inventory(&name, true, None)
-                    .await
-                {
-                    Ok(inv) => break inv,
-                    Err(e) if retries < max_retries => {
-                        retries += 1;
-                        eprintln!("Failed to generate inventory on attempt {retries}: {:?}", e);
-                        eprintln!("Will retry up to {max_retries} times...");
-                    }
-                    Err(_) => {
-                        eprintln!("Failed to generate inventory after {max_retries} attempts");
-                        eprintln!(
-                            "Please try running the `inventory` command or workflow separately"
-                        );
-                        return Ok(());
-                    }
-                }
-            };
-
-            inventory.print_report(false)?;
-            inventory.save()?;
-
+            cmd::deployments::handle_upscale(
+                ansible_verbose,
+                ant_version,
+                antctl_version,
+                antnode_version,
+                branch,
+                desired_node_count,
+                desired_full_cone_private_node_count,
+                desired_full_cone_private_node_vm_count,
+                desired_node_vm_count,
+                desired_peer_cache_node_count,
+                desired_peer_cache_node_vm_count,
+                desired_symmetric_private_node_count,
+                desired_symmetric_private_node_vm_count,
+                desired_uploader_vm_count,
+                desired_uploaders_count,
+                funding_wallet_secret_key,
+                infra_only,
+                interval,
+                max_archived_log_files,
+                max_log_files,
+                name,
+                plan,
+                provider,
+                public_rpc,
+                repo_owner,
+            )
+            .await?;
             Ok(())
         }
         Commands::UpdatePeer {
@@ -3095,68 +564,8 @@ async fn main() -> Result<()> {
             peer,
             provider,
         } => {
-            if let Err(e) = libp2p::multiaddr::Multiaddr::from_str(&peer) {
-                return Err(eyre!("Invalid peer multiaddr: {}", e));
-            }
-
-            let testnet_deployer = TestnetDeployBuilder::default()
-                .environment_name(&name)
-                .provider(provider)
-                .build()?;
-
-            let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-            let inventory = inventory_service
-                .generate_or_retrieve_inventory(&name, true, None)
+            nodes::handle_update_peer_command(custom_inventory, name, node_type, peer, provider)
                 .await?;
-
-            let custom_inventory = if let Some(custom_inventory) = custom_inventory {
-                let custom_vms = get_custom_inventory(&inventory, &custom_inventory)?;
-                Some(custom_vms)
-            } else {
-                None
-            };
-
-            let mut extra_vars = ExtraVarsDocBuilder::default();
-            extra_vars.add_variable("peer", &peer);
-
-            let inventory_type = if let Some(custom_inventory) = custom_inventory {
-                println!("Updating peers against a custom inventory");
-                generate_custom_environment_inventory(
-                    &custom_inventory,
-                    &name,
-                    &testnet_deployer
-                        .ansible_provisioner
-                        .ansible_runner
-                        .working_directory_path
-                        .join("inventory"),
-                )?;
-                AnsibleInventoryType::Custom
-            } else {
-                let inventory_type = match node_type {
-                    Some(NodeType::FullConePrivateNode) => {
-                        AnsibleInventoryType::FullConePrivateNodes
-                    }
-                    Some(NodeType::Genesis) => AnsibleInventoryType::Genesis,
-                    Some(NodeType::Generic) => AnsibleInventoryType::Nodes,
-                    Some(NodeType::PeerCache) => AnsibleInventoryType::PeerCacheNodes,
-                    Some(NodeType::SymmetricPrivateNode) => {
-                        AnsibleInventoryType::SymmetricPrivateNodes
-                    }
-                    None => AnsibleInventoryType::Nodes,
-                };
-                println!("Updating peers against {inventory_type:?}");
-                inventory_type
-            };
-
-            testnet_deployer
-                .ansible_provisioner
-                .ansible_runner
-                .run_playbook(
-                    AnsiblePlaybook::UpdatePeer,
-                    inventory_type,
-                    Some(extra_vars.build()),
-                )?;
-
             Ok(())
         }
         Commands::ResetToNNodes {
@@ -3171,274 +580,20 @@ async fn main() -> Result<()> {
             stop_interval,
             version,
         } => {
-            // We will use 50 forks for the initial run to retrieve the inventory, then recreate the
-            // deployer using the custom fork value.
-            let testnet_deployer = TestnetDeployBuilder::default()
-                .ansible_forks(50)
-                .environment_name(&name)
-                .provider(provider)
-                .build()?;
-            let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
-            let inventory = inventory_service
-                .generate_or_retrieve_inventory(&name, true, None)
-                .await?;
-            if inventory.is_empty() {
-                return Err(eyre!("The {name} environment does not exist"));
-            }
-
-            let testnet_deployer = TestnetDeployBuilder::default()
-                .ansible_forks(forks)
-                .environment_name(&name)
-                .provider(provider)
-                .build()?;
-            testnet_deployer.init().await?;
-
-            let antnode_version = get_version_from_option(version, &ReleaseType::AntNode).await?;
-            let mut extra_vars = ExtraVarsDocBuilder::default();
-            extra_vars.add_variable("environment_name", &name);
-            extra_vars.add_variable("evm_network_type", &evm_network_type.to_string());
-            extra_vars.add_variable("node_count", &node_count.to_string());
-            extra_vars.add_variable("start_interval", &start_interval.as_millis().to_string());
-            extra_vars.add_variable("stop_interval", &stop_interval.as_millis().to_string());
-            extra_vars.add_variable("version", &antnode_version.to_string());
-
-            let ansible_runner = &testnet_deployer.ansible_provisioner.ansible_runner;
-
-            if let Some(custom_inventory) = custom_inventory {
-                println!("Running the playbook with a custom inventory");
-                let custom_vms = get_custom_inventory(&inventory, &custom_inventory)?;
-                generate_custom_environment_inventory(
-                    &custom_vms,
-                    &name,
-                    &ansible_runner.working_directory_path.join("inventory"),
-                )?;
-                ansible_runner.run_playbook(
-                    AnsiblePlaybook::ResetToNNodes,
-                    AnsibleInventoryType::Custom,
-                    Some(extra_vars.build()),
-                )?;
-                return Ok(());
-            }
-
-            if let Some(node_type) = node_type {
-                println!("Running the playbook for {node_type:?} nodes");
-                ansible_runner.run_playbook(
-                    AnsiblePlaybook::ResetToNNodes,
-                    node_type.to_ansible_inventory_type(),
-                    Some(extra_vars.build()),
-                )?;
-                return Ok(());
-            }
-
-            println!("Running the playbook for all node types");
-            for node_inv_type in AnsibleInventoryType::iter_node_type() {
-                ansible_runner.run_playbook(
-                    AnsiblePlaybook::ResetToNNodes,
-                    node_inv_type,
-                    Some(extra_vars.build()),
-                )?;
-            }
+            nodes::handle_reset_to_n_nodes_command(
+                custom_inventory,
+                evm_network_type,
+                forks,
+                name,
+                node_count,
+                node_type,
+                provider,
+                start_interval,
+                stop_interval,
+                version,
+            )
+            .await?;
             Ok(())
         }
-    }
-}
-
-/// Get the binary option for the deployment.
-///
-/// Versioned binaries are preferred first, since building from source adds significant time to the
-/// deployment. There are two options here. If no version arguments were supplied, the latest
-/// versions will be used. Otherwise, the specified versions will be used, and if any were not
-/// specified, the latest version will be used in its place.
-///
-/// The second option is to build from source, which is useful for testing changes from forks.
-///
-/// The usage of arguments are also validated here.
-#[allow(clippy::too_many_arguments)]
-async fn get_binary_option(
-    branch: Option<String>,
-    repo_owner: Option<String>,
-    ant_version: Option<String>,
-    antnode_version: Option<String>,
-    antctl_version: Option<String>,
-    antnode_features: Option<Vec<String>>,
-) -> Result<BinaryOption> {
-    let mut use_versions = true;
-
-    let branch_specified = branch.is_some() || repo_owner.is_some();
-    let versions_specified = antnode_version.is_some() || antctl_version.is_some();
-    if branch_specified && versions_specified {
-        return Err(
-            eyre!("Version numbers and branches cannot be supplied at the same time").suggestion(
-                "Please choose whether you want to use version numbers or build the binaries",
-            ),
-        );
-    }
-
-    if versions_specified && antnode_features.is_some() {
-        return Err(eyre!(
-            "The --antnode-features argument only applies if we are building binaries"
-        ));
-    }
-
-    if branch_specified {
-        if let (Some(_), None) | (None, Some(_)) = (&repo_owner, &branch) {
-            return Err(eyre!(
-                "The --branch and --repo-owner arguments must be supplied together"
-            ));
-        }
-        use_versions = false;
-    }
-
-    let binary_option = if use_versions {
-        print_with_banner("Binaries will be supplied from pre-built versions");
-
-        let ant_version = get_version_from_option(ant_version, &ReleaseType::Ant).await?;
-        let antnode_version =
-            get_version_from_option(antnode_version, &ReleaseType::AntNode).await?;
-        let antctl_version = get_version_from_option(antctl_version, &ReleaseType::AntCtl).await?;
-        BinaryOption::Versioned {
-            ant_version: Some(ant_version),
-            antnode_version,
-            antctl_version,
-        }
-    } else {
-        // Unwraps are justified here because it's already been asserted that both must have
-        // values.
-        let repo_owner = repo_owner.unwrap();
-        let branch = branch.unwrap();
-
-        print_with_banner(&format!(
-            "Binaries will be built from {}/{}",
-            repo_owner, branch
-        ));
-
-        let url = format!("https://github.com/{repo_owner}/autonomi/tree/{branch}",);
-        let response = reqwest::get(&url).await?;
-        if !response.status().is_success() {
-            bail!("The provided branch or owner does not exist: {url:?}");
-        }
-        BinaryOption::BuildFromSource {
-            repo_owner,
-            branch,
-            antnode_features: antnode_features.map(|list| list.join(",")),
-        }
-    };
-
-    Ok(binary_option)
-}
-
-fn print_with_banner(s: &str) {
-    let banner = "=".repeat(s.len());
-    println!("{}\n{}\n{}", banner, s, banner);
-}
-
-pub fn parse_provider(val: &str) -> Result<CloudProvider> {
-    match val {
-        "aws" => Ok(CloudProvider::Aws),
-        "digital-ocean" => Ok(CloudProvider::DigitalOcean),
-        _ => Err(eyre!(
-            "The only supported providers are 'aws' or 'digital-ocean'"
-        )),
-    }
-}
-
-pub fn parse_deployment_type(val: &str) -> Result<EnvironmentType> {
-    match val {
-        "development" => Ok(EnvironmentType::Development),
-        "production" => Ok(EnvironmentType::Production),
-        "staging" => Ok(EnvironmentType::Staging),
-        _ => Err(eyre!(
-            "Supported deployment types are 'development', 'production' or 'staging'."
-        )),
-    }
-}
-
-// Since delimiter is on, we get element of the csv and not the entire csv.
-fn parse_environment_variables(env_var: &str) -> Result<(String, String)> {
-    let parts: Vec<&str> = env_var.splitn(2, '=').collect();
-    if parts.len() != 2 {
-        return Err(eyre!(
-            "Environment variable must be in the format KEY=VALUE or KEY=INNER_KEY=VALUE.\nMultiple key-value pairs can be given with a comma between them."
-        ));
-    }
-    Ok((parts[0].to_string(), parts[1].to_string()))
-}
-
-async fn get_version_from_option(
-    version: Option<String>,
-    release_type: &ReleaseType,
-) -> Result<Version> {
-    let release_repo = <dyn AntReleaseRepoActions>::default_config();
-    let version = if let Some(version) = version {
-        println!("Using {version} for {release_type}");
-        version
-    } else {
-        println!("Getting latest version for {release_type}...");
-        let version = release_repo
-            .get_latest_version(release_type)
-            .await?
-            .to_string();
-        println!("Using {version} for {release_type}");
-        version
-    };
-    Ok(version.parse()?)
-}
-
-fn get_custom_inventory(
-    inventory: &DeploymentInventory,
-    vm_list: &[String],
-) -> Result<Vec<VirtualMachine>> {
-    debug!("Attempting to use a custom inventory: {vm_list:?}");
-    let mut custom_vms = Vec::new();
-    for vm_name in vm_list.iter() {
-        let vm_list = inventory.vm_list();
-        let vm = vm_list
-            .iter()
-            .find(|vm| vm_name == &vm.name)
-            .ok_or_eyre(format!(
-                "{vm_name} is not in the inventory for this environment",
-            ))?;
-        custom_vms.push(vm.clone());
-    }
-
-    debug!("Retrieved custom inventory:");
-    for vm in &custom_vms {
-        debug!("  {} - {}", vm.name, vm.public_ip_addr);
-    }
-    Ok(custom_vms)
-}
-
-fn build_fund_faucet_extra_vars_doc(
-    genesis_ip: &IpAddr,
-    genesis_multiaddr: &str,
-) -> Result<String> {
-    let mut extra_vars = ExtraVarsDocBuilder::default();
-    extra_vars.add_variable("genesis_addr", &genesis_ip.to_string());
-    extra_vars.add_variable("genesis_multiaddr", genesis_multiaddr);
-    Ok(extra_vars.build())
-}
-
-fn build_swapfile_extra_vars_doc(size: u16) -> Result<String> {
-    let mut extra_vars = ExtraVarsDocBuilder::default();
-    extra_vars.add_variable("swapfile_size", &format!("{size}G"));
-    Ok(extra_vars.build())
-}
-
-fn parse_chunk_size(val: &str) -> Result<u64> {
-    let size = val.parse::<u64>()?;
-    if size == 0 {
-        Err(eyre!("chunk_size must be a positive integer"))
-    } else {
-        Ok(size)
-    }
-}
-
-fn parse_evm_network(s: &str) -> Result<EvmNetwork, String> {
-    match s.to_lowercase().as_str() {
-        "anvil" => Ok(EvmNetwork::Anvil),
-        "arbitrum-one" => Ok(EvmNetwork::ArbitrumOne),
-        "arbitrum-sepolia" => Ok(EvmNetwork::ArbitrumSepolia),
-        "custom" => Ok(EvmNetwork::Custom),
-        _ => Err(format!("Invalid EVM network type: {}", s)),
     }
 }


### PR DESCRIPTION
- 0fffc67 **refactor: split command management into modules**

  The enormous `main` module was becoming very unwieldy and was difficult for AI to digest.

  This splits the command handling into different modules.

  A few things were removed in this refactor:

  * Duplicate `DeployOptions` struct
  * The `faucet` subcommand
  * The `logstash` subcommand

  A few functions have a Clippy suppression for too many arguments: it's not worth breaking these
  arguments into an options struct.
