### PR TITLE
feat: provide `provision upnp-nodes` command

### DIFF
--- a/src/cmd/provision.rs
+++ b/src/cmd/provision.rs
@@ -52,6 +52,13 @@ pub enum ProvisionCommands {
         #[arg(short = 'n', long)]
         name: String,
     },
+    /// Provision UPnP nodes for an environment
+    #[clap(name = "upnp-nodes")]
+    UpnpNodes {
+        /// The name of the environment
+        #[arg(short = 'n', long)]
+        name: String,
+    },
 }
 
 async fn init_provision(
@@ -165,6 +172,10 @@ pub async fn handle_provision_symmetric_private_nodes(name: String) -> Result<()
 
 pub async fn handle_provision_full_cone_private_nodes(name: String) -> Result<()> {
     handle_provision_nodes(name, NodeType::FullConePrivateNode).await
+}
+
+pub async fn handle_provision_upnp_nodes(name: String) -> Result<()> {
+    handle_provision_nodes(name, NodeType::Upnp).await
 }
 
 pub async fn handle_provision_clients(name: String) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -604,6 +604,10 @@ async fn main() -> Result<()> {
             Ok(())
         }
         Commands::Provision(provision_cmd) => match provision_cmd {
+            ProvisionCommands::Clients { name } => {
+                cmd::provision::handle_provision_clients(name).await?;
+                Ok(())
+            }
             ProvisionCommands::FullConePrivateNodes { name } => {
                 cmd::provision::handle_provision_full_cone_private_nodes(name).await?;
                 Ok(())
@@ -620,8 +624,8 @@ async fn main() -> Result<()> {
                 cmd::provision::handle_provision_symmetric_private_nodes(name).await?;
                 Ok(())
             }
-            ProvisionCommands::Clients { name } => {
-                cmd::provision::handle_provision_clients(name).await?;
+            ProvisionCommands::UpnpNodes { name } => {
+                cmd::provision::handle_provision_upnp_nodes(name).await?;
                 Ok(())
             }
         },


### PR DESCRIPTION
Like the other commands, this command will provision the UPnP nodes specifically.

This is necessary for the workflow that provisions each node type in parallel.