### PR TITLE
feat: support reachability check flow on the nodes

### DIFF
--- a/resources/ansible/roles/genesis-node/tasks/main.yml
+++ b/resources/ansible/roles/genesis-node/tasks/main.yml
@@ -49,7 +49,7 @@
 
 - name: start the genesis node service
   become: True
-  command: antctl -v start --interval {{ interval}}
+  command: antctl --trace start --interval {{ interval}}
   register: start_services_result
   failed_when: false
 

--- a/resources/ansible/roles/node/defaults/main.yml
+++ b/resources/ansible/roles/node/defaults/main.yml
@@ -1,7 +1,5 @@
 ---
 public_rpc: False
-relay: False
-private_ip: False
 node_rpc_ip: "127.0.0.1"
 node_instance_count: 20
 binary_dir: /usr/local/bin

--- a/resources/ansible/roles/node/tasks/main.yml
+++ b/resources/ansible/roles/node/tasks/main.yml
@@ -64,7 +64,7 @@
   vars:
     command_args:
       - "{{ binary_dir }}/antctl"
-      - -v
+      - --trace
       - add
       - --data-dir-path=/mnt/antnode-storage/data
       - --log-dir-path=/mnt/antnode-storage/log
@@ -92,7 +92,7 @@
 
 - name: start the node services
   become: True
-  command: antctl -v start --interval {{ interval}}
+  command: antctl --trace start --interval {{ interval}}
   register: start_services_result
   failed_when: false
 

--- a/resources/ansible/roles/node/tasks/main.yml
+++ b/resources/ansible/roles/node/tasks/main.yml
@@ -87,6 +87,7 @@
       - "--max-log-files={{ max_log_files }}"
       - "{{ ('--node-ip=' + private_ip_eth1.stdout) if private_ip | bool else omit }}"
       - "{{ '--relay' if relay | bool else omit }}"
+      - --reachability-check
       - "{{ ('--rpc-port=' + rpc_port) if not use_port_range else omit }}"
       - "{{ ('--rpc-port=' + rpc_start_port + '-' + rpc_end_port) if use_port_range else omit }}"
       - "{{ ('--metrics-port=' + metrics_port) if not use_port_range else omit }}"

--- a/resources/ansible/roles/node/tasks/main.yml
+++ b/resources/ansible/roles/node/tasks/main.yml
@@ -55,14 +55,6 @@
   when: use_port_range
 
 #
-# Obtain private IP if relay is set
-#
-- name: get private ip of eth1
-  shell: ip -4 addr show dev eth1 | grep inet | awk '{print $2}' | cut -d/ -f1
-  register: private_ip_eth1
-  when: private_ip | bool
-
-#
 # Add the nodes
 #
 - name: add node services
@@ -74,7 +66,6 @@
       - "{{ binary_dir }}/antctl"
       - -v
       - add
-      - --no-upnp
       - --data-dir-path=/mnt/antnode-storage/data
       - --log-dir-path=/mnt/antnode-storage/log
       - "--count={{ nodes_to_add }}"
@@ -85,8 +76,6 @@
       - "--rewards-address={{ rewards_address }}"
       - "--max-archived-log-files={{ max_archived_log_files }}"
       - "--max-log-files={{ max_log_files }}"
-      - "{{ ('--node-ip=' + private_ip_eth1.stdout) if private_ip | bool else omit }}"
-      - "{{ '--relay' if relay | bool else omit }}"
       - --reachability-check
       - "{{ ('--rpc-port=' + rpc_port) if not use_port_range else omit }}"
       - "{{ ('--rpc-port=' + rpc_start_port + '-' + rpc_end_port) if use_port_range else omit }}"

