### PR TITLE
chore: allow modifications on `autonomi` repo

### DIFF
--- a/resources/ansible/roles/build_safe_network_binary/tasks/main.yml
+++ b/resources/ansible/roles/build_safe_network_binary/tasks/main.yml
@@ -3,11 +3,16 @@
   set_fact:
     aws_secret_key: "{{ lookup('file', 'files/s3_deploy_secret_access_key') }}"
 
+# The force: true parameter will discard any local modifications and reset the repository to match
+# the specified branch/version on subsequent runs.
+# This can sometimes be necessary if there is a clumsy commit that will cause the `Cargo.lock` file
+# to be modified.
 - name: clone autonomi repo
   ansible.builtin.git:
     repo: https://github.com/{{ org }}/autonomi
     version: "{{ branch }}"
     dest: "{{ ansible_env.HOME }}/autonomi"
+    force: true
 
 # only enable safenode features
 - name: "build {{ bin_name }} binary"

--- a/src/ansible/extra_vars.rs
+++ b/src/ansible/extra_vars.rs
@@ -115,8 +115,7 @@ impl ExtraVarsDocBuilder {
                 self.add_branch_url_variable(
                     "antnode_rpc_client_archive_url",
                     &format!(
-                        "{}/{}/{}/antnode_rpc_client-{}-x86_64-unknown-linux-musl.tar.gz",
-                        BRANCH_S3_BUCKET_URL, repo_owner, branch, deployment_name
+                        "{BRANCH_S3_BUCKET_URL}/{repo_owner}/{branch}/antnode_rpc_client-{deployment_name}-x86_64-unknown-linux-musl.tar.gz"
                     ),
                     branch,
                     repo_owner,
@@ -126,8 +125,7 @@ impl ExtraVarsDocBuilder {
                 self.add_variable(
                     "antnode_rpc_client_archive_url",
                     &format!(
-                        "{}/antnode_rpc_client-latest-x86_64-unknown-linux-musl.tar.gz",
-                        RPC_CLIENT_BUCKET_URL
+                        "{RPC_CLIENT_BUCKET_URL}/antnode_rpc_client-latest-x86_64-unknown-linux-musl.tar.gz"
                     ),
                 );
             }
@@ -142,8 +140,7 @@ impl ExtraVarsDocBuilder {
                 self.add_branch_url_variable(
                     "node_archive_url",
                     &format!(
-                        "{}/{}/{}/antnode-{}-x86_64-unknown-linux-musl.tar.gz",
-                        BRANCH_S3_BUCKET_URL, repo_owner, branch, deployment_name
+                        "{BRANCH_S3_BUCKET_URL}/{repo_owner}/{branch}/antnode-{deployment_name}-x86_64-unknown-linux-musl.tar.gz"
                     ),
                     branch,
                     repo_owner,
@@ -167,8 +164,7 @@ impl ExtraVarsDocBuilder {
                 self.add_branch_url_variable(
                     "antctl_archive_url",
                     &format!(
-                        "{}/{}/{}/antctl-{}-x86_64-unknown-linux-musl.tar.gz",
-                        BRANCH_S3_BUCKET_URL, repo_owner, branch, deployment_name
+                        "{BRANCH_S3_BUCKET_URL}/{repo_owner}/{branch}/antctl-{deployment_name}-x86_64-unknown-linux-musl.tar.gz"
                     ),
                     branch,
                     repo_owner,
@@ -197,8 +193,7 @@ impl ExtraVarsDocBuilder {
                 self.add_branch_url_variable(
                     "antctld_archive_url",
                     &format!(
-                        "{}/{}/{}/antctld-{}-x86_64-unknown-linux-musl.tar.gz",
-                        BRANCH_S3_BUCKET_URL, repo_owner, branch, deployment_name
+                        "{BRANCH_S3_BUCKET_URL}/{repo_owner}/{branch}/antctld-{deployment_name}-x86_64-unknown-linux-musl.tar.gz"
                     ),
                     branch,
                     repo_owner,
@@ -231,10 +226,7 @@ impl ExtraVarsDocBuilder {
         if let Some(version) = ant_version {
             self.add_variable(
                 "ant_archive_url",
-                &format!(
-                    "{}/ant-{}-x86_64-unknown-linux-musl.tar.gz",
-                    ANT_S3_BUCKET_URL, version
-                ),
+                &format!("{ANT_S3_BUCKET_URL}/ant-{version}-x86_64-unknown-linux-musl.tar.gz"),
             );
             return Ok(());
         }
@@ -246,8 +238,7 @@ impl ExtraVarsDocBuilder {
                 self.add_branch_url_variable(
                     "ant_archive_url",
                     &format!(
-                        "{}/{}/{}/ant-{}-x86_64-unknown-linux-musl.tar.gz",
-                        BRANCH_S3_BUCKET_URL, repo_owner, branch, deployment_name
+                        "{BRANCH_S3_BUCKET_URL}/{repo_owner}/{branch}/ant-{deployment_name}-x86_64-unknown-linux-musl.tar.gz"
                     ),
                     branch,
                     repo_owner,
@@ -259,8 +250,7 @@ impl ExtraVarsDocBuilder {
                     self.add_variable(
                         "ant_archive_url",
                         &format!(
-                            "{}/ant-{}-x86_64-unknown-linux-musl.tar.gz",
-                            ANT_S3_BUCKET_URL, version
+                            "{ANT_S3_BUCKET_URL}/ant-{version}-x86_64-unknown-linux-musl.tar.gz"
                         ),
                     );
                     Ok(())

--- a/src/ansible/inventory.rs
+++ b/src/ansible/inventory.rs
@@ -83,7 +83,7 @@ impl std::fmt::Display for AnsibleInventoryType {
             AnsibleInventoryType::SymmetricPrivateNodes => "SymmetricPrivateNodes",
             AnsibleInventoryType::SymmetricPrivateNodesStatic => "SymmetricPrivateNodesStatic",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 
@@ -405,9 +405,9 @@ pub fn generate_symmetric_private_node_static_environment_inventory(
 
     for (privat_node_vm, nat_gateway_vm) in private_node_nat_gateway_map.iter() {
         let node_number = privat_node_vm.name.split('-').next_back().unwrap();
-        writeln!(file, "[symmetric_private_node_{}]", node_number)?;
+        writeln!(file, "[symmetric_private_node_{node_number}]")?;
         writeln!(file, "{}", privat_node_vm.private_ip_addr)?;
-        writeln!(file, "[symmetric_private_node_{}:vars]", node_number)?;
+        writeln!(file, "[symmetric_private_node_{node_number}:vars]")?;
         writeln!(
             file,
             "ansible_ssh_common_args='-o ProxyCommand=\"ssh -p 22 -W %h:%p -q root@{} -i \"{}\" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null\"'",
@@ -458,11 +458,11 @@ pub fn generate_full_cone_private_node_static_environment_inventory(
 
     for (privat_node_vm, nat_gateway_vm) in private_node_nat_gateway_map.iter() {
         let node_number = privat_node_vm.name.split('-').next_back().unwrap();
-        writeln!(file, "[full_cone_private_node_{}]", node_number)?;
+        writeln!(file, "[full_cone_private_node_{node_number}]")?;
 
         writeln!(file, "{}", privat_node_vm.private_ip_addr)?;
 
-        writeln!(file, "[full_cone_private_node_{}:vars]", node_number)?;
+        writeln!(file, "[full_cone_private_node_{node_number}:vars]")?;
         writeln!(
             file,
             "ansible_ssh_common_args='-o ProxyCommand=\"ssh -p 22 -W %h:%p -q root@{} -i \"{}\" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null\"'",

--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -642,10 +642,7 @@ impl AnsibleProvisioner {
             self.ssh_client
                 .wait_for_ssh_availability(&vm.public_ip_addr, &self.cloud_provider.get_ssh_user())
                 .map_err(|e| {
-                    println!(
-                        "Failed to establish SSH connection to Full Cone NAT Gateway: {}",
-                        e
-                    );
+                    println!("Failed to establish SSH connection to Full Cone NAT Gateway: {e}");
                     e
                 })?;
         }
@@ -801,7 +798,7 @@ impl AnsibleProvisioner {
         let home_dir = std::env::var("HOME").inspect_err(|err| {
             println!("Failed to get home directory with error: {err:?}",);
         })?;
-        let known_hosts_path = format!("{}/.ssh/known_hosts", home_dir);
+        let known_hosts_path = format!("{home_dir}/.ssh/known_hosts");
         debug!("Cleaning up known hosts file at {known_hosts_path} ");
         run_external_command(
             PathBuf::from("rm"),
@@ -842,10 +839,7 @@ impl AnsibleProvisioner {
             self.ssh_client
                 .wait_for_ssh_availability(&vm.public_ip_addr, &self.cloud_provider.get_ssh_user())
                 .map_err(|e| {
-                    println!(
-                        "Failed to establish SSH connection to Symmetric NAT Gateway: {}",
-                        e
-                    );
+                    println!("Failed to establish SSH connection to Symmetric NAT Gateway: {e}");
                     e
                 })?;
         }
@@ -1475,6 +1469,6 @@ impl AnsibleProvisioner {
     pub fn print_ansible_run_banner(&self, s: &str) {
         let ansible_run_msg = "Ansible Run: ";
         let line = "=".repeat(s.len() + ansible_run_msg.len());
-        println!("{}\n{}{}\n{}", line, ansible_run_msg, s, line);
+        println!("{line}\n{ansible_run_msg}{s}\n{line}");
     }
 }

--- a/src/cmd/clients.rs
+++ b/src/cmd/clients.rs
@@ -368,13 +368,13 @@ pub async fn handle_clients_command(cmd: ClientsCommands) -> Result<()> {
             Ok(())
         }
         ClientsCommands::Clean { name, provider } => {
-            println!("Cleaning Client environment '{}'...", name);
+            println!("Cleaning Client environment '{name}'...");
             let client_deployer = ClientsDeployBuilder::default()
                 .environment_name(&name)
                 .provider(provider)
                 .build()?;
             client_deployer.clean().await?;
-            println!("Client environment '{}' cleaned", name);
+            println!("Client environment '{name}' cleaned");
             Ok(())
         }
         ClientsCommands::Deploy {
@@ -547,7 +547,7 @@ pub async fn handle_clients_command(cmd: ClientsCommands) -> Result<()> {
 
             client_deployer.deploy(options).await?;
 
-            println!("Client deployment for '{}' completed successfully", name);
+            println!("Client deployment for '{name}' completed successfully");
             Ok(())
         }
         ClientsCommands::StartDownloaders { name, provider } => {
@@ -743,7 +743,7 @@ pub async fn handle_clients_command(cmd: ClientsCommands) -> Result<()> {
                     Ok(inv) => break inv,
                     Err(e) if retries < max_retries => {
                         retries += 1;
-                        eprintln!("Failed to generate inventory on attempt {retries}: {:?}", e);
+                        eprintln!("Failed to generate inventory on attempt {retries}: {e:?}");
                         eprintln!("Will retry up to {max_retries} times...");
                     }
                     Err(_) => {

--- a/src/cmd/deployments.rs
+++ b/src/cmd/deployments.rs
@@ -417,7 +417,7 @@ pub async fn handle_deploy(
             Ok(inv) => break inv,
             Err(e) if retries < max_retries => {
                 retries += 1;
-                eprintln!("Failed to generate inventory on attempt {retries}: {:?}", e);
+                eprintln!("Failed to generate inventory on attempt {retries}: {e:?}");
                 eprintln!("Will retry up to {max_retries} times...");
             }
             Err(_) => {
@@ -545,8 +545,8 @@ pub async fn handle_upscale(
                     .unwrap_or_else(|| existing_antctl_version.clone());
 
                 println!("The upscale will use the following override binary versions:");
-                println!("antnode: {}", new_antnode_version);
-                println!("antctl: {}", new_antctl_version);
+                println!("antnode: {new_antnode_version}");
+                println!("antctl: {new_antctl_version}");
 
                 inventory.binary_option = BinaryOption::Versioned {
                     ant_version: None,
@@ -612,7 +612,7 @@ pub async fn handle_upscale(
             Ok(inv) => break inv,
             Err(e) if retries < max_retries => {
                 retries += 1;
-                eprintln!("Failed to generate inventory on attempt {retries}: {:?}", e);
+                eprintln!("Failed to generate inventory on attempt {retries}: {e:?}");
                 eprintln!("Will retry up to {max_retries} times...");
             }
             Err(_) => {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1142,8 +1142,8 @@ pub enum OptionsType {
 impl OptionsType {
     fn file_name(&self, environment_name: &str) -> String {
         match self {
-            Self::Deploy => format!("{}-deploy.json", environment_name),
-            Self::Provision => format!("{}-provision.json", environment_name),
+            Self::Deploy => format!("{environment_name}-deploy.json"),
+            Self::Provision => format!("{environment_name}-provision.json"),
         }
     }
 }
@@ -1268,8 +1268,7 @@ async fn get_binary_option(
         let branch = branch.unwrap();
 
         print_with_banner(&format!(
-            "Binaries will be built from {}/{}",
-            repo_owner, branch
+            "Binaries will be built from {repo_owner}/{branch}"
         ));
 
         let url = format!("https://github.com/{repo_owner}/autonomi/tree/{branch}",);
@@ -1369,7 +1368,7 @@ pub fn parse_evm_network(s: &str) -> Result<EvmNetwork, String> {
         "arbitrum-one" => Ok(EvmNetwork::ArbitrumOne),
         "arbitrum-sepolia-test" => Ok(EvmNetwork::ArbitrumSepoliaTest),
         "custom" => Ok(EvmNetwork::Custom),
-        _ => Err(format!("Invalid EVM network type: {}", s)),
+        _ => Err(format!("Invalid EVM network type: {s}")),
     }
 }
 
@@ -1385,5 +1384,5 @@ pub fn parse_provider(val: &str) -> Result<CloudProvider> {
 
 fn print_with_banner(s: &str) {
     let banner = "=".repeat(s.len());
-    println!("{}\n{}\n{}", banner, s, banner);
+    println!("{banner}\n{s}\n{banner}");
 }

--- a/src/cmd/provision.rs
+++ b/src/cmd/provision.rs
@@ -138,7 +138,7 @@ async fn handle_provision_nodes(name: String, node_type: NodeType) -> Result<()>
             }
         }
         _ => {
-            provisioner.print_ansible_run_banner(&format!("Provision {} Nodes", node_type));
+            provisioner.print_ansible_run_banner(&format!("Provision {node_type} Nodes"));
             provisioner.provision_nodes(
                 &provision_options,
                 Some(genesis_multiaddr),

--- a/src/digital_ocean.rs
+++ b/src/digital_ocean.rs
@@ -47,8 +47,8 @@ impl DigitalOceanClient {
             } else if !response.status().is_success() {
                 let status_code = response.status().as_u16();
                 let response_body = response.text().await?;
-                debug!("Response status code: {}", status_code);
-                debug!("Error response body: {}", response_body);
+                debug!("Response status code: {status_code}");
+                debug!("Error response body: {response_body}");
                 return Err(Error::DigitalOceanUnexpectedResponse(
                     status_code,
                     response_body,

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -70,7 +70,7 @@ impl From<&TestnetDeployer> for DeploymentInventoryService {
                 .working_directory_path
                 .join("ansible")
                 .join("inventory")
-                .join(format!("dev_inventory_{}.yml", provider)),
+                .join(format!("dev_inventory_{provider}.yml")),
             s3_repository: item.s3_repository.clone(),
             ssh_client: item.ssh_client.clone(),
             terraform_runner: item.terraform_runner.clone(),
@@ -93,7 +93,7 @@ impl From<&ClientsDeployer> for DeploymentInventoryService {
                 .working_directory_path
                 .join("ansible")
                 .join("inventory")
-                .join(format!("dev_inventory_{}.yml", provider)),
+                .join(format!("dev_inventory_{provider}.yml")),
             s3_repository: item.s3_repository.clone(),
             ssh_client: item.ssh_client.clone(),
             terraform_runner: item.terraform_runner.clone(),
@@ -234,7 +234,10 @@ impl DeploymentInventoryService {
                     wallet_public_key: sks
                         .iter()
                         .enumerate()
-                        .map(|(user, sk)| (format!("safe{}", user + 1), sk.address().encode_hex()))
+                        .map(|(user, sk)| {
+                            let user_number = user + 1;
+                            (format!("safe{user_number}"), sk.address().encode_hex())
+                        })
                         .collect(),
                 })
                 .collect()
@@ -399,13 +402,13 @@ impl DeploymentInventoryService {
 
             println!("Retrieved binary versions from previous deployment:");
             if let Some(version) = &antnode_version {
-                println!("  antnode: {}", version);
+                println!("  antnode: {version}");
             }
             if let Some(version) = &antctl_version {
-                println!("  antctl: {}", version);
+                println!("  antctl: {version}");
             }
             if let Some(version) = &ant_version {
-                println!("  ant: {}", version);
+                println!("  ant: {version}");
             }
 
             BinaryOption::Versioned {
@@ -652,7 +655,10 @@ impl DeploymentInventoryService {
                 wallet_public_key: sks
                     .iter()
                     .enumerate()
-                    .map(|(user, sk)| (format!("safe{}", user + 1), sk.address().encode_hex()))
+                    .map(|(user, sk)| {
+                        let user_number = user + 1;
+                        (format!("safe{user_number}"), sk.address().encode_hex())
+                    })
                     .collect(),
             })
             .collect();
@@ -672,7 +678,7 @@ impl DeploymentInventoryService {
 
             println!("Retrieved binary versions from previous deployment:");
             if let Some(version) = &ant_version {
-                println!("  ant: {}", version);
+                println!("  ant: {version}");
             }
 
             BinaryOption::Versioned {
@@ -845,7 +851,7 @@ impl DeploymentNodeRegistries {
                 self.inventory_type
             );
             for vm_name in self.failed_vms.iter() {
-                println!("- {}", vm_name);
+                println!("- {vm_name}");
             }
         }
     }
@@ -866,9 +872,9 @@ impl DeploymentNodeRegistries {
         let total_width = text_width + border_chars;
         let top_bottom = "═".repeat(total_width);
 
-        println!("╔{}╗", top_bottom);
-        println!("║ {:^width$} ║", text, width = text_width);
-        println!("╚{}╝", top_bottom);
+        println!("╔{top_bottom}╗");
+        println!("║ {text:^text_width$} ║");
+        println!("╚{top_bottom}╝");
     }
 }
 
@@ -1572,7 +1578,7 @@ impl ClientsDeploymentInventory {
             println!("======================");
             println!("Funding Wallet Address");
             println!("======================");
-            println!("{}", funding_wallet_address);
+            println!("{funding_wallet_address}");
             println!();
         }
 
@@ -1580,7 +1586,7 @@ impl ClientsDeploymentInventory {
             println!("==========");
             println!("Network ID");
             println!("==========");
-            println!("{}", network_id);
+            println!("{network_id}");
             println!();
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ impl std::str::FromStr for DeploymentType {
             "bootstrap" => Ok(DeploymentType::Bootstrap),
             "clients" => Ok(DeploymentType::Client),
             "new" => Ok(DeploymentType::New),
-            _ => Err(format!("Invalid deployment type: {}", s)),
+            _ => Err(format!("Invalid deployment type: {s}")),
         }
     }
 }
@@ -133,7 +133,7 @@ impl std::str::FromStr for NodeType {
             "genesis" => Ok(NodeType::Genesis),
             "peer-cache" => Ok(NodeType::PeerCache),
             "symmetric-private" => Ok(NodeType::SymmetricPrivateNode),
-            _ => Err(format!("Invalid node type: {}", s)),
+            _ => Err(format!("Invalid node type: {s}")),
         }
     }
 }
@@ -189,7 +189,7 @@ impl std::str::FromStr for EvmNetwork {
             "arbitrum-one" => Ok(EvmNetwork::ArbitrumOne),
             "arbitrum-sepolia-test" => Ok(EvmNetwork::ArbitrumSepoliaTest),
             "custom" => Ok(EvmNetwork::Custom),
-            _ => Err(format!("Invalid EVM network type: {}", s)),
+            _ => Err(format!("Invalid EVM network type: {s}")),
         }
     }
 }
@@ -341,10 +341,10 @@ impl BinaryOption {
                 skip_binary_build: _,
             } => {
                 println!("Source configuration:");
-                println!("  Repository owner: {}", repo_owner);
-                println!("  Branch: {}", branch);
+                println!("  Repository owner: {repo_owner}");
+                println!("  Branch: {branch}");
                 if let Some(features) = antnode_features {
-                    println!("  Antnode features: {}", features);
+                    println!("  Antnode features: {features}");
                 }
             }
             BinaryOption::Versioned {
@@ -354,13 +354,13 @@ impl BinaryOption {
             } => {
                 println!("Versioned binaries configuration:");
                 if let Some(version) = ant_version {
-                    println!("  ant version: {}", version);
+                    println!("  ant version: {version}");
                 }
                 if let Some(version) = antctl_version {
-                    println!("  antctl version: {}", version);
+                    println!("  antctl version: {version}");
                 }
                 if let Some(version) = antnode_version {
-                    println!("  antnode version: {}", version);
+                    println!("  antnode version: {version}");
                 }
             }
         }
@@ -877,11 +877,11 @@ impl TestnetDeployer {
             },
             full_cone_private_nodes
         );
-        println!("Total nodes: {}", total_nodes);
-        println!("Running nodes: {}", running_nodes);
-        println!("Stopped nodes: {}", stopped_nodes);
-        println!("Added nodes: {}", added_nodes);
-        println!("Removed nodes: {}", removed_nodes);
+        println!("Total nodes: {total_nodes}");
+        println!("Running nodes: {running_nodes}");
+        println!("Stopped nodes: {stopped_nodes}");
+        println!("Added nodes: {added_nodes}");
+        println!("Removed nodes: {removed_nodes}");
 
         Ok(())
     }
@@ -1097,7 +1097,7 @@ pub fn get_anvil_node_data(
     const RETRY_DELAY: Duration = Duration::from_secs(5);
 
     for attempt in 1..=MAX_ATTEMPTS {
-        match ssh_client.run_command(&evm_ip, "ant", &format!("cat {}", csv_file_path), false) {
+        match ssh_client.run_command(&evm_ip, "ant", &format!("cat {csv_file_path}"), false) {
             Ok(output) => {
                 if let Some(csv_contents) = output.first() {
                     let parts: Vec<&str> = csv_contents.split(',').collect();
@@ -1293,8 +1293,8 @@ pub async fn notify_slack(inventory: DeploymentInventory) -> Result<()> {
             ..
         } => {
             message.push_str("*Branch Details*\n");
-            message.push_str(&format!("Repo owner: {}\n", repo_owner));
-            message.push_str(&format!("Branch: {}\n", branch));
+            message.push_str(&format!("Repo owner: {repo_owner}\n"));
+            message.push_str(&format!("Branch: {branch}\n"));
         }
         BinaryOption::Versioned {
             ant_version: ref safe_version,
@@ -1333,7 +1333,7 @@ pub async fn notify_slack(inventory: DeploymentInventory) -> Result<()> {
     message.push_str("*Available Files*\n");
     message.push_str("```\n");
     for (addr, file_name) in inventory.uploaded_files.iter() {
-        message.push_str(&format!("{}: {}\n", addr, file_name))
+        message.push_str(&format!("{addr}: {file_name}\n"))
     }
     message.push_str("```\n");
 
@@ -1354,7 +1354,7 @@ fn print_duration(duration: Duration) {
     let total_seconds = duration.as_secs();
     let minutes = total_seconds / 60;
     let seconds = total_seconds % 60;
-    debug!("Time taken: {} minutes and {} seconds", minutes, seconds);
+    debug!("Time taken: {minutes} minutes and {seconds} seconds");
 }
 
 pub fn get_progress_bar(length: u64) -> Result<ProgressBar> {
@@ -1399,7 +1399,7 @@ pub async fn get_environment_details(
                         }
                     }
                 };
-                trace!("Content of the environment details file: {}", content);
+                trace!("Content of the environment details file: {content}");
 
                 match serde_json::from_str(&content) {
                     Ok(environment_details) => break environment_details,

--- a/src/logs.rs
+++ b/src/logs.rs
@@ -393,7 +393,7 @@ impl TestnetDeployer {
         writeln!(file, "Command: {cmd}")?;
 
         for line in output {
-            writeln!(file, "{}", line)?;
+            writeln!(file, "{line}")?;
         }
 
         Ok(())

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -29,7 +29,7 @@ impl S3Repository {
             .to_str()
             .ok_or_else(|| Error::FilenameNotRetrieved)?;
 
-        println!("Uploading {} to bucket {}", object_key, bucket_name);
+        println!("Uploading {object_key} to bucket {bucket_name}");
 
         let mut file = tokio::fs::File::open(file_path).await?;
         let mut contents = Vec::new();
@@ -47,7 +47,7 @@ impl S3Repository {
             Error::PutS3ObjectError(object_key.to_string(), bucket_name.to_string())
         })?;
 
-        println!("{} has been uploaded to {}", object_key, bucket_name);
+        println!("{object_key} has been uploaded to {bucket_name}");
         Ok(())
     }
 
@@ -101,7 +101,7 @@ impl S3Repository {
         let prefix = if folder_path.ends_with('/') {
             folder_path.to_string()
         } else {
-            format!("{}/", folder_path)
+            format!("{folder_path}/")
         };
         let output = client
             .list_objects_v2()

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -86,27 +86,17 @@ pub fn setup_dotenv_file() -> Result<()> {
 
     let contents = format!(
         r#"
-ANSIBLE_VAULT_PASSWORD_PATH={}
-AWS_ACCESS_KEY_ID={}
-AWS_SECRET_ACCESS_KEY={}
-AWS_DEFAULT_REGION={}
-DO_PAT={}
-SSH_KEY_PATH={}
-SLACK_WEBHOOK_URL={}
-SN_TESTNET_DEV_SUBNET_ID={}
-SN_TESTNET_DEV_SECURITY_GROUP_ID={}
-TERRAFORM_STATE_BUCKET_NAME={}
-"#,
-        ansible_vault_password_path,
-        aws_access_key_id,
-        aws_access_secret_access_key,
-        aws_region,
-        digital_ocean_pat,
-        ssh_key_path,
-        slack_webhook_url,
-        sn_testnet_dev_subnet_id,
-        sn_testnet_dev_security_group_id,
-        terraform_state_bucket_name
+ANSIBLE_VAULT_PASSWORD_PATH={ansible_vault_password_path}
+AWS_ACCESS_KEY_ID={aws_access_key_id}
+AWS_SECRET_ACCESS_KEY={aws_access_secret_access_key}
+AWS_DEFAULT_REGION={aws_region}
+DO_PAT={digital_ocean_pat}
+SSH_KEY_PATH={ssh_key_path}
+SLACK_WEBHOOK_URL={slack_webhook_url}
+SN_TESTNET_DEV_SUBNET_ID={sn_testnet_dev_subnet_id}
+SN_TESTNET_DEV_SECURITY_GROUP_ID={sn_testnet_dev_security_group_id}
+TERRAFORM_STATE_BUCKET_NAME={terraform_state_bucket_name}
+"#
     );
 
     std::fs::write(".env", contents.trim())?;

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -291,10 +291,7 @@ impl SshClient {
             );
             args.push(format!("{user}@{gateway}"));
         } else {
-            debug!(
-                "Running command '{}' on {}@{}...",
-                command, user, ip_address
-            );
+            debug!("Running command '{command}' on {user}@{ip_address}...");
             args.push(format!("{user}@{ip_address}"));
         }
         args.extend(command_args);

--- a/src/terraform.rs
+++ b/src/terraform.rs
@@ -50,7 +50,7 @@ impl TerraformRunner {
         let mut args = vec!["apply".to_string(), "-auto-approve".to_string()];
         if let Some(filenames) = tfvars_filenames {
             for filename in filenames {
-                args.push(format!("-var-file={}", filename));
+                args.push(format!("-var-file={filename}"));
             }
         }
         for var in vars.iter() {
@@ -75,7 +75,7 @@ impl TerraformRunner {
         let mut args = vec!["plan".to_string()];
         if let Some(filenames) = tfvars_filenames {
             for filename in filenames {
-                args.push(format!("-var-file={}", filename));
+                args.push(format!("-var-file={filename}"));
             }
         }
         if let Some(vars) = vars {
@@ -102,7 +102,7 @@ impl TerraformRunner {
         let mut args = vec!["destroy".to_string(), "-auto-approve".to_string()];
         if let Some(filenames) = tfvars_filenames {
             for filename in filenames {
-                args.push(format!("-var-file={}", filename));
+                args.push(format!("-var-file={filename}"));
             }
         }
         if let Some(vars) = vars {


### PR DESCRIPTION
There can sometimes be files (like `Cargo.lock`) that get modified when a binary is built in the previous application of this role. The `force` parameter should deal with this situation without causing a failure.