### PR TITLE
refactor: rename `--home-network` to `--relay`

### DIFF
--- a/resources/ansible/roles/genesis-node/defaults/main.yml
+++ b/resources/ansible/roles/genesis-node/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 public_rpc: False
-home_network: False
+relay: False
 node_rpc_ip: "127.0.0.1"
 binary_dir: /usr/local/bin
 # If a custom branch / version is specified, this value must be overwritten.

--- a/resources/ansible/roles/node/defaults/main.yml
+++ b/resources/ansible/roles/node/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 public_rpc: False
-home_network: False
+relay: False
 node_rpc_ip: "127.0.0.1"
 node_instance_count: 20
 binary_dir: /usr/local/bin

--- a/resources/ansible/roles/node/tasks/main.yml
+++ b/resources/ansible/roles/node/tasks/main.yml
@@ -55,12 +55,12 @@
   when: use_port_range
 
 #
-# Obtain private IP if home_network is set
+# Obtain private IP if relay is set
 #
 - name: get private ip of eth1
   shell: ip -4 addr show dev eth1 | grep inet | awk '{print $2}' | cut -d/ -f1
   register: private_ip_eth1
-  when: home_network | bool
+  when: relay | bool
 
 #
 # Add the nodes
@@ -85,8 +85,8 @@
       - "--rewards-address={{ rewards_address }}"
       - "--max-archived-log-files={{ max_archived_log_files }}"
       - "--max-log-files={{ max_log_files }}"
-      - "{{ ('--node-ip=' + private_ip_eth1.stdout) if home_network | bool else omit }}"
-      - "{{ '--home-network' if home_network | bool else omit }}"
+      - "{{ ('--node-ip=' + private_ip_eth1.stdout) if relay | bool else omit }}"
+      - "{{ '--relay' if relay | bool else omit }}"
       - "{{ ('--rpc-port=' + rpc_port) if not use_port_range else omit }}"
       - "{{ ('--rpc-port=' + rpc_start_port + '-' + rpc_end_port) if use_port_range else omit }}"
       - "{{ ('--metrics-port=' + metrics_port) if not use_port_range else omit }}"

--- a/src/ansible/extra_vars.rs
+++ b/src/ansible/extra_vars.rs
@@ -295,7 +295,7 @@ pub fn build_node_extra_vars_doc(
     network_contacts_url: Option<String>,
     node_instance_count: u16,
     evm_network: EvmNetwork,
-    home_network_flag: bool,
+    relay: bool,
 ) -> Result<String> {
     let mut extra_vars = ExtraVarsDocBuilder::default();
     extra_vars.add_variable("provider", cloud_provider);
@@ -325,8 +325,8 @@ pub fn build_node_extra_vars_doc(
         extra_vars.add_variable("public_rpc", "true");
     }
 
-    if home_network_flag {
-        extra_vars.add_variable("home_network", "true");
+    if relay {
+        extra_vars.add_variable("relay", "true");
     }
 
     if let Some(network_id) = options.network_id {

--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -757,10 +757,10 @@ impl AnsibleProvisioner {
         node_type: NodeType,
     ) -> Result<()> {
         let start = Instant::now();
-        let mut home_network_flag = false;
+        let mut relay = false;
         let (inventory_type, node_count) = match &node_type {
             NodeType::FullConePrivateNode => {
-                home_network_flag = true;
+                relay = true;
                 (
                     node_type.to_ansible_inventory_type(),
                     options.full_cone_private_node_count,
@@ -774,7 +774,7 @@ impl AnsibleProvisioner {
                 options.peer_cache_node_count,
             ),
             NodeType::SymmetricPrivateNode => {
-                home_network_flag = true;
+                relay = true;
                 (
                     node_type.to_ansible_inventory_type(),
                     options.symmetric_private_node_count,
@@ -822,7 +822,7 @@ impl AnsibleProvisioner {
                 initial_network_contacts_url,
                 node_count,
                 options.evm_network.clone(),
-                home_network_flag,
+                relay,
             )?),
         )?;
 


### PR DESCRIPTION
The upcoming release of `antctl` has changed the `--home-network` flag to `--relay`.