### PR TITLE
chore: retry on start/stop uploader services

### DIFF
--- a/resources/ansible/start_uploaders.yml
+++ b/resources/ansible/start_uploaders.yml
@@ -13,5 +13,9 @@
         name: "ant_uploader_{{ item | regex_replace('ant([0-9]+)', '\\1') }}"
         state: started
         enabled: yes
+      register: uploader_start
+      retries: 3
+      delay: 5
+      until: uploader_start is not failed
       become: true
       loop: "{{ ant_users.stdout_lines }}"

--- a/resources/ansible/stop_uploaders.yml
+++ b/resources/ansible/stop_uploaders.yml
@@ -13,5 +13,9 @@
         name: "ant_uploader_{{ item | regex_replace('ant([0-9]+)', '\\1') }}"
         state: stopped
         enabled: yes
+      register: uploader_stop
+      retries: 3
+      delay: 5
+      until: uploader_stop is not failed
       become: true
       loop: "{{ ant_users.stdout_lines }}"


### PR DESCRIPTION
For the first time ever, I caught an error during one of the deploys when trying to stop the uploader service.

Now applying a retry.