### PR TITLE
chore: rebuild evm node and rust build images

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -140,3 +140,15 @@ build-lon1-images:
 
 build-ams3-images:
   just build-all-images ams3
+
+build-lon1-rust-build-image:
+  just build-rust-build-image lon1
+
+build-ams3-rust-build-image:
+  just build-rust-build-image ams3
+
+build-lon1-evm-node-image:
+  just build-evm-node-image lon1
+
+build-ams3-evm-node-image:
+  just build-evm-node-image ams3

--- a/resources/packer/build/build.pkr.hcl
+++ b/resources/packer/build/build.pkr.hcl
@@ -35,7 +35,7 @@ variable "size" {
 
 variable "snapshot_name" {
   type = string
-  default = "safe_network-build"
+  default = "autonomi-build"
   description = "The name of the snapshot that will be created"
 }
 

--- a/resources/terraform/testnet/digital-ocean/dev-images-ams3.tfvars
+++ b/resources/terraform/testnet/digital-ocean/dev-images-ams3.tfvars
@@ -1,6 +1,6 @@
 ant_client_droplet_image_id = 183015919
-build_droplet_image_id = 183012774
-evm_node_droplet_image_id = 183012794
+build_droplet_image_id = 192313965
+evm_node_droplet_image_id = 192327188
 nat_gateway_droplet_image_id = 183020839
 node_droplet_image_id = 183012825
 peer_cache_droplet_image_id = 183012811

--- a/resources/terraform/testnet/digital-ocean/dev-images-lon1.tfvars
+++ b/resources/terraform/testnet/digital-ocean/dev-images-lon1.tfvars
@@ -1,6 +1,6 @@
 ant_client_droplet_image_id = 172724146
-build_droplet_image_id = 172723670
-evm_node_droplet_image_id = 172723723
+build_droplet_image_id = 192313809
+evm_node_droplet_image_id = 192322493
 nat_gateway_droplet_image_id = 178052140
 node_droplet_image_id = 173265007
 peer_cache_droplet_image_id = 173264988

--- a/resources/terraform/testnet/digital-ocean/production-images-ams3.tfvars
+++ b/resources/terraform/testnet/digital-ocean/production-images-ams3.tfvars
@@ -1,6 +1,6 @@
 ant_client_droplet_image_id = 183015919
-build_droplet_image_id = 183012774
-evm_node_droplet_image_id = 183012794
+build_droplet_image_id = 192313965
+evm_node_droplet_image_id = 192327188
 nat_gateway_droplet_image_id = 183020839
 node_droplet_image_id = 183012825
 peer_cache_droplet_image_id = 183012811

--- a/resources/terraform/testnet/digital-ocean/production-images-lon1.tfvars
+++ b/resources/terraform/testnet/digital-ocean/production-images-lon1.tfvars
@@ -1,6 +1,6 @@
 ant_client_droplet_image_id = 172724146
-build_droplet_image_id = 172723670
-evm_node_droplet_image_id = 172723723
+build_droplet_image_id = 192313809
+evm_node_droplet_image_id = 192322493
 nat_gateway_droplet_image_id = 178052140
 node_droplet_image_id = 173265007
 peer_cache_droplet_image_id = 173264988

--- a/resources/terraform/testnet/digital-ocean/staging-images-ams3.tfvars
+++ b/resources/terraform/testnet/digital-ocean/staging-images-ams3.tfvars
@@ -1,6 +1,6 @@
 ant_client_droplet_image_id = 183015919
-build_droplet_image_id = 183012774
-evm_node_droplet_image_id = 183012794
+build_droplet_image_id = 192313965
+evm_node_droplet_image_id = 192327188
 nat_gateway_droplet_image_id = 183020839
 node_droplet_image_id = 183012825
 peer_cache_droplet_image_id = 183012811

--- a/resources/terraform/testnet/digital-ocean/staging-images-lon1.tfvars
+++ b/resources/terraform/testnet/digital-ocean/staging-images-lon1.tfvars
@@ -1,6 +1,6 @@
 ant_client_droplet_image_id = 172724146
-build_droplet_image_id = 172723670
-evm_node_droplet_image_id = 172723723
+build_droplet_image_id = 192313809
+evm_node_droplet_image_id = 192322493
 nat_gateway_droplet_image_id = 178052140
 node_droplet_image_id = 173265007
 peer_cache_droplet_image_id = 173264988


### PR DESCRIPTION
The autonomi code now required a newer version of Rust to build correctly.