### PR TITLE
fix: obtain antnode version without assuming specific service

### DIFF
--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     ansible::provisioning::{PrivateNodeProvisionInventory, ProvisionOptions},
-    error::Result,
+    error::{Error, Result},
     funding::get_address_from_sk,
     get_anvil_node_data, get_bootstrap_cache_url, get_genesis_multiaddr, write_environment_details,
     BinaryOption, DeploymentInventory, DeploymentType, EnvironmentDetails, EnvironmentType,
@@ -234,12 +234,8 @@ impl TestnetDeployer {
             })?;
 
         let (genesis_multiaddr, genesis_ip) =
-            get_genesis_multiaddr(&self.ansible_provisioner.ansible_runner, &self.ssh_client)
-                .map_err(|err| {
-                    println!("Failed to get genesis multiaddr {err:?}");
-                    err
-                })?;
-
+            get_genesis_multiaddr(&self.ansible_provisioner.ansible_runner, &self.ssh_client)?
+                .ok_or_else(|| Error::GenesisListenAddress)?;
         Ok((
             provision_options,
             (genesis_multiaddr, get_bootstrap_cache_url(&genesis_ip)),

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -974,10 +974,12 @@ impl DeploymentInventory {
     }
 
     pub fn is_empty(&self) -> bool {
-        if self.environment_details.deployment_type == DeploymentType::Bootstrap {
-            return self.node_vms.is_empty();
-        }
         self.genesis_vm.is_none()
+            && self.node_vms.is_empty()
+            && self.peer_cache_node_vms.is_empty()
+            && self.full_cone_private_node_vms.is_empty()
+            && self.symmetric_private_node_vms.is_empty()
+            && self.client_vms.is_empty()
     }
 
     pub fn vm_list(&self) -> Vec<VirtualMachine> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1084,8 +1084,11 @@ impl TestnetDeployer {
 pub fn get_genesis_multiaddr(
     ansible_runner: &AnsibleRunner,
     ssh_client: &SshClient,
-) -> Result<(String, IpAddr)> {
+) -> Result<Option<(String, IpAddr)>> {
     let genesis_inventory = ansible_runner.get_inventory(AnsibleInventoryType::Genesis, true)?;
+    if genesis_inventory.is_empty() {
+        return Ok(None);
+    }
     let genesis_ip = genesis_inventory[0].public_ip_addr;
 
     // It's possible for the genesis host to be altered from its original state where a node was
@@ -1119,7 +1122,7 @@ pub fn get_genesis_multiaddr(
             .ok_or_else(|| Error::GenesisListenAddress)?,
     };
 
-    Ok((multiaddr, genesis_ip))
+    Ok(Some((multiaddr, genesis_ip)))
 }
 
 pub fn get_anvil_node_data(

--- a/src/upscale.rs
+++ b/src/upscale.rs
@@ -275,6 +275,7 @@ impl TestnetDeployer {
                     println!("Failed to get genesis multiaddr {err:?}");
                     err
                 })?
+                .ok_or_else(|| Error::GenesisListenAddress)?
         };
         let initial_network_contacts_url = get_bootstrap_cache_url(&initial_ip_addr);
         debug!("Retrieved initial peer {initial_multiaddr} and initial network contacts {initial_network_contacts_url}");
@@ -510,11 +511,8 @@ impl TestnetDeployer {
         }
 
         let (initial_multiaddr, initial_ip_addr) =
-            get_genesis_multiaddr(&self.ansible_provisioner.ansible_runner, &self.ssh_client)
-                .map_err(|err| {
-                    println!("Failed to get genesis multiaddr {err:?}");
-                    err
-                })?;
+            get_genesis_multiaddr(&self.ansible_provisioner.ansible_runner, &self.ssh_client)?
+                .ok_or_else(|| Error::GenesisListenAddress)?;
         let initial_network_contacts_url = get_bootstrap_cache_url(&initial_ip_addr);
         debug!("Retrieved initial peer {initial_multiaddr} and initial network contacts {initial_network_contacts_url}");
 


### PR DESCRIPTION
- 98be100 **fix: obtain antnode version without assuming specific service**

  The current mechanism for obtaining the `antnode` version was assuming the existence of an
  `antnode1` service. In the case of the current `PROD-02` environment, with respect to the peer cache
  nodes, some of the services had been deleted in a special upgrade process.

  This new mechanism uses the `status` command to obtain the running services and gets the version
  information from one of them.

- 5a6c3ab **feat: accommodate empty genesis node in inventory**

  It is the case for some environments now that they may no longer have a genesis node.

  The original genesis node was removed from the `PROD-02` environment, but the peer cache nodes are
  still running there.