### PR TITLE
fix: pass `enable_telegraf` flag

### DIFF
--- a/src/ansible/extra_vars.rs
+++ b/src/ansible/extra_vars.rs
@@ -570,12 +570,14 @@ pub fn build_node_telegraf_upgrade(name: &str, node_type: &NodeType) -> Result<S
     let mut extra_vars: ExtraVarsDocBuilder = ExtraVarsDocBuilder::default();
     extra_vars.add_variable("testnet_name", name);
     extra_vars.add_variable("node_type", node_type.telegraf_role());
+    extra_vars.add_boolean_variable("enable_telegraf", true);
     Ok(extra_vars.build())
 }
 
 pub fn build_client_telegraf_upgrade(name: &str) -> Result<String> {
     let mut extra_vars: ExtraVarsDocBuilder = ExtraVarsDocBuilder::default();
     extra_vars.add_variable("testnet_name", name);
+    extra_vars.add_boolean_variable("enable_telegraf", true);
     Ok(extra_vars.build())
 }
 


### PR DESCRIPTION
These runs for upgrading the Telegraf configuration need to have the `enable_telegraf` variable set.