### PR TITLE
Support FIFO Cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,98 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is `sn-testnet-deploy` - a tool for automating deployment of Safe Network testnets on AWS or Digital Ocean. It orchestrates Terraform for infrastructure creation and Ansible for provisioning, coordinated by a Rust binary.
+
+## Key Commands
+
+### Build and Release
+- `cargo build` - Build the testnet-deploy binary
+- `cargo run -- <command>` - Run commands via the binary
+- `just build-release-artifacts x86_64-unknown-linux-musl` - Build release artifacts for Linux
+- `just package-release-assets` - Package binaries for distribution
+
+### Testing and Quality
+The project follows standard Rust practices:
+- `cargo test` - Run unit tests
+- `cargo clippy` - Run linting (recent commit mentions clippy fixes)
+- `cargo fmt` - Format code
+
+### Core Deployment Commands
+- `cargo run -- setup` - Initial setup (creates .env file with configuration)
+- `cargo run -- deploy --name <testnet-name>` - Deploy a new testnet
+- `cargo run -- inventory --name <testnet-name> --provider digital-ocean` - List machines and testnet info
+- `cargo run -- clean --name <testnet-name> --provider digital-ocean` - Tear down testnet
+- `cargo run -- status --name <testnet-name>` - Get status of all nodes
+- `cargo run -- upgrade --name <testnet-name>` - Upgrade node binaries
+
+### Image Building (using Just)
+- `just build-node-image` - Build VM images for nodes
+- `just build-client-image` - Build VM images for clients
+- `just build-all-images <region>` - Build all VM images for a region
+
+## Architecture
+
+### High-Level Structure
+The codebase follows a modular architecture with these main components:
+
+**Core Infrastructure:**
+- `src/terraform.rs` - Terraform orchestration for cloud infrastructure
+- `src/ansible/` - Ansible automation for VM provisioning and configuration
+- `src/infra.rs` - Infrastructure management logic
+
+**Cloud Provider Integration:**
+- `src/digital_ocean.rs` - Digital Ocean specific implementations
+- Cloud provider abstraction supports AWS and Digital Ocean
+
+**Node and Network Management:**
+- `src/bootstrap.rs` - Network bootstrapping from existing deployments
+- `src/nodes.rs` - Node lifecycle management (start/stop/upgrade)
+- `src/rpc_client.rs` - RPC communication with nodes
+- `src/inventory.rs` - Infrastructure inventory management
+
+**Deployment Types:**
+- **New Networks:** Complete fresh deployments
+- **Bootstrap Deployments:** Extending existing networks
+- **Client Deployments:** Deploy client VMs for testing
+
+**Binary Management:**
+Two approaches for obtaining binaries:
+1. **Versioned:** Pre-built binaries fetched from S3
+2. **BuildFromSource:** Custom builds from specified repository/branch
+
+### Key Components
+
+**TestnetDeployer** (src/lib.rs): Main orchestrator that coordinates:
+- Terraform for infrastructure
+- Ansible for provisioning  
+- SSH for remote operations
+- S3 for artifact storage
+
+**Command Structure** (src/cmd/): 
+- `deployments.rs` - Main deploy/bootstrap/upscale logic
+- `nodes.rs` - Node operations (start/stop/status)
+- `upgrade.rs` - Binary upgrade processes
+- `logs.rs` - Log collection and management
+
+**Node Types:**
+- Genesis nodes (bootstrap the network)
+- Generic nodes (standard network participants)
+- Peer cache nodes (provide cached peer information)
+- Private nodes (behind NAT gateways - full-cone and symmetric)
+
+### Configuration Management
+- Environment details stored in S3 (deployment type, EVM config, network ID)
+- Ansible inventories generated dynamically
+- Support for development, staging, and production environments
+- VM sizing and node counts determined by environment type
+
+### Resource Organization
+- `resources/terraform/` - Infrastructure as code definitions
+- `resources/ansible/` - Provisioning playbooks and roles
+- `resources/packer/` - VM image building templates
+- `resources/scripts/` - Utility scripts for log management
+
+The tool supports complex multi-VM deployments with different node types, NAT configurations, and automatic scaling capabilities.

