### PR TITLE
fix: explicitly disable upnp

### DIFF
--- a/src/ansible/extra_vars.rs
+++ b/src/ansible/extra_vars.rs
@@ -335,11 +335,13 @@ pub fn build_node_extra_vars_doc(
         NodeType::FullConePrivateNode => {
             // Full cone private nodes do not need relay as it is a straight port forward.
             extra_vars.add_variable("private_ip", "true");
+            extra_vars.add_boolean_variable("enable_upnp", false);
         }
         NodeType::SymmetricPrivateNode => {
             // Symmetric private nodes need relay and private ip.
             extra_vars.add_variable("private_ip", "true");
             extra_vars.add_variable("relay", "true");
+            extra_vars.add_boolean_variable("enable_upnp", false);
         }
         NodeType::Upnp => {
             extra_vars.add_boolean_variable("enable_upnp", true);


### PR DESCRIPTION
For full cone and symmetric NAT node types, UPnP is explicitly disabled by setting the `enable_upnp` variable to `false`.

Without this the role cannot be applied correctly.