### PR TITLE
chore: supply build image from variable files

### DIFF
--- a/resources/terraform/clients/digital-ocean/dev-images-lon1.tfvars
+++ b/resources/terraform/clients/digital-ocean/dev-images-lon1.tfvars
@@ -1,1 +1,2 @@
 ant_client_droplet_image_id = 172724146
+build_droplet_image_id = 192313809

--- a/resources/terraform/clients/digital-ocean/production-images-lon1.tfvars
+++ b/resources/terraform/clients/digital-ocean/production-images-lon1.tfvars
@@ -1,1 +1,2 @@
 ant_client_droplet_image_id = 172724146
+build_droplet_image_id = 192313809

--- a/resources/terraform/clients/digital-ocean/staging-images-lon1.tfvars
+++ b/resources/terraform/clients/digital-ocean/staging-images-lon1.tfvars
@@ -1,1 +1,2 @@
 ant_client_droplet_image_id = 172724146
+build_droplet_image_id = 192313809

--- a/resources/terraform/clients/digital-ocean/variables.tf
+++ b/resources/terraform/clients/digital-ocean/variables.tf
@@ -28,7 +28,7 @@ variable "build_machine_size" {
 }
 
 variable "build_droplet_image_id" {
-  default = "172723670"
+  description = "The ID of the image for the build machine. Varies per region."
 }
 
 variable "ant_client_droplet_image_id" {


### PR DESCRIPTION
The client deployment should use the same build image as the testnet deployment, so rather than having a default value, it will also be supplied from tfvars.