### PR TITLE
chore: relax determination of empty inventory

### DIFF
--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -930,7 +930,7 @@ impl DeploymentInventory {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.peer_cache_node_vms.is_empty() && self.node_vms.is_empty()
+        self.genesis_vm.is_none()
     }
 
     pub fn vm_list(&self) -> Vec<VirtualMachine> {


### PR DESCRIPTION
The previous check for an empty inventory was that there were at least some nodes on generic and peer-cache hosts.

However, now we have certain test configurations where we don't want any nodes on generic or peer-cache hosts, so we'll just check for the existence of a genesis node.