### PR TITLE
fix: determine empty inventory for bootstrap deployment

### DIFF
--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -930,6 +930,9 @@ impl DeploymentInventory {
     }
 
     pub fn is_empty(&self) -> bool {
+        if self.environment_details.deployment_type == DeploymentType::Bootstrap {
+            return self.node_vms.is_empty();
+        }
         self.genesis_vm.is_none()
     }
 


### PR DESCRIPTION
The bootstrap deployment is not going to have a genesis node to work with, so we can use generic node hosts in this case.