### PR TITLE
feat: do not set relay flag for full cone nats

### DIFF
--- a/resources/ansible/roles/node/defaults/main.yml
+++ b/resources/ansible/roles/node/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 public_rpc: False
 relay: False
+private_ip: False
 node_rpc_ip: "127.0.0.1"
 node_instance_count: 20
 binary_dir: /usr/local/bin

--- a/resources/ansible/roles/node/tasks/main.yml
+++ b/resources/ansible/roles/node/tasks/main.yml
@@ -60,7 +60,7 @@
 - name: get private ip of eth1
   shell: ip -4 addr show dev eth1 | grep inet | awk '{print $2}' | cut -d/ -f1
   register: private_ip_eth1
-  when: relay | bool
+  when: private_ip | bool
 
 #
 # Add the nodes
@@ -86,7 +86,7 @@
       - "--rewards-address={{ rewards_address }}"
       - "--max-archived-log-files={{ max_archived_log_files }}"
       - "--max-log-files={{ max_log_files }}"
-      - "{{ ('--node-ip=' + private_ip_eth1.stdout) if relay | bool else omit }}"
+      - "{{ ('--node-ip=' + private_ip_eth1.stdout) if private_ip | bool else omit }}"
       - "{{ '--relay' if relay | bool else omit }}"
       - "{{ ('--rpc-port=' + rpc_port) if not use_port_range else omit }}"
       - "{{ ('--rpc-port=' + rpc_start_port + '-' + rpc_end_port) if use_port_range else omit }}"

--- a/src/ansible/extra_vars.rs
+++ b/src/ansible/extra_vars.rs
@@ -308,7 +308,6 @@ pub fn build_node_extra_vars_doc(
     network_contacts_url: Option<String>,
     node_instance_count: u16,
     evm_network: EvmNetwork,
-    relay: bool,
 ) -> Result<String> {
     let mut extra_vars = ExtraVarsDocBuilder::default();
     extra_vars.add_variable("provider", cloud_provider);
@@ -340,8 +339,17 @@ pub fn build_node_extra_vars_doc(
         extra_vars.add_variable("public_rpc", "true");
     }
 
-    if relay {
-        extra_vars.add_variable("relay", "true");
+    match node_type {
+        NodeType::FullConePrivateNode => {
+            // Full cone private nodes do not need relay as it is a straight port forward.
+            extra_vars.add_variable("private_ip", "true");
+        }
+        NodeType::SymmetricPrivateNode => {
+            // Symmetric private nodes need relay and private ip.
+            extra_vars.add_variable("private_ip", "true");
+            extra_vars.add_variable("relay", "true");
+        }
+        _ => {}
     }
 
     if let Some(network_id) = options.network_id {

--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -606,7 +606,6 @@ impl AnsibleProvisioner {
                 None,
                 1,
                 options.evm_network.clone(),
-                false,
             )?),
         )?;
 
@@ -884,15 +883,11 @@ impl AnsibleProvisioner {
         node_type: NodeType,
     ) -> Result<()> {
         let start = Instant::now();
-        let mut relay = false;
         let (inventory_type, node_count) = match &node_type {
-            NodeType::FullConePrivateNode => {
-                relay = true;
-                (
-                    node_type.to_ansible_inventory_type(),
-                    options.full_cone_private_node_count,
-                )
-            }
+            NodeType::FullConePrivateNode => (
+                node_type.to_ansible_inventory_type(),
+                options.full_cone_private_node_count,
+            ),
             // use provision_genesis_node fn
             NodeType::Generic => (node_type.to_ansible_inventory_type(), options.node_count),
             NodeType::Genesis => return Err(Error::InvalidNodeType(node_type)),
@@ -900,13 +895,10 @@ impl AnsibleProvisioner {
                 node_type.to_ansible_inventory_type(),
                 options.peer_cache_node_count,
             ),
-            NodeType::SymmetricPrivateNode => {
-                relay = true;
-                (
-                    node_type.to_ansible_inventory_type(),
-                    options.symmetric_private_node_count,
-                )
-            }
+            NodeType::SymmetricPrivateNode => (
+                node_type.to_ansible_inventory_type(),
+                options.symmetric_private_node_count,
+            ),
         };
 
         // For a new deployment, it's quite probable that SSH is available, because this part occurs
@@ -949,7 +941,6 @@ impl AnsibleProvisioner {
                 initial_network_contacts_url,
                 node_count,
                 options.evm_network.clone(),
-                relay,
             )?),
         )?;
 


### PR DESCRIPTION
- Nodes behind full cone nat gateways are equivalent to port forwarded nodes, and hence they don't require the `--relay` flag.