### PR TITLE
chore: do not use full cone nat by default

### DIFF
--- a/resources/terraform/testnet/digital-ocean/dev.tfvars
+++ b/resources/terraform/testnet/digital-ocean/dev.tfvars
@@ -1,7 +1,7 @@
 evm_node_droplet_size = "s-4vcpu-8gb"
 evm_node_droplet_image_id = 172723723
 evm_node_vm_count = 1
-full_cone_private_node_vm_count = 1
+full_cone_private_node_vm_count = 0
 nat_gateway_droplet_image_id = 178052140
 node_droplet_size = "s-2vcpu-4gb"
 node_droplet_image_id = 173265007

--- a/resources/terraform/testnet/digital-ocean/staging.tfvars
+++ b/resources/terraform/testnet/digital-ocean/staging.tfvars
@@ -1,7 +1,7 @@
 evm_node_droplet_size = "s-4vcpu-8gb"
 evm_node_droplet_image_id = 172723723
 evm_node_vm_count = 1
-full_cone_private_node_vm_count = 1
+full_cone_private_node_vm_count = 0
 nat_gateway_droplet_image_id = 178052140
 node_droplet_size = "s-2vcpu-4gb"
 node_droplet_image_id = 173265007


### PR DESCRIPTION
In the development and staging setups we will not use full cone NAT until we are doing more experimentation and testing with that configuration.