### PR TITLE
feat: use additional volume for upload logs

### DIFF
--- a/resources/ansible/genesis_node.yml
+++ b/resources/ansible/genesis_node.yml
@@ -18,16 +18,8 @@
   roles:
     - role: ant_user
       become: True
-    - role: attach_volume
+    - role: setup_striped_storage
       become: True
-    - {
-        role: format_disk,
-        become: True,
-        block_device: "{{ block_device }}",
-        mount_info:
-          { name: "{{ node_data_mount_path }}", owner: "root", group: "root", mode: 0755 },
-        when: provider == "aws"
-      }
     - antctl
     - genesis-node
     - role: cache_webserver

--- a/resources/ansible/nodes.yml
+++ b/resources/ansible/nodes.yml
@@ -9,16 +9,8 @@
   roles:
     - role: ant_user
       become: True
-    - role: attach_volume
+    - role: setup_striped_storage
       become: True
-    - {
-        role: format_disk,
-        become: True,
-        block_device: "{{ block_device }}",
-        mount_info:
-          { name: "{{ node_data_mount_path }}", owner: "root", group: "root", mode: 0755 },
-        when: provider == "aws"
-      }
     - antctl
     - role: telegraf-configuration
       become: True

--- a/resources/ansible/nodes.yml
+++ b/resources/ansible/nodes.yml
@@ -26,6 +26,10 @@
         name: systemd-journald
         state: restarted
         enabled: yes
+      register: journald_restart
+      retries: 3
+      delay: 5
+      until: journald_restart is success
     - name: restart telegraf
       become: True
       ansible.builtin.systemd:
@@ -33,3 +37,7 @@
         state: restarted
         enabled: yes
       when: enable_telegraf | bool
+      register: telegraf_restart
+      retries: 3
+      delay: 5
+      until: telegraf_restart is success

--- a/resources/ansible/peer_cache_node.yml
+++ b/resources/ansible/peer_cache_node.yml
@@ -9,16 +9,8 @@
   roles:
     - role: ant_user
       become: True
-    - role: attach_volume
+    - role: setup_striped_storage
       become: True
-    - {
-        role: format_disk,
-        become: True,
-        block_device: "{{ block_device }}",
-        mount_info:
-          { name: "{{ node_data_mount_path }}", owner: "root", group: "root", mode: 0755 },
-        when: provider == "aws"
-      }
     - antctl
     - role: telegraf-configuration
       become: True

--- a/resources/ansible/roles/setup_striped_storage/defaults/main.yml
+++ b/resources/ansible/roles/setup_striped_storage/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+mount_base: "/mnt/antnode-storage"

--- a/resources/ansible/roles/setup_striped_storage/tasks/main.yml
+++ b/resources/ansible/roles/setup_striped_storage/tasks/main.yml
@@ -65,23 +65,23 @@
   when: not volume_in_fstab
 
 - name: create dir for mount point
-  command: mkdir -p /mnt/antnode-storage
+  command: mkdir -p {{ mount_base }}
   when: not volume_in_fstab
 
 - name: mount the logical volume
-  command: mount -o discard,defaults,noatime /dev/lvm_vol_group/striped_logical_volume /mnt/antnode-storage
+  command: mount -o discard,defaults,noatime /dev/lvm_vol_group/striped_logical_volume {{ mount_base }}
   when: not volume_in_fstab
 
 - name: change fstab so the volume will be mounted after a reboot
   lineinfile:
     path: /etc/fstab
-    line: '/dev/lvm_vol_group/striped_logical_volume /mnt/antnode-storage ext4 defaults,nofail,discard 0 0'
+    line: '/dev/lvm_vol_group/striped_logical_volume {{ mount_base }} ext4 defaults,nofail,discard 0 0'
     state: present
     backup: yes
   when: not volume_in_fstab
 
 - name: create subdirs
-  command: mkdir -p /mnt/antnode-storage/{{ item }}
+  command: mkdir -p {{ mount_base }}/{{ item }}
   loop: 
     - data
     - log

--- a/resources/ansible/roles/uploaders/defaults/main.yml
+++ b/resources/ansible/roles/uploaders/defaults/main.yml
@@ -1,3 +1,4 @@
 binary_dir: /usr/local/bin
 ant_archive_filename: ant-latest-x86_64-unknown-linux-musl.tar.gz
 ant_archive_url: https://autonomi-cli.s3.eu-west-2.amazonaws.com/{{ autonomi_archive_filename }}
+log_output_dest: /mnt/client-logs/log

--- a/resources/ansible/roles/uploaders/tasks/main.yml
+++ b/resources/ansible/roles/uploaders/tasks/main.yml
@@ -18,19 +18,36 @@
   become: true
   when: not ant_binary.stat.exists
 
+- name: create ant group
+  ansible.builtin.group:
+    name: ant
+    state: present
+  become: true
+
 - name: create ant users
   ansible.builtin.user:
     name: "ant{{ item }}"
     shell: /bin/bash
+    group: ant
     state: present
   loop: "{{ range(1, ant_uploader_instances | int + 1) | list }}"
