### PR TITLE
fix: client provisioning is now idempotent

### DIFF
--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -335,34 +335,32 @@ impl TestnetDeployer {
             }
         }
 
-        if options.current_inventory.is_empty() {
-            self.ansible_provisioner
-                .print_ansible_run_banner("Provision Clients");
-            self.ansible_provisioner
-                .provision_clients(
-                    &provision_options,
-                    Some(genesis_multiaddr.clone()),
-                    Some(genesis_network_contacts.clone()),
-                )
-                .await
-                .map_err(|err| {
-                    println!("Failed to provision Clients {err:?}");
-                    err
-                })?;
-            self.ansible_provisioner
-                .print_ansible_run_banner("Provision Downloaders");
-            self.ansible_provisioner
-                .provision_downloaders(
-                    &provision_options,
-                    Some(genesis_multiaddr.clone()),
-                    Some(genesis_network_contacts.clone()),
-                )
-                .await
-                .map_err(|err| {
-                    println!("Failed to provision downloaders {err:?}");
-                    err
-                })?;
-        }
+        self.ansible_provisioner
+            .print_ansible_run_banner("Provision Clients");
+        self.ansible_provisioner
+            .provision_clients(
+                &provision_options,
+                Some(genesis_multiaddr.clone()),
+                Some(genesis_network_contacts.clone()),
+            )
+            .await
+            .map_err(|err| {
+                println!("Failed to provision Clients {err:?}");
+                err
+            })?;
+        self.ansible_provisioner
+            .print_ansible_run_banner("Provision Downloaders");
+        self.ansible_provisioner
+            .provision_downloaders(
+                &provision_options,
+                Some(genesis_multiaddr.clone()),
+                Some(genesis_network_contacts.clone()),
+            )
+            .await
+            .map_err(|err| {
+                println!("Failed to provision downloaders {err:?}");
+                err
+            })?;
 
         if node_provision_failed {
             println!();


### PR DESCRIPTION
- Running `deploy` cmd on a failed deployment would not provision client vms. This should fix that now.