### PR TITLE
feat: downloaders log to external disk

### DIFF
--- a/resources/ansible/roles/downloaders/defaults/main.yml
+++ b/resources/ansible/roles/downloaders/defaults/main.yml
@@ -1,0 +1,1 @@
+log_output_dest: /mnt/client-logs/log/downloads

--- a/resources/ansible/roles/downloaders/tasks/main.yml
+++ b/resources/ansible/roles/downloaders/tasks/main.yml
@@ -45,6 +45,15 @@
   become: true
   when: enable_performance_verifier | bool
 
+- name: ensure the ant users can write to the log output destination
+  ansible.builtin.file:
+    path: "{{ log_output_dest }}"
+    state: directory
+    mode: '0775'
+    owner: root
+    group: ant
+  become: true
+
 - name: Check if systemd ant_download_random_verifier service file exists
   ansible.builtin.stat:
     path: "/etc/systemd/system/ant_download_random_verifier.service"

--- a/resources/ansible/roles/downloaders/templates/ant_downloader.sh.j2
+++ b/resources/ansible/roles/downloaders/templates/ant_downloader.sh.j2
@@ -11,6 +11,7 @@
 #   -h, --expected-hash: Required if file-address is provided - expected SHA256 hash of the file
 #   -s, --expected-size: Required if file-address is provided - expected size of the file in KB
 
+LOG_OUTPUT_DEST="{{ log_output_dest }}"
 MODE=""
 CONTACT_PEER=""
 NETWORK_CONTACTS_URL=""
@@ -274,9 +275,13 @@ download_file() {
     if [[ "$MODE" == "verifier" ]]; then
       QUORUM_ARG="--quorum majority"
     fi
+
+    timestamp=$(date +"%Y%m%d_%H%M%S")
+    log_file_path="${LOG_OUTPUT_DEST}/${timestamp}"
+    LOG_OUTPUT_ARG="--log-output-dest $log_file_path"
     
     start_time=$(date +%s%N)
-    stdout=$(ant $CONTACT_PEER_ARG $NETWORK_CONTACTS_URL_ARG $NETWORK_ID_ARG file download "$file_ref" "$download_path" $QUORUM_ARG 2>&1)
+    stdout=$(ant $CONTACT_PEER_ARG $NETWORK_CONTACTS_URL_ARG $NETWORK_ID_ARG $LOG_OUTPUT_ARG file download "$file_ref" "$download_path" $QUORUM_ARG 2>&1)
     exit_code=$?
     end_time=$(date +%s%N)
     echo "$stdout"

--- a/resources/ansible/roles/uploaders/defaults/main.yml
+++ b/resources/ansible/roles/uploaders/defaults/main.yml
@@ -1,5 +1,5 @@
 binary_dir: /usr/local/bin
 ant_archive_filename: ant-latest-x86_64-unknown-linux-musl.tar.gz
 ant_archive_url: https://autonomi-cli.s3.eu-west-2.amazonaws.com/{{ autonomi_archive_filename }}
-log_output_dest: /mnt/client-logs/log
+log_output_dest: /mnt/client-logs/log/uploads
 enable_uploaders: true


### PR DESCRIPTION
The new CLN branch seems to have much more verbose logging, which caused the disks to fill up on the client machines, since the downloaders were never setup to log to the alternate locations.

We can address the logging output, but in principle it's just good for the logs for the downloaders to also go to the external disk.