+  become: true
+
+- name: ensure the ant users can write to the log output destination
+  ansible.builtin.file:
+    path: "{{ log_output_dest }}"
+    state: directory
+    mode: '0775'
+    owner: root
+    group: ant
+  become: true
 
 - name: copy upload-random-data.sh to remote for each ant user
   ansible.builtin.template:
     src: upload-random-data.sh.j2
     dest: "/home/ant{{ item }}/upload-random-data.sh"
     owner: "ant{{ item }}"
-    group: "ant{{ item }}"
+    group: "ant"
     mode: '0744'
   become: true
   become_user: "ant{{ item }}"
@@ -51,7 +68,7 @@
     src: ant_uploader.service.j2
     dest: "/etc/systemd/system/ant_uploader_{{ item.0 }}.service"
     owner: "ant{{ item.0 }}"
-    group: "ant{{ item.0 }}"
+    group: "ant"
     mode: '0644'
   become: true
   when: not service_file_stat.results[item.0 - 1].stat.exists

--- a/resources/ansible/roles/uploaders/templates/upload-random-data.sh.j2
+++ b/resources/ansible/roles/uploaders/templates/upload-random-data.sh.j2
@@ -50,6 +50,8 @@ if [ -n "$NETWORK_ID" ]; then
   NETWORK_ID_ARG="--network-id $NETWORK_ID"
 fi
 
+LOG_OUTPUT_DEST="{{ log_output_dest }}"
+
 if ! command -v ant &> /dev/null; then
   echo "Error: 'ant' not found in PATH."
   exit 1
@@ -85,10 +87,20 @@ generate_random_data_file_and_upload() {
   echo "Generated random data file at $tmpfile"
   file_size_kb=$(du -k "$tmpfile" | cut -f1)
 
-  now=$(date +"%s")
-  stdout=$(ant $CONTACT_PEER_ARG $NETWORK_CONTACTS_URL_ARG $TESTNET_ARG $NETWORK_ID_ARG file upload "$tmpfile" 2>&1)
+  timestamp=$(date +"%Y%m%d_%H%M%S")
+  log_file_path="${LOG_OUTPUT_DEST}/${timestamp}"
+  LOG_OUTPUT_ARG="--log-output-dest $log_file_path"
+  
+  stdout=$(ant \
+    $CONTACT_PEER_ARG \
+    $NETWORK_CONTACTS_URL_ARG \
+    $TESTNET_ARG \
+    $NETWORK_ID_ARG \
+    $LOG_OUTPUT_ARG \
+    file upload "$tmpfile" 2>&1)
   echo "$stdout"
 
+  now=$(date +"%s")
   if [ $? -eq 0 ]; then
     echo "Successfully uploaded $tmpfile using SAFE CLI"
 

--- a/resources/ansible/uploaders.yml
+++ b/resources/ansible/uploaders.yml
@@ -4,6 +4,10 @@
   become: False
   ignore_unreachable: yes
   roles:
+    - role: setup_striped_storage
+      become: True
+      vars:
+        mount_base: /mnt/client-logs
     - role: uploader-metrics
       become: True
     - role: uploaders

--- a/resources/ansible/uploaders.yml
+++ b/resources/ansible/uploaders.yml
@@ -22,6 +22,10 @@
         name: systemd-journald
         state: restarted
         enabled: yes
+      register: journald_restart
+      retries: 3
+      delay: 5
+      until: journald_restart is success
     # # The Telegraf service seems to need to be rebooted for metrics to start transmitting.
     - name: restart telegraf
       become: True
@@ -30,3 +34,7 @@
         state: restarted
         enabled: yes
       when: enable_telegraf | bool
+      register: telegraf_restart
+      retries: 3
+      delay: 5
+      until: telegraf_restart is success

--- a/resources/terraform/testnet/digital-ocean/variables.tf
+++ b/resources/terraform/testnet/digital-ocean/variables.tf
@@ -159,3 +159,9 @@ variable "peer_cache_reserved_ips" {
   description = "List of reserved IPs for the peer nodes"
   default = []
 }
+
+variable "uploader_volume_size" {
+  description = "Size of each volume in GB for uploader nodes"
+  type        = number
+  default     = 70
+}


### PR DESCRIPTION
- d741e1b **chore: vary base mount point for striped volume**

  I want to use this role to mount a volume on the uploaders too, so the base mount point may be
  different.

  I renamed the role to something a bit more specific that I think captures the purpose.

  I've also taken out a role being applied to the playbook that formatted a disk if we were using AWS
  as the provider. We will hopefully move to AWS soon, but for the time being this was causing a bit
  of confusion and I don't think it will be used; we'll probably need the striped volume setup for AWS
  too.

- ed609e7 **chore: apply retries for service restarts**

  I've seen these fail during deployments and unfortunately they will cause the workflow run to fail.

  A simple restart should prevent the failure. These have been applied to other service restarts that
  fail occasionally and they seem to work.

- 6f5d955 **feat: use additional volume for upload logs**

  If we want to launch testnets with extended and verbose logging for uploads, we will run out of disk
  space very quickly. For this reason, we will use an additional volume and have the upload logs
  output here.
