### PR TITLE
chore: build a `testnet-deploy` package

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -18,6 +18,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+          components: rustfmt
       - shell: bash
         run: cargo build --all-targets --all-features
   checks:


### PR DESCRIPTION
This can be used to avoid compilation when using `testnet-deploy` in a workflow.