### PR TITLE
feat: provide `--service-name` arg on `stop` cmd

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -33,7 +33,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cargo cache registry, index and build
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -72,31 +72,6 @@ jobs:
         # ignored due to nightly failure.
         # should be fixed by https://github.com/zowens/crc32c/pull/52
         continue-on-error: true
-
-  unit-test:
-    name: unit test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: cargo cache registry, index and build
-        uses: actions/cache@v2.1.4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release
 
   test-publish:
     name: test publish

--- a/resources/ansible/stop_nodes.yml
+++ b/resources/ansible/stop_nodes.yml
@@ -10,6 +10,13 @@
         {% if delay is defined %}
         sleep {{ delay | default(0) }}
         {% endif %}
+        {% if service_names is defined %}
+        {% for service in service_names %}
+        antctl stop --service-name {{ service }}
+        sleep $(( {{ interval }} / 1000 ))
+        {% endfor %}
+        {% else %}
         antctl stop --interval {{ interval }}
+        {% endif %}
       args:
         executable: /bin/bash

--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -1045,11 +1045,15 @@ impl AnsibleProvisioner {
         node_type: Option<NodeType>,
         custom_inventory: Option<Vec<VirtualMachine>>,
         delay: Option<u64>,
+        service_names: Option<Vec<String>>,
     ) -> Result<()> {
         let mut extra_vars = ExtraVarsDocBuilder::default();
         extra_vars.add_variable("interval", &interval.as_millis().to_string());
         if let Some(delay) = delay {
             extra_vars.add_variable("delay", &delay.to_string());
+        }
+        if let Some(service_names) = service_names {
+            extra_vars.add_list_variable("service_names", service_names);
         }
         let extra_vars = extra_vars.build();
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -737,6 +737,9 @@ pub enum Commands {
         /// The cloud provider for the environment.
         #[clap(long, value_parser = parse_provider, verbatim_doc_comment, default_value_t = CloudProvider::DigitalOcean)]
         provider: CloudProvider,
+        /// The service names to stop.
+        #[clap(long)]
+        service_name: Option<Vec<String>>,
     },
     /// Stop the Telegraf service on all machines in the environment.
     ///

--- a/src/cmd/nodes.rs
+++ b/src/cmd/nodes.rs
@@ -65,6 +65,7 @@ pub async fn handle_stop_command(
     name: String,
     node_type: Option<NodeType>,
     provider: CloudProvider,
+    service_names: Option<Vec<String>>,
 ) -> Result<()> {
     // Use a large number of forks for retrieving the inventory from a large deployment.
     // Then if a smaller number of forks is specified, we will recreate the deployer
@@ -94,7 +95,7 @@ pub async fn handle_stop_command(
         None
     };
 
-    testnet_deployer.stop(interval, node_type, custom_inventory, delay)?;
+    testnet_deployer.stop(interval, node_type, custom_inventory, delay, service_names)?;
 
     Ok(())
 }

--- a/src/cmd/nodes.rs
+++ b/src/cmd/nodes.rs
@@ -57,6 +57,7 @@ pub async fn handle_start_command(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn handle_stop_command(
     custom_inventory: Option<Vec<String>>,
     delay: Option<u64>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -849,6 +849,7 @@ impl TestnetDeployer {
         node_type: Option<NodeType>,
         custom_inventory: Option<Vec<VirtualMachine>>,
         delay: Option<u64>,
+        service_names: Option<Vec<String>>,
     ) -> Result<()> {
         self.ansible_provisioner.stop_nodes(
             &self.environment_name,
@@ -856,6 +857,7 @@ impl TestnetDeployer {
             node_type,
             custom_inventory,
             delay,
+            service_names
         )?;
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -857,7 +857,7 @@ impl TestnetDeployer {
             node_type,
             custom_inventory,
             delay,
-            service_names
+            service_names,
         )?;
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -395,6 +395,7 @@ async fn main() -> Result<()> {
             name,
             node_type,
             provider,
+            service_name,
         } => {
             nodes::handle_stop_command(
                 custom_inventory,
@@ -404,6 +405,7 @@ async fn main() -> Result<()> {
                 name,
                 node_type,
                 provider,
+                service_name,
             )
             .await?;
             Ok(())


### PR DESCRIPTION
Enables individual services to be stopped rather than all of them.