--- a/resources/ansible/roles/cache_webserver/tasks/main.yml
+++ b/resources/ansible/roles/cache_webserver/tasks/main.yml
@@ -5,22 +5,30 @@
     state: started
     enabled: yes
 
-- name: find the json file in the bootstrap cache directory
+- name: find the version0 json file
   find:
     paths: "{{ bootstrap_cache_dir }}"
     patterns: "*.json"
-  register: json_files
+    recurse: no
+  register: version0_file
 
-- name: fail if no json file is found
-  fail:
-    msg: "No json file found in the bootstrap directory."
-  when: json_files.matched == 0
+- name: find the version1 json file
+  find:
+    paths: "{{ bootstrap_cache_dir }}/version_1"
+    patterns: "*.json"
+    recurse: no
+  register: version1_file
+
+- name: create a map of versions to their respective json files
+  set_fact:
+    version_files:
+      version0: "{{ version0_file.files[0].path }}"
+      version1: "{{ version1_file.files[0].path }}"
 
 - name: ensure nginx is serving the json file using a template
   template:
     src: nginx.conf.j2
     dest: /etc/nginx/sites-available/default
-  when: json_files.matched > 0
 
 - name: ensure nginx status site file is set
   template:
@@ -32,10 +40,8 @@
     src: /etc/nginx/sites-available/nginx_status
     dest: /etc/nginx/sites-enabled/nginx_status
     state: link
-  when: json_files.matched > 0
 
 - name: reload nginx to apply changes
   service:
     name: nginx
     state: reloaded
-  when: json_files.matched > 0

--- a/resources/ansible/roles/cache_webserver/tasks/main.yml
+++ b/resources/ansible/roles/cache_webserver/tasks/main.yml
@@ -41,7 +41,11 @@
     dest: /etc/nginx/sites-enabled/nginx_status
     state: link
 
-- name: reload nginx to apply changes
+- name: restart nginx to apply changes
   service:
     name: nginx
-    state: reloaded
+    state: restarted
+  register: nginx_restart
+  retries: 3
+  delay: 5
+  until: nginx_restart is success

