### PR TITLE
chore: use `--no-upnp` flag for node services

### DIFF
--- a/resources/ansible/roles/genesis-node/tasks/main.yml
+++ b/resources/ansible/roles/genesis-node/tasks/main.yml
@@ -29,6 +29,7 @@
       - "{{ binary_dir }}/antctl"
       - -v
       - add
+      - --no-upnp
       - --first
       - --data-dir-path=/mnt/antnode-storage/data
       - --log-dir-path=/mnt/antnode-storage/log

--- a/resources/ansible/roles/node/tasks/main.yml
+++ b/resources/ansible/roles/node/tasks/main.yml
@@ -74,6 +74,7 @@
       - "{{ binary_dir }}/antctl"
       - -v
       - add
+      - --no-upnp
       - --data-dir-path=/mnt/antnode-storage/data
       - --log-dir-path=/mnt/antnode-storage/log
       - "--count={{ nodes_to_add }}"


### PR DESCRIPTION
The `antctl` binary now adds the `--upnp` flag by default, so we have to explicitly switch it off for the deployment of the node on droplets.