### PR TITLE
fix: apply vm count even with zero value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6193,7 +6193,7 @@ dependencies = [
 
 [[package]]
 name = "sn-testnet-deploy"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy",
  "ant-releases",

--- a/src/infra.rs
+++ b/src/infra.rs
@@ -519,23 +519,11 @@ pub fn build_terraform_args(options: &InfraRunOptions) -> Result<Vec<(String, St
         ));
     }
 
-    // Set the port restricted cone NAT gateway VM count based on private node VM count
-    if let Some(port_restricted_private_node_vm_count) =
-        options.port_restricted_private_node_vm_count
-    {
-        if port_restricted_private_node_vm_count > 0 {
-            args.push((
-                "port_restricted_cone_node_vm_count".to_string(),
-                port_restricted_private_node_vm_count.to_string(),
-            ));
-        }
-    }
-
     if let Some(port_restricted_private_node_vm_count) =
         options.port_restricted_private_node_vm_count
     {
         args.push((
-            "port_restricted_private_node_vm_count".to_string(),
+            "port_restricted_cone_node_vm_count".to_string(),
             port_restricted_private_node_vm_count.to_string(),
         ));
     }


### PR DESCRIPTION
For port restricted hosts, the count variable variable was only being applied if its count was greater than 0, causing the default value of 1 to be used.

Also removes the use of a Terraform variable that was not being used.