### PR TITLE
fix: remove criteria for node to be running

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6193,7 +6193,7 @@ dependencies = [
 
 [[package]]
 name = "sn-testnet-deploy"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "alloy",
  "ant-releases",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "sn-testnet-deploy"
 description = "Tool for creating Autonomi networks"
 readme = "README.md"
 repository = "https://github.com/maidsafe/sn-testnet-deploy"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "BSD-3-Clause"
 

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -700,7 +700,7 @@ impl DeploymentInventoryService {
         let output = self.ssh_client.run_command(
             &vm.public_ip_addr,
             &self.cloud_provider.get_ssh_user(),
-            "antctl status --json | jq -r '.nodes[] | select(.status == \"Running\") | .version' | head -n1",
+            "antctl status --json | jq -r '.nodes[] | .version' | head -n1",
             true,
         )?;
 


### PR DESCRIPTION
- eeae17b **fix: remove criteria for node to be running**

  When the `antnode` version is being selected, it doesn't need to be from a running node.

  Previously this could cause crashes in the inventory retrieval if no nodes were running on a
  particular host.

- 52e51da **chore(release): v0.3.2**