### PR TITLE
fix: peer cache node provisioning

### DIFF
--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -803,8 +803,13 @@ impl AnsibleProvisioner {
 
         println!("SSH is available on all nodes. Proceeding with provisioning...");
 
+        let playbook = match node_type {
+            NodeType::Generic => AnsiblePlaybook::Nodes,
+            NodeType::PeerCache => AnsiblePlaybook::PeerCacheNodes,
+            _ => return Err(Error::InvalidNodeType(node_type.clone())),
+        };
         self.ansible_runner.run_playbook(
-            AnsiblePlaybook::Nodes,
+            playbook,
             inventory_type,
             Some(extra_vars::build_node_extra_vars_doc(
                 &self.cloud_provider.to_string(),


### PR DESCRIPTION
We used to have a separate function for provisioning the peer cache nodes and this invoked the correct playbook. However, as part of the NAT rework, this function was removed in favour of the `provision_nodes` function that shared most of the code. The only thing was, when this refactor took place, it meant the nodes playbook was being specified when the peer cache nodes were being provisioned.

This has now been fixed to select the playbook based on the node type.