### PR TITLE
fix: correctly evaluate binaries to build

### DIFF
--- a/resources/ansible/build.yml
+++ b/resources/ansible/build.yml
@@ -2,29 +2,24 @@
 - name: build binaries
   hosts: all
   become: False
-  vars:
-    build_ant: "{{ build_ant | default(true) }}"
-    build_antnode: "{{ build_antnode | default(true) }}"
-    build_antctl: "{{ build_antctl | default(true) }}"
-    build_antctld: "{{ build_antctld | default(true) }}"
   roles:
     - {
         role: build_safe_network_binary,
         bin_name: "ant",
-        when: (custom_bin == "true") and (build_ant | bool)
+        when: custom_bin | bool and (build_ant | default(true) | bool)
       }
     - {
         role: build_safe_network_binary,
         bin_name: "antnode",
-        when: (custom_bin == "true") and (build_antnode | bool)
+        when: custom_bin | bool and (build_antnode | default(true) | bool)
       }
     - {
         role: build_safe_network_binary,
         bin_name: "antctl",
-        when: (custom_bin == "true") and (build_antctl | bool)
+        when: custom_bin | bool and (build_antctl | default(true) | bool)
       }
     - {
         role: build_safe_network_binary,
         bin_name: "antctld",
-        when: (custom_bin == "true") and (build_antctld | bool)
+        when: custom_bin | bool and (build_antctld | default(true) | bool)
       }


### PR DESCRIPTION
The construct being used before this was recursive and did not work correctly.