--- a/resources/ansible/roles/cache_webserver/templates/nginx.conf.j2
+++ b/resources/ansible/roles/cache_webserver/templates/nginx.conf.j2
@@ -1,13 +1,29 @@
+{# Map to determine if the version is supported #}
+map $http_cache_version $valid_version {
+  default "1";
+  "0" "1";
+  "1" "1";
+  "~." "0";
+}
+
+{# Map to get the file path for valid versions #}
+map $http_cache_version $bootstrap_file {
+  default "{{ version_files.version0 }}";
+  "1" "{{ version_files.version1 }}";
+}
+
 server {
-    listen 80;
-
-    location / {
-        access_log off;
-        log_not_found off;
-        return 404;
+  listen 80;
+  location / {
+    access_log off;
+    log_not_found off;
+    return 404;
+  }
+  location /bootstrap_cache.json {
+    if ($valid_version = "0") {
+      return 400;
     }
-
-    location /bootstrap_cache.json {
-        alias {{ bootstrap_cache_dir }}/{{ json_files.files[0].path | basename }};
-    }
+    
+    alias $bootstrap_file;
+  }
 }

--- a/resources/ansible/roles/cache_webserver/templates/nginx.conf.j2
+++ b/resources/ansible/roles/cache_webserver/templates/nginx.conf.j2
@@ -1,29 +1,34 @@
 {# Map to determine if the version is supported #}
 map $http_cache_version $valid_version {
-  default "1";
-  "0" "1";
-  "1" "1";
-  "~." "0";
+    {# Empty/missing header is valid (for old users) #}
+    "" "1";
+    {# Version 1 is valid #}
+    "1" "1";
+    {# Everything else is invalid #}
+    default "0";
 }
 
 {# Map to get the file path for valid versions #}
 map $http_cache_version $bootstrap_file {
-  default "{{ version_files.version0 }}";
-  "1" "{{ version_files.version1 }}";
+    {# Old users (no header) get version0 #}
+    "" "{{ version_files.version0 }}";
+    {# Users with version 1 get version1 #}
+    "1" "{{ version_files.version1 }}";
+    {# Default fallback (though this shouldn't be reached due to the 400 response) #}
+    default "{{ version_files.version0 }}";
 }
 
 server {
-  listen 80;
-  location / {
-    access_log off;
-    log_not_found off;
-    return 404;
-  }
-  location /bootstrap_cache.json {
-    if ($valid_version = "0") {
-      return 400;
+    listen 80;
+    location / {
+        access_log off;
+        log_not_found off;
+        return 404;
     }
-    
-    alias $bootstrap_file;
-  }
+    location /bootstrap_cache.json {
+        if ($valid_version = "0") {
+            return 400;
+        }
+        alias $bootstrap_file;
+    }
 }

--- a/resources/ansible/roles/genesis-node/tasks/main.yml
+++ b/resources/ansible/roles/genesis-node/tasks/main.yml
@@ -41,6 +41,7 @@
       - "{{ ('--log-format=' + log_format) if log_format is defined else omit }}"
       - "{{ ('--env=' + node_env_variables) if node_env_variables is defined else omit }}"
       - "{{ ('--version=' + version) if version is defined else ('--url=' + node_archive_url) }}"
+      - "--write-older-cache-files"
       - "{{ evm_network_type }}"
       - "{{ ('--rpc-url=' + evm_rpc_url) if evm_network_type == 'evm-custom' else omit }}"
       - "{{ ('--payment-token-address=' + evm_payment_token_address) if evm_network_type == 'evm-custom' else omit }}"

--- a/resources/ansible/roles/node/defaults/main.yml
+++ b/resources/ansible/roles/node/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 public_rpc: False
 relay: False
+write_older_cache_files: False
 private_ip: False
 node_rpc_ip: "127.0.0.1"
 node_instance_count: 20

--- a/resources/ansible/roles/node/tasks/main.yml
+++ b/resources/ansible/roles/node/tasks/main.yml
@@ -94,6 +94,7 @@
       - "{{ ('--log-format=' + log_format) if log_format is defined else omit }}"
       - "{{ ('--env=' + node_env_variables) if node_env_variables is defined else omit }}"
       - "{{ ('--version=' + version) if version is defined else ('--url=' + node_archive_url) }}"
+      - "{{ '--write-older-cache-files' if write_older_cache_files | bool else omit }}"
       - "{{ evm_network_type }}"
       - "{{ ('--rpc-url=' + evm_rpc_url) if evm_network_type == 'evm-custom' else omit }}"
       - "{{ ('--payment-token-address=' + evm_payment_token_address) if evm_network_type == 'evm-custom' else omit }}"

--- a/resources/ansible/upgrade_nginx.yml
+++ b/resources/ansible/upgrade_nginx.yml
@@ -1,0 +1,6 @@
+---
+- name: upgrade the nginx configuration
+  hosts: all
+  roles:
+    - role: cache_webserver
+      become: True

--- a/resources/ansible/upgrade_nodes.yml
+++ b/resources/ansible/upgrade_nodes.yml
@@ -18,6 +18,10 @@
         {% endif %}
         {% if antnode_version is defined %}
         cmd="$cmd --version={{ antnode_version }}"
+        {% elif node_archive_url is defined %}
+        cmd="$cmd --url={{ node_archive_url }}"
+        cmd="$cmd --force"
+        echo "$cmd" >> /tmp/upgrade_cmd
         {% endif %}
         eval "$cmd"
       args:

--- a/src/ansible/extra_vars.rs
+++ b/src/ansible/extra_vars.rs
@@ -299,6 +299,7 @@ pub fn build_node_extra_vars_doc(
     network_contacts_url: Option<String>,
     node_instance_count: u16,
     evm_network: EvmNetwork,
+    write_older_cache_files: bool,
 ) -> Result<String> {
     let mut extra_vars = ExtraVarsDocBuilder::default();
     extra_vars.add_variable("provider", cloud_provider);
@@ -341,6 +342,10 @@ pub fn build_node_extra_vars_doc(
             extra_vars.add_variable("relay", "true");
         }
         _ => {}
+    }
+
+    if write_older_cache_files {
+        extra_vars.add_variable("write_older_cache_files", "true");
     }
 
     if let Some(network_id) = options.network_id {

--- a/src/ansible/mod.rs
+++ b/src/ansible/mod.rs
@@ -201,6 +201,10 @@ pub enum AnsiblePlaybook {
     UpgradeClientTelegrafConfig,
     /// Update the GeoIP Telegraf configuration to the latest version in the repository.
     UpgradeGeoIpTelegrafConfig,
+    /// Update the nginx configuration to the latest version in the repository.
+    ///
+    /// Use in combination with `AnsibleInventoryType::PeerCache`.
+    UpgradeNginx,
     /// The uploader playbook will setup the uploader scripts on the uploader VMs.
     ///
     /// Use in combination with `AnsibleInventoryType::Clients`.
@@ -250,6 +254,7 @@ impl AnsiblePlaybook {
             AnsiblePlaybook::UpgradeGeoIpTelegrafConfig => {
                 "upgrade_geoip_telegraf_config.yml".to_string()
             }
+            AnsiblePlaybook::UpgradeNginx => "upgrade_nginx.yml".to_string(),
             AnsiblePlaybook::UpgradeNodes => "upgrade_nodes.yml".to_string(),
             AnsiblePlaybook::UpgradeNodeTelegrafConfig => {
                 "upgrade_node_telegraf_config.yml".to_string()

--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -1460,6 +1460,35 @@ impl AnsibleProvisioner {
         Ok(())
     }
 
+    pub fn upgrade_nginx_config(
+        &self,
+        environment_name: &str,
+        custom_inventory: Option<Vec<VirtualMachine>>,
+    ) -> Result<()> {
+        if let Some(custom_inventory) = custom_inventory {
+            println!("Running the upgrade nginx config playbook with a custom inventory");
+            generate_custom_environment_inventory(
+                &custom_inventory,
+                environment_name,
+                &self.ansible_runner.working_directory_path.join("inventory"),
+            )?;
+            self.ansible_runner.run_playbook(
+                AnsiblePlaybook::UpgradeNginx,
+                AnsibleInventoryType::Custom,
+                None,
+            )?;
+            return Ok(());
+        }
+
+        println!("Running the upgrade nginx config playbook for peer cache nodes");
+        self.ansible_runner.run_playbook(
+            AnsiblePlaybook::UpgradeNginx,
+            AnsibleInventoryType::PeerCacheNodes,
+            None,
+        )?;
+        Ok(())
+    }
+
     pub fn upgrade_geoip_telegraf(&self, name: &str) -> Result<()> {
         self.ansible_runner.run_playbook(
             AnsiblePlaybook::UpgradeGeoIpTelegrafConfig,

--- a/src/ansible/provisioning.rs
+++ b/src/ansible/provisioning.rs
@@ -610,6 +610,7 @@ impl AnsibleProvisioner {
                 None,
                 1,
                 options.evm_network.clone(),
+                false,
             )?),
         )?;
 
@@ -881,6 +882,7 @@ impl AnsibleProvisioner {
         node_type: NodeType,
     ) -> Result<()> {
         let start = Instant::now();
+        let mut write_older_cache_files = false;
         let (inventory_type, node_count) = match &node_type {
             NodeType::FullConePrivateNode => (
                 node_type.to_ansible_inventory_type(),
@@ -889,10 +891,13 @@ impl AnsibleProvisioner {
             // use provision_genesis_node fn
             NodeType::Generic => (node_type.to_ansible_inventory_type(), options.node_count),
             NodeType::Genesis => return Err(Error::InvalidNodeType(node_type)),
-            NodeType::PeerCache => (
-                node_type.to_ansible_inventory_type(),
-                options.peer_cache_node_count,
-            ),
+            NodeType::PeerCache => {
+                write_older_cache_files = true;
+                (
+                    node_type.to_ansible_inventory_type(),
+                    options.peer_cache_node_count,
+                )
+            }
             NodeType::SymmetricPrivateNode => (
                 node_type.to_ansible_inventory_type(),
                 options.symmetric_private_node_count,
@@ -939,6 +944,7 @@ impl AnsibleProvisioner {
                 initial_network_contacts_url,
                 node_count,
                 options.evm_network.clone(),
+                write_older_cache_files,
             )?),
         )?;
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -863,6 +863,17 @@ pub enum Commands {
         /// Set to run Ansible with more verbose output.
         #[arg(long)]
         ansible_verbose: bool,
+        /// The branch of the Github repository to use for custom binaries.
+        ///
+        /// This specifies the pre-built binaries to download from S3 for the upgrade.
+        /// The binaries must have been previously built and uploaded.
+        ///
+        /// This argument must be used in conjunction with the --repo-owner argument.
+        ///
+        /// The --branch and --repo-owner arguments are mutually exclusive with the --version
+        /// argument. You can only supply a version number or a custom branch, not both.
+        #[arg(long, verbatim_doc_comment)]
+        branch: Option<String>,
         /// Provide a list of VM names to use as a custom inventory.
         ///
         /// This will run the upgrade against this particular subset of VMs.
@@ -911,6 +922,17 @@ pub enum Commands {
         /// Valid values are "aws" or "digital-ocean".
         #[clap(long, default_value_t = CloudProvider::DigitalOcean, value_parser = parse_provider, verbatim_doc_comment)]
         provider: CloudProvider,
+        /// The owner/org of the Github repository to use for custom binaries.
+        ///
+        /// This specifies the pre-built binaries to download from S3 for the upgrade.
+        /// The binaries must have been previously built and uploaded.
+        ///
+        /// This argument must be used in conjunction with the --branch argument.
+        ///
+        /// The --branch and --repo-owner arguments are mutually exclusive with the --version
+        /// argument. You can only supply a version number or a custom branch, not both.
+        #[arg(long, verbatim_doc_comment)]
+        repo_owner: Option<String>,
         #[arg(long)]
         /// Optionally supply a version number for the antnode binary to upgrade to.
         ///

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -10,6 +10,7 @@ pub mod funds;
 pub mod logs;
 pub mod misc;
 pub mod network;
+pub mod nginx;
 pub mod nodes;
 pub mod provision;
 pub mod telegraf;
@@ -17,7 +18,7 @@ pub mod upgrade;
 
 use crate::cmd::{
     clients::ClientsCommands, funds::FundsCommand, logs::LogCommands, network::NetworkCommands,
-    provision::ProvisionCommands, telegraf::TelegrafCommands,
+    nginx::NginxCommands, provision::ProvisionCommands, telegraf::TelegrafCommands,
 };
 use alloy::primitives::U256;
 use ant_releases::{AntReleaseRepoActions, ReleaseType};
@@ -694,6 +695,9 @@ pub enum Commands {
     Logs(LogCommands),
     #[clap(name = "network", subcommand)]
     Network(NetworkCommands),
+    /// Manage nginx services and configuration
+    #[clap(name = "nginx", subcommand)]
+    Nginx(NginxCommands),
     /// Send a notification to Slack with testnet inventory details
     Notify {
         /// The name of the environment.

--- a/src/cmd/nginx.rs
+++ b/src/cmd/nginx.rs
@@ -1,0 +1,72 @@
+// Copyright (c) 2023, MaidSafe.
+// All rights reserved.
+//
+// This SAFE Network Software is licensed under the BSD-3-Clause license.
+// Please see the LICENSE file for more details.
+
+use super::get_custom_inventory;
+use clap::Subcommand;
+use color_eyre::{eyre::eyre, Result};
+use sn_testnet_deploy::{inventory::DeploymentInventoryService, TestnetDeployBuilder};
+
+#[derive(Subcommand, Debug)]
+pub enum NginxCommands {
+    /// Upgrade the nginx configuration on an environment.
+    UpgradeConfig {
+        /// Provide a list of VM names to use as a custom inventory.
+        ///
+        /// This will upgrade nginx on a particular subset of VMs.
+        #[clap(name = "custom-inventory", long, use_value_delimiter = true)]
+        custom_inventory: Option<Vec<String>>,
+        /// Maximum number of forks Ansible will use to execute tasks on target hosts.
+        #[clap(long, default_value_t = 50)]
+        forks: usize,
+        /// The name of the environment.
+        #[arg(short = 'n', long)]
+        name: String,
+        /// The cloud provider for the environment.
+        #[clap(long, default_value_t = sn_testnet_deploy::CloudProvider::DigitalOcean, value_parser = super::parse_provider, verbatim_doc_comment)]
+        provider: sn_testnet_deploy::CloudProvider,
+    },
+}
+
+pub async fn handle_upgrade_nginx_config(
+    custom_inventory: Option<Vec<String>>,
+    forks: usize,
+    name: String,
+    provider: sn_testnet_deploy::CloudProvider,
+) -> Result<()> {
+    // Use 50 forks for inventory retrieval for better performance
+    let testnet_deployer = TestnetDeployBuilder::default()
+        .ansible_forks(50)
+        .environment_name(&name)
+        .provider(provider)
+        .build()?;
+
+    let inventory_service = DeploymentInventoryService::from(&testnet_deployer);
+    let inventory = inventory_service
+        .generate_or_retrieve_inventory(&name, true, None)
+        .await?;
+    if inventory.is_empty() {
+        return Err(eyre!("The {name} environment does not exist"));
+    }
+
+    let custom_inventory = if let Some(custom_inventory) = custom_inventory {
+        let custom_vms = get_custom_inventory(&inventory, &custom_inventory)?;
+        Some(custom_vms)
+    } else {
+        None
+    };
+
+    // Recreate deployer with the specified forks for the nginx upgrade
+    let testnet_deployer = TestnetDeployBuilder::default()
+        .ansible_forks(forks)
+        .environment_name(&name)
+        .provider(provider)
+        .build()?;
+
+    let provisioner = testnet_deployer.ansible_provisioner;
+    provisioner.upgrade_nginx_config(&name, custom_inventory)?;
+
+    Ok(())
+}

--- a/src/cmd/upgrade.rs
+++ b/src/cmd/upgrade.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 #[allow(clippy::too_many_arguments)]
 pub async fn handle_upgrade_command(
     ansible_verbose: bool,
+    branch: Option<String>,
     custom_inventory: Option<Vec<String>>,
     env_variables: Option<Vec<(String, String)>>,
     force: bool,
@@ -22,6 +23,7 @@ pub async fn handle_upgrade_command(
     node_type: Option<NodeType>,
     provider: CloudProvider,
     pre_upgrade_delay: Option<u64>,
+    repo_owner: Option<String>,
     version: Option<String>,
 ) -> Result<()> {
     // The upgrade intentionally uses a small value for `forks`, but this is far too slow
@@ -56,6 +58,7 @@ pub async fn handle_upgrade_command(
         .build()?;
     testnet_deployer.upgrade(UpgradeOptions {
         ansible_verbose,
+        branch,
         custom_inventory,
         env_variables,
         force,
@@ -65,6 +68,7 @@ pub async fn handle_upgrade_command(
         node_type,
         provider,
         pre_upgrade_delay,
+        repo_owner,
         version,
     })?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -419,6 +419,7 @@ impl LogFormat {
 #[derive(Clone)]
 pub struct UpgradeOptions {
     pub ansible_verbose: bool,
+    pub branch: Option<String>,
     pub custom_inventory: Option<Vec<VirtualMachine>>,
     pub env_variables: Option<Vec<(String, String)>>,
     pub force: bool,
@@ -428,6 +429,7 @@ pub struct UpgradeOptions {
     pub node_type: Option<NodeType>,
     pub pre_upgrade_delay: Option<u64>,
     pub provider: CloudProvider,
+    pub repo_owner: Option<String>,
     pub version: Option<String>,
 }
 
@@ -447,6 +449,17 @@ impl UpgradeOptions {
         if let Some(pre_upgrade_delay) = &self.pre_upgrade_delay {
             extra_vars.add_variable("pre_upgrade_delay", &pre_upgrade_delay.to_string());
         }
+
+        if let (Some(repo_owner), Some(branch)) = (&self.repo_owner, &self.branch) {
+            let binary_option = BinaryOption::BuildFromSource {
+                antnode_features: None,
+                branch: branch.clone(),
+                repo_owner: repo_owner.clone(),
+                skip_binary_build: true,
+            };
+            extra_vars.add_node_url_or_version(&self.name, &binary_option);
+        }
+
         extra_vars.build()
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -432,6 +432,7 @@ async fn main() -> Result<()> {
         }
         Commands::Upgrade {
             ansible_verbose,
+            branch,
             custom_inventory,
             force,
             forks,
@@ -441,10 +442,12 @@ async fn main() -> Result<()> {
             node_type,
             provider,
             pre_upgrade_delay,
+            repo_owner,
             version,
         } => {
             cmd::upgrade::handle_upgrade_command(
                 ansible_verbose,
+                branch,
                 custom_inventory,
                 node_env_variables,
                 force,
@@ -454,6 +457,7 @@ async fn main() -> Result<()> {
                 node_type,
                 provider,
                 pre_upgrade_delay,
+                repo_owner,
                 version,
             )
             .await?;
@@ -660,7 +664,10 @@ async fn main() -> Result<()> {
                 forks,
                 name,
                 provider,
-            } => cmd::nginx::handle_upgrade_nginx_config(custom_inventory, forks, name, provider).await,
+            } => {
+                cmd::nginx::handle_upgrade_nginx_config(custom_inventory, forks, name, provider)
+                    .await
+            }
         },
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod cmd;
 
 use crate::cmd::{
     network::{ChurnCommands, NetworkCommands},
+    nginx::NginxCommands,
     nodes,
     provision::ProvisionCommands,
     telegraf::TelegrafCommands,
@@ -652,6 +653,14 @@ async fn main() -> Result<()> {
                 name,
                 provider,
             } => cmd::telegraf::handle_upgrade_node_telegraf_config(forks, name, provider).await,
+        },
+        Commands::Nginx(nginx_cmd) => match nginx_cmd {
+            NginxCommands::UpgradeConfig {
+                custom_inventory,
+                forks,
+                name,
+                provider,
+            } => cmd::nginx::handle_upgrade_nginx_config(custom_inventory, forks, name, provider).await,
         },
     }
 }


### PR DESCRIPTION
- f59f109 **chore: use successful uploads for max uploads**

  For tests against the production network it will be more helpful if we only stop processing on
  successful uploads, since quite a lot of the time our uploads can fail due to gas price fluctuations.

- e77d53f **chore(release): 0.2.72**


- 2fb30b1 **feat: ngnix serves cache file based on header**


- bf07b96 **fix(nginx): update the nginx config file to support multiple cache version**


- 20bab15 **fix: set default value for write_older_cache_files**


- 68f5e39 **chore: clippy fixes**


- a91f427 **chore: add config file for working with claude code**

  This was generated using Claude itself.

  I haven't modified it initially because I'm not too familiar with things yet.

- 68f1071 **feat: provide `nginx upgrade-config` command**

  This will be used to upgrade the existing peer cache servers in the production deployment.

  The binaries must be upgraded before the Nginx upgrade is applied because it's assuming the
  existence of the `version_1` directory.

- 137c8ef **feat: support custom binaries on upgrades**

  Use `--branch` and `--repo-owner` arguments to provide test binaries during the upgrade process.

  This came in useful for testing the FIFO cache upgrade process.

  The binaries must be built and uploaded to S3 by another process.

- 1261020 **chore: rebuild evm node and rust build images**

  The autonomi code now required a newer version of Rust to build correctly.