### PR TITLE
chore: reduce file references in service log

### DIFF
--- a/resources/ansible/roles/downloaders/templates/ant_downloader.sh.j2
+++ b/resources/ansible/roles/downloaders/templates/ant_downloader.sh.j2
@@ -269,7 +269,6 @@ download_file() {
   local download_filename=$(uuidgen)
   (
     download_path="$DOWNLOAD_DIR/$download_filename"
-    echo "Downloading file: $file_ref" 
     
     QUORUM_ARG=""
     if [[ "$MODE" == "verifier" ]]; then
@@ -324,7 +323,7 @@ download_file() {
     rm -rf "$download_path"
 
     if [[ $exit_code -eq 0 ]]; then
-      echo "✅ Successfully downloaded $file_ref"
+      echo "✅ File downloaded"
       success_file="$DOWNLOAD_METRICS_DIR/metrics_success.csv"
 
       if [[ ! -f "$success_file" ]]; then
@@ -332,7 +331,7 @@ download_file() {
       fi
       echo "$start_time,$end_time,$file_ref,$elapsed,0,0,0,$error_enum,$SERVICE_TYPE,$USER,1,$expected_file_size,$actual_file_size_kb,$actual_hash,$expected_hash,$package_version,$build_date" >> "$success_file"
     else
-      echo "❌ FAILED TO DOWNLOAD $file_ref"
+      echo "❌DOWNLOAD FAILED"
       echo "Error type: $error_enum"
       echo "Please check the logs above for more details."
       failure_file="$DOWNLOAD_METRICS_DIR/metrics_failure.csv"


### PR DESCRIPTION
The `ant` binary prints the file address on both successful and failed downloads, so we can have it printed once rather than three times. This will reduce a lot of noise in the service log.