### PR TITLE
fix: bring client upgrade playbook up to speed

### DIFF
--- a/resources/ansible/upgrade_clients.yml
+++ b/resources/ansible/upgrade_clients.yml
@@ -4,6 +4,7 @@
   become: True
   vars:
     ant_archive_url: "https://autonomi-cli.s3.eu-west-2.amazonaws.com/ant-{{ ant_version }}-x86_64-unknown-linux-musl.tar.gz"
+    log_output_dest: /mnt/client-logs/log/uploads
   tasks:
     - name: get list of ant users
       ansible.builtin.shell: "getent passwd | grep '^ant[0-9]\\+:' | cut -d: -f1"
@@ -50,10 +51,10 @@
 
     - name: copy ant_random_uploader.sh to remote for each ant user
       ansible.builtin.template:
-        src: roles/uploaders/templates/ant_random_uploader.sh
+        src: roles/uploaders/templates/ant_random_uploader.sh.j2
         dest: "/home/ant{{ item | regex_replace('ant([0-9]+)', '\\1') }}/ant_random_uploader.sh"
         owner: "ant{{ item | regex_replace('ant([0-9]+)', '\\1') }}"
-        group: "ant{{ item | regex_replace('ant([0-9]+)', '\\1') }}"
+        group: "ant"
         mode: '0744'
       become_user: "ant{{ item | regex_replace('ant([0-9]+)', '\\1') }}"
       loop: "{{ ant_users.stdout_lines }}"


### PR DESCRIPTION
The client upgrade playbook was missing several things since the uploader configuration had moved on a bit.