### PR TITLE
feat: `bootstrap` cmd requires `--network-id` arg

### DIFF
--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -255,7 +255,7 @@ impl From<BootstrapOptions> for ProvisionOptions {
             max_log_files: bootstrap_options.max_log_files,
             max_uploads: None,
             name: bootstrap_options.name,
-            network_id: bootstrap_options.network_id,
+            network_id: Some(bootstrap_options.network_id),
             node_count: bootstrap_options.node_count,
             node_env_variables: bootstrap_options.node_env_variables,
             output_inventory_dir_path: bootstrap_options.output_inventory_dir_path,

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -34,7 +34,7 @@ pub struct BootstrapOptions {
     pub max_archived_log_files: u16,
     pub max_log_files: u16,
     pub name: String,
-    pub network_id: Option<u8>,
+    pub network_id: u8,
     pub node_count: u16,
     pub node_env_variables: Option<Vec<(String, String)>>,
     pub node_vm_count: Option<u16>,
@@ -69,7 +69,7 @@ impl TestnetDeployer {
                     rpc_url: options.evm_rpc_url.clone(),
                 },
                 funding_wallet_address: None,
-                network_id: options.network_id,
+                network_id: Some(options.network_id),
                 rewards_address: Some(options.rewards_address.clone()),
             },
         )

--- a/src/cmd/deployments.rs
+++ b/src/cmd/deployments.rs
@@ -38,7 +38,7 @@ pub async fn handle_bootstrap(
     interval: Duration,
     log_format: Option<LogFormat>,
     name: String,
-    network_id: Option<u8>,
+    network_id: u8,
     node_count: Option<u16>,
     node_vm_count: Option<u16>,
     node_volume_size: Option<u16>,

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -176,9 +176,9 @@ pub enum Commands {
         /// Specify the network ID to use for the node services. This is used to partition the network and will not allow
         /// nodes with different network IDs to join.
         ///
-        /// By default, the network ID is set to 1, which represents the mainnet.
-        #[clap(long, verbatim_doc_comment)]
-        network_id: Option<u8>,
+        /// This must match the network ID of the original network being bootstrapped from.
+        #[clap(long, required = true, verbatim_doc_comment)]
+        network_id: u8,
         /// The number of antnode services to run on each VM.
         ///
         /// If the argument is not used, the value will be determined by the 'environment-type'


### PR DESCRIPTION
It's better to just assert that the network ID is required rather than leaving it optional, because it will inevitably be forgotten. If we want to bootstrap from `mainnet`, we can just explicitly use 1 as the ID.