### PR TITLE
feat: ngnix serves cache file based on header

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,98 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is `sn-testnet-deploy` - a tool for automating deployment of Safe Network testnets on AWS or Digital Ocean. It orchestrates Terraform for infrastructure creation and Ansible for provisioning, coordinated by a Rust binary.
+
+## Key Commands
+
+### Build and Release
+- `cargo build` - Build the testnet-deploy binary
+- `cargo run -- <command>` - Run commands via the binary
+- `just build-release-artifacts x86_64-unknown-linux-musl` - Build release artifacts for Linux
+- `just package-release-assets` - Package binaries for distribution
+
+### Testing and Quality
+The project follows standard Rust practices:
+- `cargo test` - Run unit tests
+- `cargo clippy` - Run linting (recent commit mentions clippy fixes)
+- `cargo fmt` - Format code
+
+### Core Deployment Commands
+- `cargo run -- setup` - Initial setup (creates .env file with configuration)
+- `cargo run -- deploy --name <testnet-name>` - Deploy a new testnet
+- `cargo run -- inventory --name <testnet-name> --provider digital-ocean` - List machines and testnet info
+- `cargo run -- clean --name <testnet-name> --provider digital-ocean` - Tear down testnet
+- `cargo run -- status --name <testnet-name>` - Get status of all nodes
+- `cargo run -- upgrade --name <testnet-name>` - Upgrade node binaries
+
+### Image Building (using Just)
+- `just build-node-image` - Build VM images for nodes
+- `just build-client-image` - Build VM images for clients
+- `just build-all-images <region>` - Build all VM images for a region
+
+## Architecture
+
+### High-Level Structure
+The codebase follows a modular architecture with these main components:
+
+**Core Infrastructure:**
+- `src/terraform.rs` - Terraform orchestration for cloud infrastructure
+- `src/ansible/` - Ansible automation for VM provisioning and configuration
+- `src/infra.rs` - Infrastructure management logic
+
+**Cloud Provider Integration:**
+- `src/digital_ocean.rs` - Digital Ocean specific implementations
+- Cloud provider abstraction supports AWS and Digital Ocean
+
+**Node and Network Management:**
+- `src/bootstrap.rs` - Network bootstrapping from existing deployments
+- `src/nodes.rs` - Node lifecycle management (start/stop/upgrade)
+- `src/rpc_client.rs` - RPC communication with nodes
+- `src/inventory.rs` - Infrastructure inventory management
+
+**Deployment Types:**
+- **New Networks:** Complete fresh deployments
+- **Bootstrap Deployments:** Extending existing networks
+- **Client Deployments:** Deploy client VMs for testing
+
+**Binary Management:**
+Two approaches for obtaining binaries:
+1. **Versioned:** Pre-built binaries fetched from S3
+2. **BuildFromSource:** Custom builds from specified repository/branch
+
+### Key Components
+
+**TestnetDeployer** (src/lib.rs): Main orchestrator that coordinates:
+- Terraform for infrastructure
+- Ansible for provisioning  
+- SSH for remote operations
+- S3 for artifact storage
+
+**Command Structure** (src/cmd/): 
+- `deployments.rs` - Main deploy/bootstrap/upscale logic
+- `nodes.rs` - Node operations (start/stop/status)
+- `upgrade.rs` - Binary upgrade processes
+- `logs.rs` - Log collection and management
+
+**Node Types:**
+- Genesis nodes (bootstrap the network)
+- Generic nodes (standard network participants)
+- Peer cache nodes (provide cached peer information)
+- Private nodes (behind NAT gateways - full-cone and symmetric)
+
+### Configuration Management
+- Environment details stored in S3 (deployment type, EVM config, network ID)
+- Ansible inventories generated dynamically
+- Support for development, staging, and production environments
+- VM sizing and node counts determined by environment type
+
+### Resource Organization
+- `resources/terraform/` - Infrastructure as code definitions
+- `resources/ansible/` - Provisioning playbooks and roles
+- `resources/packer/` - VM image building templates
+- `resources/scripts/` - Utility scripts for log management
+
+The tool supports complex multi-VM deployments with different node types, NAT configurations, and automatic scaling capabilities.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6192,7 +6192,7 @@ dependencies = [
 
 [[package]]
 name = "sn-testnet-deploy"
-version = "0.2.71"
+version = "0.2.72"
 dependencies = [
  "alloy",
  "ant-releases",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "sn-testnet-deploy"
 description = "Tool for creating Autonomi networks"
 readme = "README.md"
 repository = "https://github.com/maidsafe/sn-testnet-deploy"
-version = "0.2.71"
+version = "0.2.72"
 edition = "2021"
 license = "BSD-3-Clause"
 

--- a/resources/ansible/roles/cache_webserver/tasks/main.yml
+++ b/resources/ansible/roles/cache_webserver/tasks/main.yml
@@ -5,22 +5,30 @@
     state: started
     enabled: yes
 
-- name: find the json file in the bootstrap cache directory
+- name: find the version0 json file
   find:
     paths: "{{ bootstrap_cache_dir }}"
     patterns: "*.json"
-  register: json_files
+    recurse: no
+  register: version0_file
 
-- name: fail if no json file is found
-  fail:
-    msg: "No json file found in the bootstrap directory."
-  when: json_files.matched == 0
+- name: find the version1 json file
+  find:
+    paths: "{{ bootstrap_cache_dir }}/version_1"
+    patterns: "*.json"
+    recurse: no
+  register: version1_file
+
+- name: create a map of versions to their respective json files
+  set_fact:
+    version_files:
+      version0: "{{ version0_file.files[0].path }}"
+      version1: "{{ version1_file.files[0].path }}"
 
 - name: ensure nginx is serving the json file using a template
   template:
     src: nginx.conf.j2
     dest: /etc/nginx/sites-available/default
-  when: json_files.matched > 0
 
 - name: ensure nginx status site file is set
   template:
@@ -32,10 +40,8 @@
     src: /etc/nginx/sites-available/nginx_status
     dest: /etc/nginx/sites-enabled/nginx_status
     state: link
-  when: json_files.matched > 0
 
 - name: reload nginx to apply changes
   service:
     name: nginx
     state: reloaded
-  when: json_files.matched > 0

--- a/resources/ansible/roles/cache_webserver/tasks/main.yml
+++ b/resources/ansible/roles/cache_webserver/tasks/main.yml
@@ -41,7 +41,11 @@
     dest: /etc/nginx/sites-enabled/nginx_status
     state: link
 
-- name: reload nginx to apply changes
+- name: restart nginx to apply changes
   service:
     name: nginx
-    state: reloaded
+    state: restarted
+  register: nginx_restart
+  retries: 3
+  delay: 5
+  until: nginx_restart is success

--- a/resources/ansible/roles/cache_webserver/templates/nginx.conf.j2
+++ b/resources/ansible/roles/cache_webserver/templates/nginx.conf.j2
@@ -1,13 +1,29 @@
+{# Map to determine if the version is supported #}
+map $http_cache_version $valid_version {
+  default "1";
+  "0" "1";
+  "1" "1";
+  "~." "0";
+}
+
+{# Map to get the file path for valid versions #}
+map $http_cache_version $bootstrap_file {
+  default "{{ version_files.version0 }}";
+  "1" "{{ version_files.version1 }}";
+}
+
 server {
-    listen 80;
-
-    location / {
-        access_log off;
-        log_not_found off;
-        return 404;
+  listen 80;
+  location / {
+    access_log off;
+    log_not_found off;
+    return 404;
+  }
+  location /bootstrap_cache.json {
+    if ($valid_version = "0") {
+      return 400;
     }
-
-    location /bootstrap_cache.json {
-        alias {{ bootstrap_cache_dir }}/{{ json_files.files[0].path | basename }};
-    }
+    
+    alias $bootstrap_file;
+  }
 }

--- a/resources/ansible/roles/cache_webserver/templates/nginx.conf.j2
+++ b/resources/ansible/roles/cache_webserver/templates/nginx.conf.j2
@@ -1,29 +1,34 @@
 {# Map to determine if the version is supported #}
 map $http_cache_version $valid_version {
-  default "1";
-  "0" "1";
-  "1" "1";
-  "~." "0";
+    {# Empty/missing header is valid (for old users) #}
+    "" "1";
+    {# Version 1 is valid #}
+    "1" "1";
+    {# Everything else is invalid #}
+    default "0";
 }
 
 {# Map to get the file path for valid versions #}
 map $http_cache_version $bootstrap_file {
-  default "{{ version_files.version0 }}";
-  "1" "{{ version_files.version1 }}";
+    {# Old users (no header) get version0 #}
+    "" "{{ version_files.version0 }}";
+    {# Users with version 1 get version1 #}
+    "1" "{{ version_files.version1 }}";
+    {# Default fallback (though this shouldn't be reached due to the 400 response) #}
+    default "{{ version_files.version0 }}";
 }
 
 server {
-  listen 80;
-  location / {
-    access_log off;
-    log_not_found off;
-    return 404;
-  }
-  location /bootstrap_cache.json {
-    if ($valid_version = "0") {
-      return 400;
+    listen 80;
+    location / {
+        access_log off;
+        log_not_found off;
+        return 404;
     }
-    
-    alias $bootstrap_file;
-  }
+    location /bootstrap_cache.json {
+        if ($valid_version = "0") {
+            return 400;
+        }
+        alias $bootstrap_file;
+    }
 }

--- a/resources/ansible/roles/genesis-node/tasks/main.yml
+++ b/resources/ansible/roles/genesis-node/tasks/main.yml
@@ -41,6 +41,7 @@
       - "{{ ('--log-format=' + log_format) if log_format is defined else omit }}"
       - "{{ ('--env=' + node_env_variables) if node_env_variables is defined else omit }}"
       - "{{ ('--version=' + version) if version is defined else ('--url=' + node_archive_url) }}"
+      - "--write-older-cache-files"
       - "{{ evm_network_type }}"
       - "{{ ('--rpc-url=' + evm_rpc_url) if evm_network_type == 'evm-custom' else omit }}"
       - "{{ ('--payment-token-address=' + evm_payment_token_address) if evm_network_type == 'evm-custom' else omit }}"

--- a/resources/ansible/roles/node/defaults/main.yml
+++ b/resources/ansible/roles/node/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 public_rpc: False
 relay: False
+write_older_cache_files: False
 private_ip: False
 node_rpc_ip: "127.0.0.1"
 node_instance_count: 20

--- a/resources/ansible/roles/node/tasks/main.yml
+++ b/resources/ansible/roles/node/tasks/main.yml
@@ -94,6 +94,7 @@
       - "{{ ('--log-format=' + log_format) if log_format is defined else omit }}"
       - "{{ ('--env=' + node_env_variables) if node_env_variables is defined else omit }}"
       - "{{ ('--version=' + version) if version is defined else ('--url=' + node_archive_url) }}"
+      - "{{ '--write-older-cache-files' if write_older_cache_files | bool else omit }}"
       - "{{ evm_network_type }}"
       - "{{ ('--rpc-url=' + evm_rpc_url) if evm_network_type == 'evm-custom' else omit }}"
       - "{{ ('--payment-token-address=' + evm_payment_token_address) if evm_network_type == 'evm-custom' else omit }}"

--- a/resources/ansible/roles/uploaders/templates/ant_random_uploader.sh.j2
+++ b/resources/ansible/roles/uploaders/templates/ant_random_uploader.sh.j2
@@ -261,9 +261,12 @@ generate_random_data_file_and_upload() {
   fi
 
   rm "$tmpfile"
+  
+  return $exit_code
 }
 
 upload_count=0
+successful_upload_count=0
 while true; do
   echo "================================"
   echo "Generating and uploading file..."
@@ -273,14 +276,20 @@ while true; do
   
   upload_count=$((upload_count + 1))
   
+  if [[ $? -eq 0 ]]; then
+    successful_upload_count=$((successful_upload_count + 1))
+    echo "$successful_upload_count successful uploads so far"
+  fi
+  
   {% if max_uploads is defined %}
-  if [[ $upload_count -ge {{ max_uploads }} ]]; then
+  if [[ $successful_upload_count -ge {{ max_uploads }} ]]; then
     # Sleeping indefinitely allows the service restart policy to be retained
     # such that the service would restart on errors.
-    echo "Reached maximum upload count of {{ max_uploads }}, pausing uploads."
+    echo "We now have $successful_upload_count successful uploads"
+    echo "The service will remain running but we won't attempt any more uploads"
     while true; do
       sleep 3600
-      echo "Maximum uploads ({{ max_uploads }}) reached. Service remains active but not uploading."
+      echo "Service remains active but not uploading"
     done
   fi
   {% endif %}

--- a/resources/ansible/upgrade_nginx.yml
+++ b/resources/ansible/upgrade_nginx.yml
@@ -1,0 +1,6 @@
+---
+- name: upgrade the nginx configuration
+  hosts: all
+  roles:
+    - role: cache_webserver
+      become: True

--- a/resources/ansible/upgrade_nodes.yml
+++ b/resources/ansible/upgrade_nodes.yml
@@ -18,6 +18,10 @@
         {% endif %}
         {% if antnode_version is defined %}
         cmd="$cmd --version={{ antnode_version }}"
+        {% elif node_archive_url is defined %}
+        cmd="$cmd --url={{ node_archive_url }}"
+        cmd="$cmd --force"
+        echo "$cmd" >> /tmp/upgrade_cmd
         {% endif %}
         eval "$cmd"
       args:

--- a/src/ansible/extra_vars.rs
+++ b/src/ansible/extra_vars.rs
@@ -309,6 +309,7 @@ pub fn build_node_extra_vars_doc(
     network_contacts_url: Option<String>,
     node_instance_count: u16,
     evm_network: EvmNetwork,
+    write_older_cache_files: bool,
 ) -> Result<String> {
     let mut extra_vars = ExtraVarsDocBuilder::default();
     extra_vars.add_variable("provider", cloud_provider);
@@ -351,6 +352,10 @@ pub fn build_node_extra_vars_doc(
             extra_vars.add_variable("relay", "true");
         }
         _ => {}
+    }
+
+    if write_older_cache_files {
+        extra_vars.add_variable("write_older_cache_files", "true");
     }
 
     if let Some(network_id) = options.network_id {

--- a/src/ansible/extra_vars.rs
+++ b/src/ansible/extra_vars.rs
@@ -115,8 +115,7 @@ impl ExtraVarsDocBuilder {
                 self.add_branch_url_variable(
                     "antnode_rpc_client_archive_url",
                     &format!(
-                        "{}/{}/{}/antnode_rpc_client-{}-x86_64-unknown-linux-musl.tar.gz",
-                        BRANCH_S3_BUCKET_URL, repo_owner, branch, deployment_name
+                        "{BRANCH_S3_BUCKET_URL}/{repo_owner}/{branch}/antnode_rpc_client-{deployment_name}-x86_64-unknown-linux-musl.tar.gz"
                     ),
                     branch,
                     repo_owner,
@@ -126,8 +125,7 @@ impl ExtraVarsDocBuilder {
                 self.add_variable(
                     "antnode_rpc_client_archive_url",
                     &format!(
-                        "{}/antnode_rpc_client-latest-x86_64-unknown-linux-musl.tar.gz",
-                        RPC_CLIENT_BUCKET_URL
+                        "{RPC_CLIENT_BUCKET_URL}/antnode_rpc_client-latest-x86_64-unknown-linux-musl.tar.gz"
                     ),
                 );
             }
@@ -142,8 +140,7 @@ impl ExtraVarsDocBuilder {
                 self.add_branch_url_variable(
                     "node_archive_url",
                     &format!(
-                        "{}/{}/{}/antnode-{}-x86_64-unknown-linux-musl.tar.gz",
-                        BRANCH_S3_BUCKET_URL, repo_owner, branch, deployment_name
+                        "{BRANCH_S3_BUCKET_URL}/{repo_owner}/{branch}/antnode-{deployment_name}-x86_64-unknown-linux-musl.tar.gz"
                     ),
                     branch,
                     repo_owner,
@@ -167,8 +164,7 @@ impl ExtraVarsDocBuilder {
                 self.add_branch_url_variable(
                     "antctl_archive_url",
                     &format!(
-                        "{}/{}/{}/antctl-{}-x86_64-unknown-linux-musl.tar.gz",
-                        BRANCH_S3_BUCKET_URL, repo_owner, branch, deployment_name
+                        "{BRANCH_S3_BUCKET_URL}/{repo_owner}/{branch}/antctl-{deployment_name}-x86_64-unknown-linux-musl.tar.gz"
                     ),
                     branch,
                     repo_owner,
@@ -197,8 +193,7 @@ impl ExtraVarsDocBuilder {
                 self.add_branch_url_variable(
                     "antctld_archive_url",
                     &format!(
-                        "{}/{}/{}/antctld-{}-x86_64-unknown-linux-musl.tar.gz",
-                        BRANCH_S3_BUCKET_URL, repo_owner, branch, deployment_name
+                        "{BRANCH_S3_BUCKET_URL}/{repo_owner}/{branch}/antctld-{deployment_name}-x86_64-unknown-linux-musl.tar.gz"
                     ),
                     branch,
                     repo_owner,
@@ -231,10 +226,7 @@ impl ExtraVarsDocBuilder {
         if let Some(version) = ant_version {
             self.add_variable(
                 "ant_archive_url",
-                &format!(
-                    "{}/ant-{}-x86_64-unknown-linux-musl.tar.gz",
-                    ANT_S3_BUCKET_URL, version
-                ),
+                &format!("{ANT_S3_BUCKET_URL}/ant-{version}-x86_64-unknown-linux-musl.tar.gz"),
             );
             return Ok(());
         }
@@ -246,8 +238,7 @@ impl ExtraVarsDocBuilder {
                 self.add_branch_url_variable(
                     "ant_archive_url",
                     &format!(
-                        "{}/{}/{}/ant-{}-x86_64-unknown-linux-musl.tar.gz",
-                        BRANCH_S3_BUCKET_URL, repo_owner, branch, deployment_name
+                        "{BRANCH_S3_BUCKET_URL}/{repo_owner}/{branch}/ant-{deployment_name}-x86_64-unknown-linux-musl.tar.gz"
                     ),
                     branch,
                     repo_owner,
@@ -259,8 +250,7 @@ impl ExtraVarsDocBuilder {
                     self.add_variable(
                         "ant_archive_url",
                         &format!(
-                            "{}/ant-{}-x86_64-unknown-linux-musl.tar.gz",
-                            ANT_S3_BUCKET_URL, version
+                            "{ANT_S3_BUCKET_URL}/ant-{version}-x86_64-unknown-linux-musl.tar.gz"
                         ),
                     );
                     Ok(())

--- a/src/ansible/inventory.rs
+++ b/src/ansible/inventory.rs
@@ -83,7 +83,7 @@ impl std::fmt::Display for AnsibleInventoryType {
             AnsibleInventoryType::SymmetricPrivateNodes => "SymmetricPrivateNodes",
             AnsibleInventoryType::SymmetricPrivateNodesStatic => "SymmetricPrivateNodesStatic",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 
@@ -405,9 +405,9 @@ pub fn generate_symmetric_private_node_static_environment_inventory(
 
     for (privat_node_vm, nat_gateway_vm) in private_node_nat_gateway_map.iter() {
         let node_number = privat_node_vm.name.split('-').next_back().unwrap();
-        writeln!(file, "[symmetric_private_node_{}]", node_number)?;
+        writeln!(file, "[symmetric_private_node_{node_number}]")?;
         writeln!(file, "{}", privat_node_vm.private_ip_addr)?;
-        writeln!(file, "[symmetric_private_node_{}:vars]", node_number)?;
+        writeln!(file, "[symmetric_private_node_{node_number}:vars]")?;
         writeln!(
             file,
             "ansible_ssh_common_args='-o ProxyCommand=\"ssh -p 22 -W %h:%p -q root@{} -i \"{}\" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null\"'",
@@ -458,11 +458,11 @@ pub fn generate_full_cone_private_node_static_environment_inventory(
 
     for (privat_node_vm, nat_gateway_vm) in private_node_nat_gateway_map.iter() {
         let node_number = privat_node_vm.name.split('-').next_back().unwrap();
-        writeln!(file, "[full_cone_private_node_{}]", node_number)?;
+        writeln!(file, "[full_cone_private_node_{node_number}]")?;
 
         writeln!(file, "{}", privat_node_vm.private_ip_addr)?;
 
-        writeln!(file, "[full_cone_private_node_{}:vars]", node_number)?;
+        writeln!(file, "[full_cone_private_node_{node_number}:vars]")?;
         writeln!(
             file,
             "ansible_ssh_common_args='-o ProxyCommand=\"ssh -p 22 -W %h:%p -q root@{} -i \"{}\" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null\"'",

--- a/src/ansible/mod.rs
+++ b/src/ansible/mod.rs
@@ -201,6 +201,10 @@ pub enum AnsiblePlaybook {
     UpgradeClientTelegrafConfig,
     /// Update the GeoIP Telegraf configuration to the latest version in the repository.
     UpgradeGeoIpTelegrafConfig,
+    /// Update the nginx configuration to the latest version in the repository.
+    ///
+    /// Use in combination with `AnsibleInventoryType::PeerCache`.
+    UpgradeNginx,
     /// The uploader playbook will setup the uploader scripts on the uploader VMs.
     ///
     /// Use in combination with `AnsibleInventoryType::Clients`.
@@ -250,6 +254,7 @@ impl AnsiblePlaybook {
             AnsiblePlaybook::UpgradeGeoIpTelegrafConfig => {
                 "upgrade_geoip_telegraf_config.yml".to_string()
             }
+            AnsiblePlaybook::UpgradeNginx => "upgrade_nginx.yml".to_string(),
             AnsiblePlaybook::UpgradeNodes => "upgrade_nodes.yml".to_string(),
             AnsiblePlaybook::UpgradeNodeTelegrafConfig => {
                 "upgrade_node_telegraf_config.yml".to_string()

--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -1460,6 +1460,35 @@ impl AnsibleProvisioner {
         Ok(())
     }
 
+    pub fn upgrade_nginx_config(
+        &self,
+        environment_name: &str,
+        custom_inventory: Option<Vec<VirtualMachine>>,
+    ) -> Result<()> {
+        if let Some(custom_inventory) = custom_inventory {
+            println!("Running the upgrade nginx config playbook with a custom inventory");
+            generate_custom_environment_inventory(
+                &custom_inventory,
+                environment_name,
+                &self.ansible_runner.working_directory_path.join("inventory"),
+            )?;
+            self.ansible_runner.run_playbook(
+                AnsiblePlaybook::UpgradeNginx,
+                AnsibleInventoryType::Custom,
+                None,
+            )?;
+            return Ok(());
+        }
+
+        println!("Running the upgrade nginx config playbook for peer cache nodes");
+        self.ansible_runner.run_playbook(
+            AnsiblePlaybook::UpgradeNginx,
+            AnsibleInventoryType::PeerCacheNodes,
+            None,
+        )?;
+        Ok(())
+    }
+
     pub fn upgrade_geoip_telegraf(&self, name: &str) -> Result<()> {
         self.ansible_runner.run_playbook(
             AnsiblePlaybook::UpgradeGeoIpTelegrafConfig,

--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -610,6 +610,7 @@ impl AnsibleProvisioner {
                 None,
                 1,
                 options.evm_network.clone(),
+                false,
             )?),
         )?;
 
@@ -887,6 +888,7 @@ impl AnsibleProvisioner {
         node_type: NodeType,
     ) -> Result<()> {
         let start = Instant::now();
+        let mut write_older_cache_files = false;
         let (inventory_type, node_count) = match &node_type {
             NodeType::FullConePrivateNode => (
                 node_type.to_ansible_inventory_type(),
@@ -895,10 +897,13 @@ impl AnsibleProvisioner {
             // use provision_genesis_node fn
             NodeType::Generic => (node_type.to_ansible_inventory_type(), options.node_count),
             NodeType::Genesis => return Err(Error::InvalidNodeType(node_type)),
-            NodeType::PeerCache => (
-                node_type.to_ansible_inventory_type(),
-                options.peer_cache_node_count,
-            ),
+            NodeType::PeerCache => {
+                write_older_cache_files = true;
+                (
+                    node_type.to_ansible_inventory_type(),
+                    options.peer_cache_node_count,
+                )
+            }
             NodeType::SymmetricPrivateNode => (
                 node_type.to_ansible_inventory_type(),
                 options.symmetric_private_node_count,
@@ -945,6 +950,7 @@ impl AnsibleProvisioner {
                 initial_network_contacts_url,
                 node_count,
                 options.evm_network.clone(),
+                write_older_cache_files,
             )?),
         )?;
 

--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -643,10 +643,7 @@ impl AnsibleProvisioner {
             self.ssh_client
                 .wait_for_ssh_availability(&vm.public_ip_addr, &self.cloud_provider.get_ssh_user())
                 .map_err(|e| {
-                    println!(
-                        "Failed to establish SSH connection to Full Cone NAT Gateway: {}",
-                        e
-                    );
+                    println!("Failed to establish SSH connection to Full Cone NAT Gateway: {e}");
                     e
                 })?;
         }
@@ -802,7 +799,7 @@ impl AnsibleProvisioner {
         let home_dir = std::env::var("HOME").inspect_err(|err| {
             println!("Failed to get home directory with error: {err:?}",);
         })?;
-        let known_hosts_path = format!("{}/.ssh/known_hosts", home_dir);
+        let known_hosts_path = format!("{home_dir}/.ssh/known_hosts");
         debug!("Cleaning up known hosts file at {known_hosts_path} ");
         run_external_command(
             PathBuf::from("rm"),
@@ -843,10 +840,7 @@ impl AnsibleProvisioner {
             self.ssh_client
                 .wait_for_ssh_availability(&vm.public_ip_addr, &self.cloud_provider.get_ssh_user())
                 .map_err(|e| {
-                    println!(
-                        "Failed to establish SSH connection to Symmetric NAT Gateway: {}",
-                        e
-                    );
+                    println!("Failed to establish SSH connection to Symmetric NAT Gateway: {e}");
                     e
                 })?;
         }
@@ -1481,6 +1475,6 @@ impl AnsibleProvisioner {
     pub fn print_ansible_run_banner(&self, s: &str) {
         let ansible_run_msg = "Ansible Run: ";
         let line = "=".repeat(s.len() + ansible_run_msg.len());
-        println!("{}\n{}{}\n{}", line, ansible_run_msg, s, line);
+        println!("{line}\n{ansible_run_msg}{s}\n{line}");
     }
 }

--- a/src/cmd/clients.rs
+++ b/src/cmd/clients.rs
@@ -368,13 +368,13 @@ pub async fn handle_clients_command(cmd: ClientsCommands) -> Result<()> {
             Ok(())
         }
         ClientsCommands::Clean { name, provider } => {
-            println!("Cleaning Client environment '{}'...", name);
+            println!("Cleaning Client environment '{name}'...");
             let client_deployer = ClientsDeployBuilder::default()
                 .environment_name(&name)
                 .provider(provider)
                 .build()?;
             client_deployer.clean().await?;
-            println!("Client environment '{}' cleaned", name);
+            println!("Client environment '{name}' cleaned");
             Ok(())
         }
         ClientsCommands::Deploy {
@@ -547,7 +547,7 @@ pub async fn handle_clients_command(cmd: ClientsCommands) -> Result<()> {
 
             client_deployer.deploy(options).await?;
 
-            println!("Client deployment for '{}' completed successfully", name);
+            println!("Client deployment for '{name}' completed successfully");
             Ok(())
         }
         ClientsCommands::StartDownloaders { name, provider } => {
@@ -743,7 +743,7 @@ pub async fn handle_clients_command(cmd: ClientsCommands) -> Result<()> {
                     Ok(inv) => break inv,
                     Err(e) if retries < max_retries => {
                         retries += 1;
-                        eprintln!("Failed to generate inventory on attempt {retries}: {:?}", e);
+                        eprintln!("Failed to generate inventory on attempt {retries}: {e:?}");
                         eprintln!("Will retry up to {max_retries} times...");
                     }
                     Err(_) => {

--- a/src/cmd/deployments.rs
+++ b/src/cmd/deployments.rs
@@ -417,7 +417,7 @@ pub async fn handle_deploy(
             Ok(inv) => break inv,
             Err(e) if retries < max_retries => {
                 retries += 1;
-                eprintln!("Failed to generate inventory on attempt {retries}: {:?}", e);
+                eprintln!("Failed to generate inventory on attempt {retries}: {e:?}");
                 eprintln!("Will retry up to {max_retries} times...");
             }
             Err(_) => {
@@ -545,8 +545,8 @@ pub async fn handle_upscale(
                     .unwrap_or_else(|| existing_antctl_version.clone());
 
                 println!("The upscale will use the following override binary versions:");
-                println!("antnode: {}", new_antnode_version);
-                println!("antctl: {}", new_antctl_version);
+                println!("antnode: {new_antnode_version}");
+                println!("antctl: {new_antctl_version}");
 
                 inventory.binary_option = BinaryOption::Versioned {
                     ant_version: None,
@@ -612,7 +612,7 @@ pub async fn handle_upscale(
             Ok(inv) => break inv,
             Err(e) if retries < max_retries => {
                 retries += 1;
-                eprintln!("Failed to generate inventory on attempt {retries}: {:?}", e);
+                eprintln!("Failed to generate inventory on attempt {retries}: {e:?}");
                 eprintln!("Will retry up to {max_retries} times...");
             }
             Err(_) => {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -863,6 +863,17 @@ pub enum Commands {
         /// Set to run Ansible with more verbose output.
         #[arg(long)]
         ansible_verbose: bool,
+        /// The branch of the Github repository to use for custom binaries.
+        ///
+        /// This specifies the pre-built binaries to download from S3 for the upgrade.
+        /// The binaries must have been previously built and uploaded.
+        ///
+        /// This argument must be used in conjunction with the --repo-owner argument.
+        ///
+        /// The --branch and --repo-owner arguments are mutually exclusive with the --version
+        /// argument. You can only supply a version number or a custom branch, not both.
+        #[arg(long, verbatim_doc_comment)]
+        branch: Option<String>,
         /// Provide a list of VM names to use as a custom inventory.
         ///
         /// This will run the upgrade against this particular subset of VMs.
@@ -911,6 +922,17 @@ pub enum Commands {
         /// Valid values are "aws" or "digital-ocean".
         #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
         provider: CloudProvider,
+        /// The owner/org of the Github repository to use for custom binaries.
+        ///
+        /// This specifies the pre-built binaries to download from S3 for the upgrade.
+        /// The binaries must have been previously built and uploaded.
+        ///
+        /// This argument must be used in conjunction with the --branch argument.
+        ///
+        /// The --branch and --repo-owner arguments are mutually exclusive with the --version
+        /// argument. You can only supply a version number or a custom branch, not both.
+        #[arg(long, verbatim_doc_comment)]
+        repo_owner: Option<String>,
         #[arg(long)]
         /// Optionally supply a version number for the antnode binary to upgrade to.
         ///

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -10,6 +10,7 @@ pub mod funds;
 pub mod logs;
 pub mod misc;
 pub mod network;
+pub mod nginx;
 pub mod nodes;
 pub mod provision;
 pub mod telegraf;
@@ -17,7 +18,7 @@ pub mod upgrade;
 
 use crate::cmd::{
     clients::ClientsCommands, funds::FundsCommand, logs::LogCommands, network::NetworkCommands,
-    provision::ProvisionCommands, telegraf::TelegrafCommands,
+    nginx::NginxCommands, provision::ProvisionCommands, telegraf::TelegrafCommands,
 };
 use alloy::primitives::U256;
 use ant_releases::{AntReleaseRepoActions, ReleaseType};
@@ -694,6 +695,9 @@ pub enum Commands {
     Logs(LogCommands),
     #[clap(name = "network", subcommand)]
     Network(NetworkCommands),
+    /// Manage nginx services and configuration
+    #[clap(name = "nginx", subcommand)]
+    Nginx(NginxCommands),
     /// Send a notification to Slack with testnet inventory details
     Notify {
         /// The name of the environment.

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1142,8 +1142,8 @@ pub enum OptionsType {
 impl OptionsType {
     fn file_name(&self, environment_name: &str) -> String {
         match self {
-            Self::Deploy => format!("{}-deploy.json", environment_name),
-            Self::Provision => format!("{}-provision.json", environment_name),
+            Self::Deploy => format!("{environment_name}-deploy.json"),
+            Self::Provision => format!("{environment_name}-provision.json"),
         }
     }
 }
@@ -1268,8 +1268,7 @@ async fn get_binary_option(
         let branch = branch.unwrap();
 
         print_with_banner(&format!(
-            "Binaries will be built from {}/{}",
-            repo_owner, branch
+            "Binaries will be built from {repo_owner}/{branch}"
         ));
 
         let url = format!("https://github.com/{repo_owner}/autonomi/tree/{branch}",);
@@ -1369,7 +1368,7 @@ pub fn parse_evm_network(s: &str) -> Result<EvmNetwork, String> {
         "arbitrum-one" => Ok(EvmNetwork::ArbitrumOne),
         "arbitrum-sepolia-test" => Ok(EvmNetwork::ArbitrumSepoliaTest),
         "custom" => Ok(EvmNetwork::Custom),
-        _ => Err(format!("Invalid EVM network type: {}", s)),
+        _ => Err(format!("Invalid EVM network type: {s}")),
     }
 }
 
@@ -1385,5 +1384,5 @@ pub fn parse_provider(val: &str) -> Result<CloudProvider> {
 
 fn print_with_banner(s: &str) {
     let banner = "=".repeat(s.len());
-    println!("{}\n{}\n{}", banner, s, banner);
+    println!("{banner}\n{s}\n{banner}");
 }

--- a/src/cmd/nginx.rs
+++ b/src/cmd/nginx.rs
@@ -1,0 +1,72 @@
+// Copyright (c) 2023, MaidSafe.
+// All rights reserved.
+//
+// This SAFE Network Software is licensed under the BSD-3-Clause license.
+// Please see the LICENSE file for more details.
+
+use super::get_custom_inventory;
+use clap::Subcommand;
+use color_eyre::{eyre::eyre, Result};
+use sn_testnet_deploy::{inventory::DeploymentInventoryService, TestnetDeployBuilder};
+
+#[derive(Subcommand, Debug)]
+pub enum NginxCommands {
+    /// Upgrade the nginx configuration on an environment.
+    UpgradeConfig {
+        /// Provide a list of VM names to use as a custom inventory.
+        ///
+        /// This will upgrade nginx on a particular subset of VMs.
+        #[clap(name = "custom-inventory", long, use_value_delimiter = true)]
+        custom_inventory: Option<Vec<String>>,
+        /// Maximum number of forks Ansible will use to execute tasks on target hosts.
+        #[clap(long, default_value_t = 50)]
+        forks: usize,
+        /// The name of the environment.
+        #[arg(short = 'n', long)]
+        name: String,
+        /// The cloud provider for the environment.
+        #[clap(long, default_value_t = sn_testnet_deploy::CloudProvider::DigitalOcean, value_parser = super::parse_provider, verbatim_doc_comment)]
+        provider: sn_testnet_deploy::CloudProvider,
+    },
+}
+
+pub async fn handle_upgrade_nginx_config(
+    custom_inventory: Option<Vec<String>>,
+    forks: usize,
+    name: String,
+    provider: sn_testnet_deploy::CloudProvider,
+) -> Result<()> {
+    // Use 50 forks for inventory retrieval for better performance
+    let testnet_deployer = TestnetDeployBuilder::default()
+        .ansible_forks(50)
+        .environment_name(&name)
+        .provider(provider)
+        .build()?;
+
+    let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
+    let inventory = inventory_service
+        .generate_or_retrieve_inventory(&name, true, None)
+        .await?;
+    if inventory.is_empty() {
+        return Err(eyre!("The {name} environment does not exist"));
+    }
+
+    let custom_inventory = if let Some(custom_inventory) = custom_inventory {
+        let custom_vms = get_custom_inventory(&inventory, &custom_inventory)?;
+        Some(custom_vms)
+    } else {
+        None
+    };
+
+    // Recreate deployer with the specified forks for the nginx upgrade
+    let testnet_deployer = TestnetDeployBuilder::default()
+        .ansible_forks(forks)
+        .environment_name(&name)
+        .provider(provider)
+        .build()?;
+
+    let provisioner = testnet_deployer.ansible_provisioner;
+    provisioner.upgrade_nginx_config(&name, custom_inventory)?;
+
+    Ok(())
+}

--- a/src/cmd/provision.rs
+++ b/src/cmd/provision.rs
@@ -138,7 +138,7 @@ async fn handle_provision_nodes(name: String, node_type: NodeType) -> Result<()>
             }
         }
         _ => {
-            provisioner.print_ansible_run_banner(&format!("Provision {} Nodes", node_type));
+            provisioner.print_ansible_run_banner(&format!("Provision {node_type} Nodes"));
             provisioner.provision_nodes(
                 &provision_options,
                 Some(genesis_multiaddr),

--- a/src/cmd/upgrade.rs
+++ b/src/cmd/upgrade.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 #[allow(clippy::too_many_arguments)]
 pub async fn handle_upgrade_command(
     ansible_verbose: bool,
+    branch: Option<String>,
     custom_inventory: Option<Vec<String>>,
     env_variables: Option<Vec<(String, String)>>,
     force: bool,
@@ -22,6 +23,7 @@ pub async fn handle_upgrade_command(
     node_type: Option<NodeType>,
     provider: CloudProvider,
     pre_upgrade_delay: Option<u64>,
+    repo_owner: Option<String>,
     version: Option<String>,
 ) -> Result<()> {
     // The upgrade intentionally uses a small value for `forks`, but this is far too slow
@@ -56,6 +58,7 @@ pub async fn handle_upgrade_command(
         .build()?;
     testnet_deployer.upgrade(UpgradeOptions {
         ansible_verbose,
+        branch,
         custom_inventory,
         env_variables,
         force,
@@ -65,6 +68,7 @@ pub async fn handle_upgrade_command(
         node_type,
         provider,
         pre_upgrade_delay,
+        repo_owner,
         version,
     })?;
 

--- a/src/digital_ocean.rs
+++ b/src/digital_ocean.rs
@@ -47,8 +47,8 @@ impl DigitalOceanClient {
             } else if !response.status().is_success() {
                 let status_code = response.status().as_u16();
                 let response_body = response.text().await?;
-                debug!("Response status code: {}", status_code);
-                debug!("Error response body: {}", response_body);
+                debug!("Response status code: {status_code}");
+                debug!("Error response body: {response_body}");
                 return Err(Error::DigitalOceanUnexpectedResponse(
                     status_code,
                     response_body,

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -70,7 +70,7 @@ impl From<&TestnetDeployer> for DeploymentInventoryService {
                 .working_directory_path
                 .join("ansible")
                 .join("inventory")
-                .join(format!("dev_inventory_{}.yml", provider)),
+                .join(format!("dev_inventory_{provider}.yml")),
             s3_repository: item.s3_repository.clone(),
             ssh_client: item.ssh_client.clone(),
             terraform_runner: item.terraform_runner.clone(),
@@ -93,7 +93,7 @@ impl From<&ClientsDeployer> for DeploymentInventoryService {
                 .working_directory_path
                 .join("ansible")
                 .join("inventory")
-                .join(format!("dev_inventory_{}.yml", provider)),
+                .join(format!("dev_inventory_{provider}.yml")),
             s3_repository: item.s3_repository.clone(),
             ssh_client: item.ssh_client.clone(),
             terraform_runner: item.terraform_runner.clone(),
@@ -399,13 +399,13 @@ impl DeploymentInventoryService {
 
             println!("Retrieved binary versions from previous deployment:");
             if let Some(version) = &antnode_version {
-                println!("  antnode: {}", version);
+                println!("  antnode: {version}");
             }
             if let Some(version) = &antctl_version {
-                println!("  antctl: {}", version);
+                println!("  antctl: {version}");
             }
             if let Some(version) = &ant_version {
-                println!("  ant: {}", version);
+                println!("  ant: {version}");
             }
 
             BinaryOption::Versioned {
@@ -672,7 +672,7 @@ impl DeploymentInventoryService {
 
             println!("Retrieved binary versions from previous deployment:");
             if let Some(version) = &ant_version {
-                println!("  ant: {}", version);
+                println!("  ant: {version}");
             }
 
             BinaryOption::Versioned {
@@ -845,7 +845,7 @@ impl DeploymentNodeRegistries {
                 self.inventory_type
             );
             for vm_name in self.failed_vms.iter() {
-                println!("- {}", vm_name);
+                println!("- {vm_name}");
             }
         }
     }
@@ -866,9 +866,9 @@ impl DeploymentNodeRegistries {
         let total_width = text_width + border_chars;
         let top_bottom = "═".repeat(total_width);
 
-        println!("╔{}╗", top_bottom);
-        println!("║ {:^width$} ║", text, width = text_width);
-        println!("╚{}╝", top_bottom);
+        println!("╔{top_bottom}╗");
+        println!("║ {text:^text_width$} ║");
+        println!("╚{top_bottom}╝");
     }
 }
 
@@ -1572,7 +1572,7 @@ impl ClientsDeploymentInventory {
             println!("======================");
             println!("Funding Wallet Address");
             println!("======================");
-            println!("{}", funding_wallet_address);
+            println!("{funding_wallet_address}");
             println!();
         }
 
@@ -1580,7 +1580,7 @@ impl ClientsDeploymentInventory {
             println!("==========");
             println!("Network ID");
             println!("==========");
-            println!("{}", network_id);
+            println!("{network_id}");
             println!();
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ impl std::str::FromStr for DeploymentType {
             "bootstrap" => Ok(DeploymentType::Bootstrap),
             "clients" => Ok(DeploymentType::Client),
             "new" => Ok(DeploymentType::New),
-            _ => Err(format!("Invalid deployment type: {}", s)),
+            _ => Err(format!("Invalid deployment type: {s}")),
         }
     }
 }
@@ -133,7 +133,7 @@ impl std::str::FromStr for NodeType {
             "genesis" => Ok(NodeType::Genesis),
             "peer-cache" => Ok(NodeType::PeerCache),
             "symmetric-private" => Ok(NodeType::SymmetricPrivateNode),
-            _ => Err(format!("Invalid node type: {}", s)),
+            _ => Err(format!("Invalid node type: {s}")),
         }
     }
 }
@@ -189,7 +189,7 @@ impl std::str::FromStr for EvmNetwork {
             "arbitrum-one" => Ok(EvmNetwork::ArbitrumOne),
             "arbitrum-sepolia-test" => Ok(EvmNetwork::ArbitrumSepoliaTest),
             "custom" => Ok(EvmNetwork::Custom),
-            _ => Err(format!("Invalid EVM network type: {}", s)),
+            _ => Err(format!("Invalid EVM network type: {s}")),
         }
     }
 }
@@ -341,10 +341,10 @@ impl BinaryOption {
                 skip_binary_build: _,
             } => {
                 println!("Source configuration:");
-                println!("  Repository owner: {}", repo_owner);
-                println!("  Branch: {}", branch);
+                println!("  Repository owner: {repo_owner}");
+                println!("  Branch: {branch}");
                 if let Some(features) = antnode_features {
-                    println!("  Antnode features: {}", features);
+                    println!("  Antnode features: {features}");
                 }
             }
             BinaryOption::Versioned {
@@ -354,13 +354,13 @@ impl BinaryOption {
             } => {
                 println!("Versioned binaries configuration:");
                 if let Some(version) = ant_version {
-                    println!("  ant version: {}", version);
+                    println!("  ant version: {version}");
                 }
                 if let Some(version) = antctl_version {
-                    println!("  antctl version: {}", version);
+                    println!("  antctl version: {version}");
                 }
                 if let Some(version) = antnode_version {
-                    println!("  antnode version: {}", version);
+                    println!("  antnode version: {version}");
                 }
             }
         }
@@ -877,11 +877,11 @@ impl TestnetDeployer {
             },
             full_cone_private_nodes
         );
-        println!("Total nodes: {}", total_nodes);
-        println!("Running nodes: {}", running_nodes);
-        println!("Stopped nodes: {}", stopped_nodes);
-        println!("Added nodes: {}", added_nodes);
-        println!("Removed nodes: {}", removed_nodes);
+        println!("Total nodes: {total_nodes}");
+        println!("Running nodes: {running_nodes}");
+        println!("Stopped nodes: {stopped_nodes}");
+        println!("Added nodes: {added_nodes}");
+        println!("Removed nodes: {removed_nodes}");
 
         Ok(())
     }
@@ -1097,7 +1097,7 @@ pub fn get_anvil_node_data(
     const RETRY_DELAY: Duration = Duration::from_secs(5);
 
     for attempt in 1..=MAX_ATTEMPTS {
-        match ssh_client.run_command(&evm_ip, "ant", &format!("cat {}", csv_file_path), false) {
+        match ssh_client.run_command(&evm_ip, "ant", &format!("cat {csv_file_path}"), false) {
             Ok(output) => {
                 if let Some(csv_contents) = output.first() {
                     let parts: Vec<&str> = csv_contents.split(',').collect();
@@ -1293,8 +1293,8 @@ pub async fn notify_slack(inventory: DeploymentInventory) -> Result<()> {
             ..
         } => {
             message.push_str("*Branch Details*\n");
-            message.push_str(&format!("Repo owner: {}\n", repo_owner));
-            message.push_str(&format!("Branch: {}\n", branch));
+            message.push_str(&format!("Repo owner: {repo_owner}\n"));
+            message.push_str(&format!("Branch: {branch}\n"));
         }
         BinaryOption::Versioned {
             ant_version: ref safe_version,
@@ -1333,7 +1333,7 @@ pub async fn notify_slack(inventory: DeploymentInventory) -> Result<()> {
     message.push_str("*Available Files*\n");
     message.push_str("```\n");
     for (addr, file_name) in inventory.uploaded_files.iter() {
-        message.push_str(&format!("{}: {}\n", addr, file_name))
+        message.push_str(&format!("{addr}: {file_name}\n"))
     }
     message.push_str("```\n");
 
@@ -1354,7 +1354,7 @@ fn print_duration(duration: Duration) {
     let total_seconds = duration.as_secs();
     let minutes = total_seconds / 60;
     let seconds = total_seconds % 60;
-    debug!("Time taken: {} minutes and {} seconds", minutes, seconds);
+    debug!("Time taken: {minutes} minutes and {seconds} seconds");
 }
 
 pub fn get_progress_bar(length: u64) -> Result<ProgressBar> {
@@ -1399,7 +1399,7 @@ pub async fn get_environment_details(
                         }
                     }
                 };
-                trace!("Content of the environment details file: {}", content);
+                trace!("Content of the environment details file: {content}");
 
                 match serde_json::from_str(&content) {
                     Ok(environment_details) => break environment_details,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -419,6 +419,7 @@ impl LogFormat {
 #[derive(Clone)]
 pub struct UpgradeOptions {
     pub ansible_verbose: bool,
+    pub branch: Option<String>,
     pub custom_inventory: Option<Vec<VirtualMachine>>,
     pub env_variables: Option<Vec<(String, String)>>,
     pub force: bool,
@@ -428,6 +429,7 @@ pub struct UpgradeOptions {
     pub node_type: Option<NodeType>,
     pub pre_upgrade_delay: Option<u64>,
     pub provider: CloudProvider,
+    pub repo_owner: Option<String>,
     pub version: Option<String>,
 }
 
@@ -447,6 +449,17 @@ impl UpgradeOptions {
         if let Some(pre_upgrade_delay) = &self.pre_upgrade_delay {
             extra_vars.add_variable("pre_upgrade_delay", &pre_upgrade_delay.to_string());
         }
+
+        if let (Some(repo_owner), Some(branch)) = (&self.repo_owner, &self.branch) {
+            let binary_option = BinaryOption::BuildFromSource {
+                antnode_features: None,
+                branch: branch.clone(),
+                repo_owner: repo_owner.clone(),
+                skip_binary_build: true,
+            };
+            extra_vars.add_node_url_or_version(&self.name, &binary_option);
+        }
+
         extra_vars.build()
     }
 }

--- a/src/logs.rs
+++ b/src/logs.rs
@@ -393,7 +393,7 @@ impl TestnetDeployer {
         writeln!(file, "Command: {cmd}")?;
 
         for line in output {
-            writeln!(file, "{}", line)?;
+            writeln!(file, "{line}")?;
         }
 
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -432,6 +432,7 @@ async fn main() -> Result<()> {
         }
         Commands::Upgrade {
             ansible_verbose,
+            branch,
             custom_inventory,
             force,
             forks,
@@ -441,10 +442,12 @@ async fn main() -> Result<()> {
             node_type,
             provider,
             pre_upgrade_delay,
+            repo_owner,
             version,
         } => {
             cmd::upgrade::handle_upgrade_command(
                 ansible_verbose,
+                branch,
                 custom_inventory,
                 node_env_variables,
                 force,
@@ -454,6 +457,7 @@ async fn main() -> Result<()> {
                 node_type,
                 provider,
                 pre_upgrade_delay,
+                repo_owner,
                 version,
             )
             .await?;
@@ -660,7 +664,10 @@ async fn main() -> Result<()> {
                 forks,
                 name,
                 provider,
-            } => cmd::nginx::handle_upgrade_nginx_config(custom_inventory, forks, name, provider).await,
+            } => {
+                cmd::nginx::handle_upgrade_nginx_config(custom_inventory, forks, name, provider)
+                    .await
+            }
         },
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod cmd;
 
 use crate::cmd::{
     network::{ChurnCommands, NetworkCommands},
+    nginx::NginxCommands,
     nodes,
     provision::ProvisionCommands,
     telegraf::TelegrafCommands,
@@ -652,6 +653,14 @@ async fn main() -> Result<()> {
                 name,
                 provider,
             } => cmd::telegraf::handle_upgrade_node_telegraf_config(forks, name, provider).await,
+        },
+        Commands::Nginx(nginx_cmd) => match nginx_cmd {
+            NginxCommands::UpgradeConfig {
+                custom_inventory,
+                forks,
+                name,
+                provider,
+            } => cmd::nginx::handle_upgrade_nginx_config(custom_inventory, forks, name, provider).await,
         },
     }
 }

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -29,7 +29,7 @@ impl S3Repository {
             .to_str()
             .ok_or_else(|| Error::FilenameNotRetrieved)?;
 
-        println!("Uploading {} to bucket {}", object_key, bucket_name);
+        println!("Uploading {object_key} to bucket {bucket_name}");
 
         let mut file = tokio::fs::File::open(file_path).await?;
         let mut contents = Vec::new();
@@ -47,7 +47,7 @@ impl S3Repository {
             Error::PutS3ObjectError(object_key.to_string(), bucket_name.to_string())
         })?;
 
-        println!("{} has been uploaded to {}", object_key, bucket_name);
+        println!("{object_key} has been uploaded to {bucket_name}");
         Ok(())
     }
 
@@ -101,7 +101,7 @@ impl S3Repository {
         let prefix = if folder_path.ends_with('/') {
             folder_path.to_string()
         } else {
-            format!("{}/", folder_path)
+            format!("{folder_path}/")
         };
         let output = client
             .list_objects_v2()

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -86,27 +86,17 @@ pub fn setup_dotenv_file() -> Result<()> {
 
     let contents = format!(
         r#"
-ANSIBLE_VAULT_PASSWORD_PATH={}
-AWS_ACCESS_KEY_ID={}
-AWS_SECRET_ACCESS_KEY={}
-AWS_DEFAULT_REGION={}
-DO_PAT={}
-SSH_KEY_PATH={}
-SLACK_WEBHOOK_URL={}
-SN_TESTNET_DEV_SUBNET_ID={}
-SN_TESTNET_DEV_SECURITY_GROUP_ID={}
-TERRAFORM_STATE_BUCKET_NAME={}
-"#,
-        ansible_vault_password_path,
-        aws_access_key_id,
-        aws_access_secret_access_key,
-        aws_region,
-        digital_ocean_pat,
-        ssh_key_path,
-        slack_webhook_url,
-        sn_testnet_dev_subnet_id,
-        sn_testnet_dev_security_group_id,
-        terraform_state_bucket_name
+ANSIBLE_VAULT_PASSWORD_PATH={ansible_vault_password_path}
+AWS_ACCESS_KEY_ID={aws_access_key_id}
+AWS_SECRET_ACCESS_KEY={aws_access_secret_access_key}
+AWS_DEFAULT_REGION={aws_region}
+DO_PAT={digital_ocean_pat}
+SSH_KEY_PATH={ssh_key_path}
+SLACK_WEBHOOK_URL={slack_webhook_url}
+SN_TESTNET_DEV_SUBNET_ID={sn_testnet_dev_subnet_id}
+SN_TESTNET_DEV_SECURITY_GROUP_ID={sn_testnet_dev_security_group_id}
+TERRAFORM_STATE_BUCKET_NAME={terraform_state_bucket_name}
+"#
     );
 
     std::fs::write(".env", contents.trim())?;

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -291,10 +291,7 @@ impl SshClient {
             );
             args.push(format!("{user}@{gateway}"));
         } else {
-            debug!(
-                "Running command '{}' on {}@{}...",
-                command, user, ip_address
-            );
+            debug!("Running command '{command}' on {user}@{ip_address}...");
             args.push(format!("{user}@{ip_address}"));
         }
         args.extend(command_args);

--- a/src/terraform.rs
+++ b/src/terraform.rs
@@ -50,7 +50,7 @@ impl TerraformRunner {
         let mut args = vec!["apply".to_string(), "-auto-approve".to_string()];
         if let Some(filenames) = tfvars_filenames {
             for filename in filenames {
-                args.push(format!("-var-file={}", filename));
+                args.push(format!("-var-file={filename}"));
             }
         }
         for var in vars.iter() {
@@ -75,7 +75,7 @@ impl TerraformRunner {
         let mut args = vec!["plan".to_string()];
         if let Some(filenames) = tfvars_filenames {
             for filename in filenames {
-                args.push(format!("-var-file={}", filename));
+                args.push(format!("-var-file={filename}"));
             }
         }
         if let Some(vars) = vars {
@@ -102,7 +102,7 @@ impl TerraformRunner {
         let mut args = vec!["destroy".to_string(), "-auto-approve".to_string()];
         if let Some(filenames) = tfvars_filenames {
             for filename in filenames {
-                args.push(format!("-var-file={}", filename));
+                args.push(format!("-var-file={filename}"));
             }
         }
         if let Some(vars) = vars {


### PR DESCRIPTION
- The nginx server now serves caches based on the passed in `Cache-Version` header.
  - If `Cache-Version` is absent, i.e, the case with old antnodes, we'd return version0.
  - If `Cache-Version` is 1, we serve the latest version.
  - For anyother case, we return an error.
  
- 7de9027 **feat: ngnix serves cache file based on header**


- ca11015 **fix(nginx): update the nginx config file to support multiple cache version**


- 02fc723 **fix: set default value for write_older_cache_files**


- e3ede67 **chore: clippy fixes**


- e0b6f4d **chore: add config file for working with claude code**

  This was generated using Claude itself.

  I haven't modified it initially because I'm not too familiar with things yet.

- f8f9753 **feat: provide `nginx upgrade-config` command**

  This will be used to upgrade the existing peer cache servers in the production deployment.

  The binaries must be upgraded before the Nginx upgrade is applied because it's assuming the
  existence of the `version_1` directory.

- 77dec4f **feat: support custom binaries on upgrades**

  Use `--branch` and `--repo-owner` arguments to provide test binaries during the upgrade process.

  This came in useful for testing the FIFO cache upgrade process.

  The binaries must be built and uploaded to S3 by another process.
