### PR TITLE
fix: restore provisioning private nodes

### DIFF
--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -806,6 +806,8 @@ impl AnsibleProvisioner {
         let playbook = match node_type {
             NodeType::Generic => AnsiblePlaybook::Nodes,
             NodeType::PeerCache => AnsiblePlaybook::PeerCacheNodes,
+            NodeType::FullConePrivateNode => AnsiblePlaybook::Nodes,
+            NodeType::SymmetricPrivateNode => AnsiblePlaybook::Nodes,
             _ => return Err(Error::InvalidNodeType(node_type.clone())),
         };
         self.ansible_runner.run_playbook(


### PR DESCRIPTION
I didn't realise, but these private node types also need to be supported.

Also don't print either types of private nodes in the inventory if they are not present.