--- a/resources/terraform/testnet/digital-ocean/main.tf
+++ b/resources/terraform/testnet/digital-ocean/main.tf
@@ -39,7 +39,7 @@ resource "digitalocean_droplet" "build" {
 resource "digitalocean_droplet" "genesis_bootstrap" {
   count    = var.genesis_vm_count
   image    = var.peer_cache_droplet_image_id
-  name     = "${terraform.workspace}-genesis-bootstrap"
+  name     = "${terraform.workspace}-genesis-bootstrap-${count.index + 1}"
   region   = var.region
   size     = var.peer_cache_droplet_size
   ssh_keys = var.droplet_ssh_keys

--- a/resources/terraform/testnet/digital-ocean/variables.tf
+++ b/resources/terraform/testnet/digital-ocean/variables.tf
@@ -73,8 +73,8 @@ variable "region" {
 }
 
 variable "genesis_vm_count" {
-  default     = 1
-  description = "Set to 1 or 0 to control whether there is a genesis node"
+  default     = 5
+  description = "The number of genesis droplets to launch"
 }
 
 variable "peer_cache_node_vm_count" {

--- a/src/ansible/extra_vars.rs
+++ b/src/ansible/extra_vars.rs
@@ -62,6 +62,12 @@ impl ExtraVarsDocBuilder {
         self
     }
 
+    pub fn add_list_variable_as_csv(&mut self, name: &str, values: Vec<String>) -> &mut Self {
+        let joined_values = values.join(",");
+        self.add_variable(name, &joined_values);
+        self
+    }
+
     /// Add a serde value to the extra vars map. This is useful if you have a complex type.
     pub fn add_serde_value(&mut self, name: &str, value: Value) {
         self.map.insert(name.to_owned(), value);
@@ -304,8 +310,8 @@ pub fn build_node_extra_vars_doc(
     cloud_provider: &str,
     options: &ProvisionOptions,
     node_type: NodeType,
-    genesis_multiaddr: Option<String>,
-    network_contacts_url: Option<String>,
+    genesis_multiaddrs: Vec<String>,
+    network_contacts_urls: Vec<String>,
     node_instance_count: u16,
     evm_network: EvmNetwork,
 ) -> Result<String> {
@@ -313,11 +319,11 @@ pub fn build_node_extra_vars_doc(
     extra_vars.add_variable("provider", cloud_provider);
     extra_vars.add_variable("testnet_name", &options.name);
     extra_vars.add_variable("node_type", node_type.telegraf_role());
-    if let Some(genesis_multiaddr) = genesis_multiaddr {
-        extra_vars.add_variable("genesis_multiaddr", &genesis_multiaddr);
+    if !genesis_multiaddrs.is_empty() {
+        extra_vars.add_list_variable_as_csv("genesis_multiaddr", genesis_multiaddrs);
     }
-    if let Some(network_contacts_url) = network_contacts_url {
-        extra_vars.add_variable("network_contacts_url", &network_contacts_url);
+    if !network_contacts_urls.is_empty() {
+        extra_vars.add_list_variable_as_csv("network_contacts_url", network_contacts_urls);
     }
 
     extra_vars.add_variable("node_instance_count", &node_instance_count.to_string());
@@ -466,17 +472,17 @@ pub fn build_symmetric_private_node_config_extra_vars_doc(
 pub fn build_downloaders_extra_vars_doc(
     cloud_provider: &str,
     options: &ProvisionOptions,
-    peer: Option<String>,
-    network_contacts_url: Option<String>,
+    peers: Vec<String>,
+    network_contacts_urls: Vec<String>,
 ) -> Result<String> {
     let mut extra_vars: ExtraVarsDocBuilder = ExtraVarsDocBuilder::default();
     extra_vars.add_variable("provider", cloud_provider);
     extra_vars.add_variable("testnet_name", &options.name);
-    if let Some(peer) = peer {
-        extra_vars.add_variable("peer", &peer);
+    if !peers.is_empty() {
+        extra_vars.add_list_variable_as_csv("peer", peers);
     }
-    if let Some(network_contacts_url) = network_contacts_url {
-        extra_vars.add_variable("network_contacts_url", &network_contacts_url);
+    if !network_contacts_urls.is_empty() {
+        extra_vars.add_list_variable_as_csv("network_contacts_url", network_contacts_urls);
     }
 
     extra_vars.add_boolean_variable("enable_download_verifier", options.enable_download_verifier);
@@ -516,18 +522,18 @@ pub fn build_downloaders_extra_vars_doc(
 pub fn build_clients_extra_vars_doc(
     cloud_provider: &str,
     options: &ProvisionOptions,
-    peer: Option<String>,
-    network_contacts_url: Option<String>,
+    peers: Vec<String>,
+    network_contacts_urls: Vec<String>,
     sk_map: &HashMap<VirtualMachine, Vec<PrivateKeySigner>>,
 ) -> Result<String> {
     let mut extra_vars = ExtraVarsDocBuilder::default();
     extra_vars.add_variable("provider", cloud_provider);
     extra_vars.add_variable("testnet_name", &options.name);
-    if let Some(peer) = peer {
-        extra_vars.add_variable("peer", &peer);
+    if !peers.is_empty() {
+        extra_vars.add_list_variable_as_csv("peer", peers);
     }
-    if let Some(network_contacts_url) = network_contacts_url {
-        extra_vars.add_variable("network_contacts_url", &network_contacts_url);
+    if !network_contacts_urls.is_empty() {
+        extra_vars.add_list_variable_as_csv("network_contacts_url", network_contacts_urls);
     }
 
     extra_vars.add_ant_url_or_version(

--- a/src/ansible/extra_vars.rs
+++ b/src/ansible/extra_vars.rs
@@ -345,19 +345,6 @@ pub fn build_node_extra_vars_doc(
         extra_vars.add_variable("public_rpc", "true");
     }
 
-    match node_type {
-        NodeType::FullConePrivateNode => {
-            // Full cone private nodes do not need relay as it is a straight port forward.
-            extra_vars.add_variable("private_ip", "true");
-        }
-        NodeType::SymmetricPrivateNode => {
-            // Symmetric private nodes need relay and private ip.
-            extra_vars.add_variable("private_ip", "true");
-            extra_vars.add_variable("relay", "true");
-        }
-        _ => {}
-    }
-
     if let Some(network_id) = options.network_id {
         extra_vars.add_variable("network_id", &network_id.to_string());
     }

--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -602,8 +602,8 @@ impl AnsibleProvisioner {
                 &self.cloud_provider.to_string(),
                 options,
                 NodeType::Genesis,
-                None,
-                None,
+                vec![],
+                vec![],
                 1,
                 options.evm_network.clone(),
             )?),
@@ -617,8 +617,8 @@ impl AnsibleProvisioner {
     pub fn provision_full_cone(
         &self,
         options: &ProvisionOptions,
-        initial_contact_peer: Option<String>,
-        initial_network_contacts_url: Option<String>,
+        initial_contact_peers: Vec<String>,
+        initial_network_contacts_urls: Vec<String>,
         private_node_inventory: PrivateNodeProvisionInventory,
         new_full_cone_nat_gateway_new_vms_for_upscale: Option<Vec<VirtualMachine>>,
     ) -> Result<()> {
@@ -816,8 +816,8 @@ impl AnsibleProvisioner {
 
         self.provision_nodes(
             options,
-            initial_contact_peer,
-            initial_network_contacts_url,
+            initial_contact_peers,
+            initial_network_contacts_urls,
             NodeType::FullConePrivateNode,
         )?;
 
@@ -878,8 +878,8 @@ impl AnsibleProvisioner {
     pub fn provision_nodes(
         &self,
         options: &ProvisionOptions,
-        initial_contact_peer: Option<String>,
-        initial_network_contacts_url: Option<String>,
+        initial_contact_peers: Vec<String>,
+        initial_network_contacts_urls: Vec<String>,
         node_type: NodeType,
     ) -> Result<()> {
         let start = Instant::now();
@@ -937,8 +937,8 @@ impl AnsibleProvisioner {
                 &self.cloud_provider.to_string(),
                 options,
                 node_type.clone(),
-                initial_contact_peer,
-                initial_network_contacts_url,
+                initial_contact_peers,
+                initial_network_contacts_urls,
                 node_count,
                 options.evm_network.clone(),
             )?),
@@ -951,8 +951,8 @@ impl AnsibleProvisioner {
     pub fn provision_symmetric_private_nodes(
         &self,
         options: &mut ProvisionOptions,
-        initial_contact_peer: Option<String>,
-        initial_network_contacts_url: Option<String>,
+        initial_contact_peers: Vec<String>,
+        initial_network_contacts_urls: Vec<String>,
         private_node_inventory: &PrivateNodeProvisionInventory,
     ) -> Result<()> {
         let start = Instant::now();
@@ -1013,8 +1013,8 @@ impl AnsibleProvisioner {
 
         self.provision_nodes(
             options,
-            initial_contact_peer,
-            initial_network_contacts_url,
+            initial_contact_peers,
+            initial_network_contacts_urls,
             NodeType::SymmetricPrivateNode,
         )?;
 
@@ -1024,8 +1024,8 @@ impl AnsibleProvisioner {
     pub async fn provision_downloaders(
         &self,
         options: &ProvisionOptions,
-        genesis_multiaddr: Option<String>,
-        genesis_network_contacts_url: Option<String>,
+        genesis_multiaddrs: Vec<String>,
+        genesis_network_contacts_urls: Vec<String>,
     ) -> Result<()> {
         let start = Instant::now();
 
@@ -1038,8 +1038,8 @@ impl AnsibleProvisioner {
             Some(extra_vars::build_downloaders_extra_vars_doc(
                 &self.cloud_provider.to_string(),
                 options,
-                genesis_multiaddr,
-                genesis_network_contacts_url,
+                genesis_multiaddrs,
+                genesis_network_contacts_urls,
             )?),
         )?;
         print_duration(start.elapsed());
@@ -1049,8 +1049,8 @@ impl AnsibleProvisioner {
     pub async fn provision_clients(
         &self,
         options: &ProvisionOptions,
-        genesis_multiaddr: Option<String>,
-        genesis_network_contacts_url: Option<String>,
+        genesis_multiaddrs: Vec<String>,
+        genesis_network_contacts_urls: Vec<String>,
     ) -> Result<()> {
         let start = Instant::now();
 
@@ -1076,8 +1076,8 @@ impl AnsibleProvisioner {
             Some(extra_vars::build_clients_extra_vars_doc(
                 &self.cloud_provider.to_string(),
                 options,
-                genesis_multiaddr,
-                genesis_network_contacts_url,
+                genesis_multiaddrs,
+                genesis_network_contacts_urls,
                 &sk_map,
             )?),
         )?;

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -133,8 +133,8 @@ impl TestnetDeployer {
             .print_ansible_run_banner("Provision Normal Nodes");
         match self.ansible_provisioner.provision_nodes(
             &provision_options,
-            options.peer.clone(),
-            options.network_contacts_url.clone(),
+            options.peer.iter().cloned().collect(),
+            options.network_contacts_url.iter().cloned().collect(),
             NodeType::Generic,
         ) {
             Ok(()) => {
@@ -155,8 +155,8 @@ impl TestnetDeployer {
         if private_node_inventory.should_provision_full_cone_private_nodes() {
             match self.ansible_provisioner.provision_full_cone(
                 &provision_options,
-                options.peer.clone(),
-                options.network_contacts_url.clone(),
+                options.peer.iter().cloned().collect(),
+                options.network_contacts_url.iter().cloned().collect(),
                 private_node_inventory.clone(),
                 None,
             ) {
@@ -184,8 +184,8 @@ impl TestnetDeployer {
                 .print_ansible_run_banner("Provision Symmetric Private Nodes");
             match self.ansible_provisioner.provision_symmetric_private_nodes(
                 &mut provision_options,
-                options.peer.clone(),
-                options.network_contacts_url.clone(),
+                options.peer.iter().cloned().collect(),
+                options.network_contacts_url.iter().cloned().collect(),
                 &private_node_inventory,
             ) {
                 Ok(()) => {

--- a/src/clients.rs
+++ b/src/clients.rs
@@ -378,8 +378,8 @@ impl ClientsDeployer {
         self.ansible_provisioner
             .provision_clients(
                 &provision_options,
-                options.peer.clone(),
-                options.network_contacts_url.clone(),
+                options.peer.iter().cloned().collect(),
+                options.network_contacts_url.iter().cloned().collect(),
             )
             .await
             .map_err(|err| {
@@ -392,8 +392,8 @@ impl ClientsDeployer {
         self.ansible_provisioner
             .provision_downloaders(
                 &provision_options,
-                options.peer.clone(),
-                options.network_contacts_url.clone(),
+                options.peer.iter().cloned().collect(),
+                options.network_contacts_url.iter().cloned().collect(),
             )
             .await
             .map_err(|err| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,13 +44,13 @@ use flate2::read::GzDecoder;
 use indicatif::{ProgressBar, ProgressStyle};
 use infra::{build_terraform_args, InfraRunOptions};
 use log::{debug, trace};
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{
     fs::File,
     io::{BufRead, BufReader, BufWriter, Write},
-    net::IpAddr,
     path::{Path, PathBuf},
     process::{Command, Stdio},
     str::FromStr,
@@ -1026,17 +1026,19 @@ impl TestnetDeployer {
 // Shared Helpers
 //
 
+/// Returns the list of genesis node multiaddresses and the machines
 pub fn get_genesis_multiaddr(
     ansible_runner: &AnsibleRunner,
     ssh_client: &SshClient,
-) -> Result<(String, IpAddr)> {
+) -> Result<(Vec<String>, Vec<VirtualMachine>)> {
     let genesis_inventory = ansible_runner.get_inventory(AnsibleInventoryType::Genesis, true)?;
-    let genesis_ip = genesis_inventory[0].public_ip_addr;
 
-    // It's possible for the genesis host to be altered from its original state where a node was
+    let addrs = genesis_inventory.par_iter().map(|vm| {
+        let genesis_ip = vm.public_ip_addr;
+         // It's possible for the genesis host to be altered from its original state where a node was
     // started with the `--first` flag.
     // First attempt: try to find node with first=true
-    let multiaddr = ssh_client
+        let multiaddr = ssh_client
         .run_command(
             &genesis_ip,
             "root",
@@ -1050,8 +1052,8 @@ pub fn get_genesis_multiaddr(
         });
 
     // Second attempt: if first attempt failed, see if any node is available.
-    let multiaddr = match multiaddr {
-        Some(addr) => addr,
+   match multiaddr {
+        Some(addr) => Ok(addr),
         None => ssh_client
             .run_command(
                 &genesis_ip,
@@ -1061,10 +1063,10 @@ pub fn get_genesis_multiaddr(
             )?
             .first()
             .cloned()
-            .ok_or_else(|| Error::GenesisListenAddress)?,
-    };
+            .ok_or_else(|| Error::GenesisListenAddress)
+    }}).collect::<Result<Vec<_>>>()?;
 
-    Ok((multiaddr, genesis_ip))
+    Ok((addrs, genesis_inventory))
 }
 
 pub fn get_anvil_node_data(
@@ -1123,22 +1125,24 @@ pub fn get_anvil_node_data(
 pub fn get_multiaddr(
     ansible_runner: &AnsibleRunner,
     ssh_client: &SshClient,
-) -> Result<(String, IpAddr)> {
+) -> Result<(Vec<String>, Vec<VirtualMachine>)> {
     let node_inventory = ansible_runner.get_inventory(AnsibleInventoryType::Nodes, true)?;
     // For upscaling a bootstrap deployment, we'd need to select one of the nodes that's already
     // provisioned. So just try the first one.
-    let node_ip = node_inventory
-        .iter()
+    let node_vm = node_inventory
+        .into_iter()
         .find(|vm| vm.name.ends_with("-node-1"))
-        .ok_or_else(|| Error::NodeAddressNotFound)?
-        .public_ip_addr;
+        .ok_or_else(|| Error::NodeAddressNotFound)?;
 
-    debug!("Getting multiaddr from node {node_ip}");
+    debug!(
+        "Getting multiaddr from node-1 with ip: {}",
+        node_vm.public_ip_addr
+    );
 
     let multiaddr =
         ssh_client
         .run_command(
-            &node_ip,
+            &node_vm.public_ip_addr,
             "root",
             // fetch the first multiaddr which does not contain the localhost addr.
             "jq -r '.nodes[] | .listen_addr[] | select(contains(\"127.0.0.1\") | not)' /var/antctl/node_registry.json | head -n 1",
@@ -1149,7 +1153,7 @@ pub fn get_multiaddr(
 
     // The node_ip is obviously inside the multiaddr, but it's just being returned as a
     // separate item for convenience.
-    Ok((multiaddr, node_ip))
+    Ok((vec![multiaddr], vec![node_vm]))
 }
 
 pub async fn get_and_extract_archive_from_s3(
@@ -1451,6 +1455,8 @@ pub fn calculate_size_per_attached_volume(node_count: u16) -> u16 {
     (total_volume_required as f64 / 7.0).ceil() as u16
 }
 
-pub fn get_bootstrap_cache_url(ip_addr: &IpAddr) -> String {
-    format!("http://{ip_addr}/bootstrap_cache.json")
+pub fn get_bootstrap_cache_url(vms: &[VirtualMachine]) -> Vec<String> {
+    vms.iter()
+        .map(|vm| format!("http://{}/bootstrap_cache.json", vm.public_ip_addr))
+        .collect()
 }


### PR DESCRIPTION
- We now spin up 5 genesis VM with `--first`. This is used to make sure that the reachability check can run on the other VMs.
- Removes the other network flag and instead uses `--reachability-check` for all kinds of nodes.