### PR TITLE
fix: use correct enum variant for node type

### DIFF
--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -344,7 +344,7 @@ impl DeploymentInventoryService {
         let ansible_provisioner = self.ansible_provisioner.clone();
         let port_restricted_cone_private_node_registries_handle = tokio::spawn(async move {
             ansible_provisioner
-                .get_node_registries(&AnsibleInventoryType::PortRestrictedConePrivateNodesStatic)
+                .get_node_registries(&AnsibleInventoryType::PortRestrictedConePrivateNodes)
                 .await
         });
         let ansible_provisioner = self.ansible_provisioner.clone();


### PR DESCRIPTION
The port restricted VMs were using a different enum variant from the symmetric and full cone NAT VMs in the inventory generation process. This resulted in errors when port restricted VMs were disabled.